### PR TITLE
drop unused exporter from parent module's pom as well

### DIFF
--- a/oshdb-tool/pom.xml
+++ b/oshdb-tool/pom.xml
@@ -17,7 +17,6 @@
   
   <modules>
     <module>oshpbf-parser</module>
-    <module>updater</module>
     <module>etl</module>
   </modules>
   


### PR DESCRIPTION
this is something we overlooked in #1