### PR TITLE
Faster getModificationTimestamps routines

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/CellIterator.java
@@ -1,5 +1,6 @@
 package org.heigit.bigspatialdata.oshdb.util.celliterator;
 
+import com.google.common.collect.Streams;
 import com.vividsolutions.jts.geom.*;
 import java.io.Serializable;
 import java.util.*;
@@ -160,6 +161,10 @@ public class CellIterator implements Serializable {
       )) {
         // this osh entity doesn't match the prefilter or is fully outside the requested
         // area of interest -> skip it
+        continue;
+      }
+      if (Streams.stream(oshEntity).noneMatch(osmEntityFilter)) {
+        // none of this osh entity's versions matches the filter -> skip it
         continue;
       }
       boolean fullyInside = allFullyInside || (
@@ -392,6 +397,10 @@ public class CellIterator implements Serializable {
       )) {
         // this osh entity doesn't match the prefilter or is fully outside the requested
         // area of interest -> skip it
+        continue;
+      }
+      if (Streams.stream(oshEntity).noneMatch(osmEntityFilter)) {
+        // none of this osh entity's versions matches the filter -> skip it
         continue;
       }
 

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHEntity.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHEntity.java
@@ -318,48 +318,7 @@ public abstract class OSHEntity<OSM extends OSMEntity>
    * @param osmEntityFilter only timestamps for which the entity matches this filter are returned
    * @return a list of timestamps where this entity has been modified
    */
-  public List<OSHDBTimestamp> getModificationTimestamps(Predicate<OSMEntity> osmEntityFilter) {
-    List<OSM> versions = this.getVersions();
-    List<Boolean> versionMatches = versions.stream()
-        .map(osmEntityFilter::test)
-        .collect(Collectors.toList());
-    if (versionMatches.stream().noneMatch(match -> match)) {
-      return Collections.emptyList();
-    }
-
-    List<OSHDBTimestamp> allModTs = this.getModificationTimestamps(true);
-    List<OSHDBTimestamp> filteredModTs = new ArrayList<>(allModTs.size());
-
-    int timeIdx = allModTs.size() - 1;
-
-    long lastOsmEntityTs = Long.MAX_VALUE;
-    for (int i=0; i<versions.size(); i++) {
-      OSMEntity osmEntity = versions.get(i);
-      OSHDBTimestamp osmEntityTs = osmEntity.getTimestamp();
-      if (osmEntityTs.getRawUnixTimestamp() >= lastOsmEntityTs) {
-        continue; // skip versions with identical (or invalid*) timestamps
-      }
-      OSHDBTimestamp modTs = allModTs.get(timeIdx);
-
-      boolean matches = versionMatches.get(i);
-
-      if (matches) {
-        while (modTs.getRawUnixTimestamp() >= osmEntityTs.getRawUnixTimestamp()) {
-          filteredModTs.add(0, modTs);
-          if (--timeIdx < 0) {
-            break;
-          }
-          modTs = allModTs.get(timeIdx);
-        }
-      } else {
-        while (timeIdx >= 0 && allModTs.get(timeIdx).getRawUnixTimestamp() > osmEntityTs.getRawUnixTimestamp()) {
-          timeIdx--;
-        }
-      }
-      lastOsmEntityTs = osmEntityTs.getRawUnixTimestamp();
-    }
-    return filteredModTs;
-  }
+  public abstract List<OSHDBTimestamp> getModificationTimestamps(Predicate<OSMEntity> osmEntityFilter);
 
   /**
    * Returns all timestamps at which this entity (or one or more of its child entities) has been

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHNode.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHNode.java
@@ -12,8 +12,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
 import org.heigit.bigspatialdata.oshdb.osm.OSMNode;
+import org.heigit.bigspatialdata.oshdb.osm.OSMRelation;
 import org.heigit.bigspatialdata.oshdb.osm.OSMType;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
@@ -319,6 +321,24 @@ public class OSHNode extends OSHEntity<OSMNode> implements Iterable<OSMNode>, Se
     List<OSHDBTimestamp> result = new ArrayList<>(this.iterator().next().getVersion());
     for (OSMNode osmNode : this) {
       result.add(osmNode.getTimestamp());
+    }
+    return Lists.reverse(result);
+  }
+
+  @Override
+  public List<OSHDBTimestamp> getModificationTimestamps(Predicate<OSMEntity> osmEntityFilter) {
+    List<OSHDBTimestamp> result = new ArrayList<>(this.iterator().next().getVersion());
+    OSHDBTimestamp prevNonmatch = null;
+    for (OSMNode osmNode : this) {
+      if (osmNode.isVisible() && (osmEntityFilter == null || osmEntityFilter.test(osmNode))) {
+        if (prevNonmatch != null) {
+          result.add(prevNonmatch);
+          prevNonmatch = null;
+        }
+        result.add(osmNode.getTimestamp());
+      } else {
+        prevNonmatch = osmNode.getTimestamp();
+      }
     }
     return Lists.reverse(result);
   }

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHRelation.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHRelation.java
@@ -15,7 +15,9 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -25,6 +27,7 @@ import org.heigit.bigspatialdata.oshdb.osm.OSMMember;
 import org.heigit.bigspatialdata.oshdb.osm.OSMNode;
 import org.heigit.bigspatialdata.oshdb.osm.OSMRelation;
 import org.heigit.bigspatialdata.oshdb.osm.OSMType;
+import org.heigit.bigspatialdata.oshdb.osm.OSMWay;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.util.byteArray.ByteArrayOutputWrapper;
@@ -544,76 +547,61 @@ public class OSHRelation extends OSHEntity<OSMRelation> implements Serializable 
       return Lists.reverse(relTs);
     }
 
-    Map<Long, LinkedList<OSHDBTimestamp>> childNodes = new TreeMap<>();
-    Map<Long, LinkedList<OSHDBTimestamp>> childWays = new TreeMap<>();
-    int i = -1;
+    Map<OSHEntity, LinkedList<OSHDBTimestamp>> childEntityTs = new TreeMap<>();
+    int i = 0;
+    OSHDBTimestamp nextT = new OSHDBTimestamp(Long.MAX_VALUE);
     for (OSMRelation osmRelation : this) {
-      i++;
-      OSHDBTimestamp thisT = relTs.get(i);
-      OSHDBTimestamp nextT = i > 0 ? relTs.get(i - 1) : new OSHDBTimestamp(Long.MAX_VALUE);
-      OSMMember[] members = osmRelation.getMembers();
-      for (OSMMember member : members) {
+      OSHDBTimestamp thisT = relTs.get(i++);
+      if (!osmRelation.isVisible()) {
+        nextT = thisT;
+        continue;
+      }
+      for (OSMMember member : osmRelation.getMembers()) {
         switch (member.getType()) {
           case NODE:
-            childNodes.putIfAbsent(member.getId(), new LinkedList<>());
-            LinkedList<OSHDBTimestamp> childNodeValidityTimestamps = childNodes.get(member.getId());
-            if (childNodeValidityTimestamps.size() > 0 &&
-                childNodeValidityTimestamps.getLast().equals(thisT)) {
-              // merge consecutive time intervals
-              childNodeValidityTimestamps.pop();
-              childNodeValidityTimestamps.add(thisT);
-            } else {
-              childNodeValidityTimestamps.add(nextT);
-              childNodeValidityTimestamps.add(thisT);
-            }
-            break;
           case WAY:
-            childWays.putIfAbsent(member.getId(), new LinkedList<>());
-            LinkedList<OSHDBTimestamp> childWayValidityTimestamps = childWays.get(member.getId());
-            if (childWayValidityTimestamps.size() > 0 &&
-                childWayValidityTimestamps.getLast().equals(thisT)) {
-              // merge consecutive time intervals
-              childWayValidityTimestamps.pop();
-              childWayValidityTimestamps.add(thisT);
+            OSHEntity oshEntity = member.getEntity();
+            if (oshEntity == null) continue;
+            LinkedList<OSHDBTimestamp> childEntityValidityTimestamps;
+            if (!childEntityTs.containsKey(oshEntity)) {
+              childEntityValidityTimestamps = new LinkedList<>();
+              childEntityTs.put(oshEntity, childEntityValidityTimestamps);
             } else {
-              childWayValidityTimestamps.add(nextT);
-              childWayValidityTimestamps.add(thisT);
+              childEntityValidityTimestamps = childEntityTs.get(oshEntity);
             }
-            break;
+            if (childEntityValidityTimestamps.size() > 0 &&
+                childEntityValidityTimestamps.getFirst().equals(nextT)) {
+              // merge consecutive time intervals
+              childEntityValidityTimestamps.pop();
+              childEntityValidityTimestamps.push(thisT);
+            } else {
+              childEntityValidityTimestamps.push(nextT);
+              childEntityValidityTimestamps.push(thisT);
+            }
         }
       }
+      nextT = thisT;
     }
 
     SortedSet<OSHDBTimestamp> result = new TreeSet<>(relTs);
-    for (OSMRelation osmRelation : this) {
-      OSMMember[] members = osmRelation.getMembers();
-      for (OSMMember member : members) {
-        Iterator<OSHDBTimestamp> validMemberTs;
-        List<OSHDBTimestamp> modTs;
-        OSHEntity entity = member.getEntity();
-        if (entity == null) continue;
-        switch (member.getType()) {
-          case NODE:
-            OSHNode oshNode = (OSHNode)entity;
-            modTs = oshNode.getModificationTimestamps();
-            validMemberTs = childNodes.get(member.getId()).iterator();
-            break;
-          case WAY:
-            OSHWay oshWay = (OSHWay)entity;
-            modTs = oshWay.getModificationTimestamps(true);
-            validMemberTs = childWays.get(member.getId()).iterator();
-            break;
-          default:
-            continue;
+
+    for (Entry<OSHEntity, LinkedList<OSHDBTimestamp>> childEntityT : childEntityTs.entrySet()) {
+      @SuppressWarnings("unchecked") Iterator<OSHDBTimestamp> modTs = (
+          childEntityT.getKey().getModificationTimestamps()
+      ).iterator();
+      LinkedList<OSHDBTimestamp> validMemberTs = childEntityT.getValue();
+      OSHDBTimestamp current = modTs.next();
+      outerTLoop: while (!validMemberTs.isEmpty()) {
+        OSHDBTimestamp fromTs = validMemberTs.pop();
+        OSHDBTimestamp toTs = validMemberTs.pop();
+        while (current.compareTo(fromTs) < 0)  {
+          if (!modTs.hasNext()) break outerTLoop;
+          current = modTs.next();
         }
-        while (validMemberTs.hasNext()) {
-          OSHDBTimestamp toTs = validMemberTs.next();
-          OSHDBTimestamp fromTs = validMemberTs.next();
-          for (OSHDBTimestamp ts : modTs) {
-            if (ts.compareTo(fromTs) >= 0 && ts.compareTo(toTs) < 0) {
-              result.add(ts);
-            }
-          }
+        while (current.compareTo(toTs) <= 0)  {
+          result.add(current);
+          if (!modTs.hasNext()) break outerTLoop;
+          current = modTs.next();
         }
       }
     }

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHRelation.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHRelation.java
@@ -573,7 +573,7 @@ public class OSHRelation extends OSHEntity<OSMRelation> implements Serializable 
     OSHDBTimestamp nextT = new OSHDBTimestamp(Long.MAX_VALUE);
     for (OSMRelation osmRelation : this) {
       OSHDBTimestamp thisT = osmRelation.getTimestamp();
-      if (!osmRelation.isVisible()) {
+      if (!osmRelation.isVisible() || (osmEntityFilter != null && !osmEntityFilter.test(osmRelation))) {
         nextT = thisT;
         continue;
       }

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHWay.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osh/OSHWay.java
@@ -22,6 +22,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.function.Predicate;
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
 import org.heigit.bigspatialdata.oshdb.osm.OSMMember;
 import org.heigit.bigspatialdata.oshdb.osm.OSMNode;
@@ -404,11 +405,33 @@ public class OSHWay extends OSHEntity<OSMWay> implements Serializable {
     }
   }
 
+
+  @Override
+  public List<OSHDBTimestamp> getModificationTimestamps(Predicate<OSMEntity> osmEntityFilter) {
+    return _getModificationTimestamps(true, osmEntityFilter);
+  }
+
   @Override
   public List<OSHDBTimestamp> getModificationTimestamps(boolean recurse) {
+    return _getModificationTimestamps(recurse, null);
+  }
+
+  private List<OSHDBTimestamp> _getModificationTimestamps(
+      boolean recurse,
+      Predicate<OSMEntity> osmEntityFilter
+  ) {
     List<OSHDBTimestamp> wayTs = new ArrayList<>(this.iterator().next().getVersion());
+    OSHDBTimestamp prevNonmatch = null;
     for (OSMWay osmWay : this) {
-      wayTs.add(osmWay.getTimestamp());
+      if (osmWay.isVisible() && (osmEntityFilter == null || osmEntityFilter.test(osmWay))) {
+        if (prevNonmatch != null) {
+          wayTs.add(prevNonmatch);
+          prevNonmatch = null;
+        }
+        wayTs.add(osmWay.getTimestamp());
+      } else {
+        prevNonmatch = osmWay.getTimestamp();
+      }
     }
     if (!recurse) {
       return Lists.reverse(wayTs);
@@ -416,11 +439,10 @@ public class OSHWay extends OSHEntity<OSMWay> implements Serializable {
 
     Map<OSHEntity, LinkedList<OSHDBTimestamp>> childEntityTs = new TreeMap<>();
 
-    int i = 0;
     OSHDBTimestamp nextT = new OSHDBTimestamp(Long.MAX_VALUE);
     for (OSMWay osmWay : this) {
-      OSHDBTimestamp thisT = wayTs.get(i++);
-      if (!osmWay.isVisible()) {
+      OSHDBTimestamp thisT = osmWay.getTimestamp();
+      if (!osmWay.isVisible() || (osmEntityFilter != null && !osmEntityFilter.test(osmWay))) {
         nextT = thisT;
         continue;
       }

--- a/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/osh/OSHRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/osh/OSHRelationTest.java
@@ -142,38 +142,40 @@ public class OSHRelationTest {
     OSHNode hnode1 = OSHNode.build(n1versions);
     List<OSMNode> n2versions = new ArrayList<>();
     n2versions.add(new OSMNode(124l, 4, new OSHDBTimestamp(12l), 24l, 0, new int[]{}, 0, 0));
-    n2versions.add(new OSMNode(124l, 3, new OSHDBTimestamp(8l), 23l, 0, new int[]{}, 0, 0));
+    n2versions.add(new OSMNode(124l, 3, new OSHDBTimestamp(9l), 23l, 0, new int[]{}, 0, 0));
     n2versions.add(new OSMNode(124l, 2, new OSHDBTimestamp(4l), 22l, 0, new int[]{}, 0, 0));
     n2versions.add(new OSMNode(124l, 1, new OSHDBTimestamp(3l), 21l, 0, new int[]{}, 0, 0));
     OSHNode hnode2 = OSHNode.build(n2versions);
     List<OSMNode> n3versions = new ArrayList<>();
-    n3versions.add(new OSMNode(125l, 4, new OSHDBTimestamp(11l), 34l, 0, new int[]{}, 0, 0));
-    n3versions.add(new OSMNode(125l, 3, new OSHDBTimestamp(9l), 33l, 0, new int[]{}, 0, 0));
+    n3versions.add(new OSMNode(125l, 3, new OSHDBTimestamp(11l), 34l, 0, new int[]{}, 0, 0));
     n3versions.add(new OSMNode(125l, 2, new OSHDBTimestamp(6l), 32l, 0, new int[]{}, 0, 0));
     n3versions.add(new OSMNode(125l, 1, new OSHDBTimestamp(1l), 31l, 0, new int[]{}, 0, 0));
     OSHNode hnode3 = OSHNode.build(n3versions);
 
     List<OSMWay> w1versions = new ArrayList<>();
-    w1versions.add(new OSMWay(1, 2, new OSHDBTimestamp(7l), 4445l, 23, new int[]{}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0), new OSMMember(124, OSMType.NODE, 0)}));
-    w1versions.add(new OSMWay(1, 1, new OSHDBTimestamp(5l), 4444l, 23, new int[]{}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0), new OSMMember(124, OSMType.NODE, 0), new OSMMember(125, OSMType.NODE, 0)}));
+    w1versions.add(new OSMWay(1, 3, new OSHDBTimestamp(7l), 4445l, 23, new int[]{}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0), new OSMMember(124, OSMType.NODE, 0)}));
+    w1versions.add(new OSMWay(1, 2, new OSHDBTimestamp(5l), 4444l, 23, new int[]{}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0), new OSMMember(124, OSMType.NODE, 0), new OSMMember(125, OSMType.NODE, 0)}));
+    w1versions.add(new OSMWay(1, 1, new OSHDBTimestamp(4l), 4443l, 23, new int[]{}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0), new OSMMember(124, OSMType.NODE, 0), new OSMMember(125, OSMType.NODE, 0)}));
     OSHWay hway1 = OSHWay.build(w1versions, Arrays.asList(hnode1, hnode2, hnode3));
 
     List<OSMRelation> versions = new ArrayList<>();
-    versions.add(new OSMRelation(1, 3, new OSHDBTimestamp(10l), 10000l, 1, new int[]{1, 1, 2, 2}, new OSMMember[]{new OSMMember(1, OSMType.WAY, 0)}));
-    versions.add(new OSMRelation(1, 2, new OSHDBTimestamp(8l), 10000l, 1, new int[]{1, 1, 2, 2}, new OSMMember[]{}));
-    versions.add(new OSMRelation(1, 1, new OSHDBTimestamp(5l), 10000l, 1, new int[]{1, 1, 2, 2}, new OSMMember[]{new OSMMember(1, OSMType.WAY, 0)}));
+    versions.add(new OSMRelation(1, -4, new OSHDBTimestamp(20l), 10004l, 1, new int[]{}, new OSMMember[]{}));
+    versions.add(new OSMRelation(1, 3, new OSHDBTimestamp(10l), 10003l, 1, new int[]{1, 1, 2, 2}, new OSMMember[]{new OSMMember(1, OSMType.WAY, 0)}));
+    versions.add(new OSMRelation(1, 2, new OSHDBTimestamp(8l), 10002l, 1, new int[]{1, 1, 2, 2}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 1)}));
+    versions.add(new OSMRelation(1, 1, new OSHDBTimestamp(5l), 10001l, 1, new int[]{1, 1, 2, 2}, new OSMMember[]{new OSMMember(1, OSMType.WAY, 0)}));
     OSHRelation hrelation = OSHRelation.build(versions, Arrays.asList(hnode1, hnode2, hnode3), Arrays.asList(hway1));
 
     List<OSHDBTimestamp> tss = hrelation.getModificationTimestamps(false);
     assertNotNull(tss);
-    assertEquals(3, tss.size());
+    assertEquals(4, tss.size());
     assertEquals(5l, tss.get(0).getRawUnixTimestamp());
     assertEquals(8l, tss.get(1).getRawUnixTimestamp());
     assertEquals(10l, tss.get(2).getRawUnixTimestamp());
+    assertEquals(20l, tss.get(3).getRawUnixTimestamp());
 
     tss = hrelation.getModificationTimestamps(true);
     assertNotNull(tss);
-    assertEquals(6, tss.size());
+    assertEquals(7, tss.size());
     assertEquals(5l, tss.get(0).getRawUnixTimestamp());
     assertEquals(6l, tss.get(1).getRawUnixTimestamp());
     assertEquals(7l, tss.get(2).getRawUnixTimestamp());
@@ -182,6 +184,7 @@ public class OSHRelationTest {
     assertEquals(10l,  tss.get(4).getRawUnixTimestamp());
     // timestamp 11 has to be missing because at the time, the node wasn't part of the way member of the relation anymore
     assertEquals(12l, tss.get(5).getRawUnixTimestamp());
+    assertEquals(20l, tss.get(6).getRawUnixTimestamp());
   }
 
   static OSHNode buildHOSMNode(List<OSMNode> versions) {

--- a/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/osh/OSHRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/osh/OSHRelationTest.java
@@ -187,6 +187,37 @@ public class OSHRelationTest {
     assertEquals(20l, tss.get(6).getRawUnixTimestamp());
   }
 
+  @Test
+  public void testGetModificationTimestampsWithFilter() throws IOException {
+    List<OSMNode> n1versions = new ArrayList<>();
+    n1versions.add(new OSMNode(123l, 7, new OSHDBTimestamp(17l), 17l, 0, new int[]{}, 0, 0));
+    n1versions.add(new OSMNode(123l, 6, new OSHDBTimestamp(6l), 16l, 0, new int[]{}, 0, 0));
+    n1versions.add(new OSMNode(123l, 5, new OSHDBTimestamp(5l), 15l, 0, new int[]{}, 0, 0));
+    n1versions.add(new OSMNode(123l, 4, new OSHDBTimestamp(4l), 14l, 0, new int[]{}, 0, 0));
+    n1versions.add(new OSMNode(123l, 3, new OSHDBTimestamp(3l), 13l, 0, new int[]{}, 0, 0));
+    n1versions.add(new OSMNode(123l, 2, new OSHDBTimestamp(2l), 12l, 0, new int[]{}, 0, 0));
+    n1versions.add(new OSMNode(123l, 1, new OSHDBTimestamp(1l), 11l, 0, new int[]{}, 0, 0));
+    OSHNode hnode1 = OSHNode.build(n1versions);
+
+    List<OSMRelation> versions = new ArrayList<>();
+    versions.add(new OSMRelation(1, -4, new OSHDBTimestamp(6l), 10004l, 1, new int[]{}, new OSMMember[]{}));
+    versions.add(new OSMRelation(1, 3, new OSHDBTimestamp(5l), 10003l, 1, new int[]{}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0)}));
+    versions.add(new OSMRelation(1, 2, new OSHDBTimestamp(3l), 10002l, 1, new int[]{}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 1)}));
+    versions.add(new OSMRelation(1, 1, new OSHDBTimestamp(1l), 10001l, 1, new int[]{}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0)}));
+    OSHRelation hrelation = OSHRelation.build(versions, Arrays.asList(hnode1), Arrays.asList());
+
+    List<OSHDBTimestamp> tss = hrelation.getModificationTimestamps(entity -> entity.getVersion() != 2);
+    assertNotNull(tss);
+    assertEquals(5, tss.size());
+    assertEquals(1l, tss.get(0).getRawUnixTimestamp());
+    assertEquals(2l, tss.get(1).getRawUnixTimestamp());
+    assertEquals(3l, tss.get(2).getRawUnixTimestamp());
+    // ts 4 missing since entity filter doesn't match then
+    assertEquals(5l, tss.get(3).getRawUnixTimestamp());
+    assertEquals(6l, tss.get(4).getRawUnixTimestamp());
+
+  }
+
   static OSHNode buildHOSMNode(List<OSMNode> versions) {
     try {
       return OSHNode.build(versions);

--- a/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/osh/OSHWayTest.java
+++ b/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/osh/OSHWayTest.java
@@ -100,10 +100,12 @@ public class OSHWayTest {
   @Test
   public void testGetModificationTimestamps() throws IOException {
     List<OSMNode> n1versions = new ArrayList<>();
+    n1versions.add(new OSMNode(123l, -3, new OSHDBTimestamp(14l), 13l, 0, new int[]{}, 0, 0));
     n1versions.add(new OSMNode(123l, 2, new OSHDBTimestamp(2l), 12l, 0, new int[]{}, 0, 0));
     n1versions.add(new OSMNode(123l, 1, new OSHDBTimestamp(1l), 11l, 0, new int[]{}, 0, 0));
     OSHNode hnode1 = OSHNode.build(n1versions);
     List<OSMNode> n2versions = new ArrayList<>();
+    n2versions.add(new OSMNode(124l, 5, new OSHDBTimestamp(14l), 25l, 0, new int[]{}, 0, 0));
     n2versions.add(new OSMNode(124l, 4, new OSHDBTimestamp(12l), 24l, 0, new int[]{}, 0, 0));
     n2versions.add(new OSMNode(124l, 3, new OSHDBTimestamp(8l), 23l, 0, new int[]{}, 0, 0));
     n2versions.add(new OSMNode(124l, 2, new OSHDBTimestamp(4l), 22l, 0, new int[]{}, 0, 0));
@@ -116,24 +118,27 @@ public class OSHWayTest {
     OSHNode hnode3 = OSHNode.build(n3versions);
 
     List<OSMWay> versions = new ArrayList<>();
+    versions.add(new OSMWay(123, -3, new OSHDBTimestamp(13l), 4446l, 23, new int[]{}, new OSMMember[]{}));
     versions.add(new OSMWay(123, 2, new OSHDBTimestamp(7l), 4445l, 23, new int[]{1, 1, 2, 2}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0), new OSMMember(124, OSMType.NODE, 0)}));
     versions.add(new OSMWay(123, 1, new OSHDBTimestamp(5l), 4444l, 23, new int[]{1, 1, 2, 1}, new OSMMember[]{new OSMMember(123, OSMType.NODE, 0), new OSMMember(124, OSMType.NODE, 0), new OSMMember(125, OSMType.NODE, 0)}));
     OSHWay hway = OSHWay.build(versions, Arrays.asList(hnode1, hnode2, hnode3));
 
     List<OSHDBTimestamp> tss = hway.getModificationTimestamps(false);
     assertNotNull(tss);
-    assertEquals(2, tss.size());
+    assertEquals(3, tss.size());
     assertEquals(5l, (long) tss.get(0).getRawUnixTimestamp());
     assertEquals(7l, (long) tss.get(1).getRawUnixTimestamp());
+    assertEquals(13l, (long) tss.get(2).getRawUnixTimestamp());
 
     tss = hway.getModificationTimestamps(true);
     assertNotNull(tss);
-    assertEquals(5, tss.size());
+    assertEquals(6, tss.size());
     assertEquals(5l, tss.get(0).getRawUnixTimestamp());
     assertEquals(6l, tss.get(1).getRawUnixTimestamp());
     assertEquals(7l, tss.get(2).getRawUnixTimestamp());
     assertEquals(8l, tss.get(3).getRawUnixTimestamp());
     assertEquals(12l, tss.get(4).getRawUnixTimestamp());
+    assertEquals(13l, (long) tss.get(5).getRawUnixTimestamp());
   }
 
   @Test

--- a/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/osh/OSHWayTest.java
+++ b/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/osh/OSHWayTest.java
@@ -182,7 +182,7 @@ public class OSHWayTest {
 
     tss = hway.getModificationTimestamps(osmEntity -> osmEntity.hasTagValue(2, 1));
     assertNotNull(tss);
-    //assertEquals(5, tss.size());
+    assertEquals(5, tss.size());
     assertEquals(5l, tss.get(0).getRawUnixTimestamp());
     assertEquals(6l, tss.get(1).getRawUnixTimestamp());
     assertEquals(7l, tss.get(2).getRawUnixTimestamp());


### PR DESCRIPTION
Improves the way modification timestamps for OSHEntity objects are calculated:

* avoid nested loops – this did work OK for small entities like ways with a couple of versions, but not for large (route) relations that have thousands of members, have hundreds of versions and it's members also have dozens of versions each. Before complexity was ~`O(v*m*mv)`, now it should be more like `O(v+m*mv*f)`, where `f` is a small factor (larger than one) representing the amount of fragmentation of the membership time intervals of the particular relation (which is usually small).
* calculate filtered modification timestamps directly (without first calculating all modification timestamps and filtering them afterwards).
* test osh entities early with the given osm entity filter (e.g. when filtering for `highway=residential`, ways that have the `highway` tag but never had the value `residential` don't need to be looked at in further processing steps).

This resolves #8