### PR TITLE
Implement MapReducer.stream()

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -3,6 +3,8 @@ package org.heigit.bigspatialdata.oshdb.api.mapreducer;
 import com.google.common.collect.Lists;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygonal;
+import java.util.Map.Entry;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.heigit.bigspatialdata.oshdb.api.generic.*;
@@ -510,6 +512,31 @@ public class MapAggregator<U extends Comparable<U>, X> implements
         (acc, cur) -> { acc.add(cur); return acc; },
         (list1, list2) -> { LinkedList<X> combinedLists = new LinkedList<>(list1); combinedLists.addAll(list2); return combinedLists; }
     );
+  }
+
+  /**
+   * Returns all results as a Stream
+   *
+   * @return a stream with all results returned by the `mapper` function
+   */
+  @Contract(pure = true)
+  public Stream<Entry<U, X>> stream() throws Exception {
+    return this._mapReducer.stream().map(d -> new Entry<U, X>() {
+      @Override
+      public U getKey() {
+        return d.getKey();
+      }
+
+      @Override
+      public X getValue() {
+        return d.getValue();
+      }
+
+      @Override
+      public X setValue(X value) {
+        throw new RuntimeException("cannot modify the value of this entry");
+      }
+    });
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -488,12 +488,14 @@ public class MapAggregator<U extends Comparable<U>, X> implements
   /**
    * Iterates over the results of this data aggregation
    *
-   * This method can be handy for testing purposes. But note that since the `action` doesn't produce a return value, it must facilitate its own way of producing output.
+   * This method can be handy for testing purposes. But note that since the `action` doesn't produce
+   * a return value, it must facilitate its own way of producing output.
    *
-   * If you'd like to use such a "forEach" in a non-test use case, use `.collect().forEach()` instead.
+   * If you'd like to use such a "forEach" in a non-test use case, use `.collect().forEach()` or
+   * `.stream().forEach()`  instead.
    *
    * @param action function that gets called for each transformed data entry
-   * @deprecated only for testing purposes
+   * @deprecated only for testing purposes. use `.collect().forEach()` or `.stream().forEach()` instead
    */
   @Deprecated
   public void forEach(SerializableBiConsumer<U, List<X>> action) throws Exception {

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -1192,7 +1192,7 @@ public abstract class MapReducer<X> implements
   public Stream<X> stream() throws Exception {
     try {
       return this._stream();
-    } catch(UnsupportedOperationException e) {
+    } catch (UnsupportedOperationException e) {
       LOG.info("stream not directly supported by chosen backend, falling back to .collect().stream()");
       return this.collect().stream();
     }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -1151,11 +1151,11 @@ public abstract class MapReducer<X> implements
    * This method can be handy for testing purposes. But note that since the `action` doesn't produce
    * a return value, it must facilitate its own way of producing output.
    *
-   * If you'd like to use such a "forEach" in a non-test use case, use `.collect().forEach()`
+   * If you'd like to use such a "forEach" in a non-test use case, use `.stream().forEach()`
    * instead.
    *
    * @param action function that gets called for each transformed data entry
-   * @deprecated only for testing purposes
+   * @deprecated only for testing purposes, use `.stream().forEach()` instead
    */
   @Deprecated
   public void forEach(SerializableConsumer<X> action) throws Exception {

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/Kernels.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/Kernels.java
@@ -1,0 +1,266 @@
+package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
+
+import com.google.common.collect.Iterables;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBiFunction;
+import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableFunction;
+import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableSupplier;
+import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
+import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
+import org.heigit.bigspatialdata.oshdb.grid.GridOSHEntity;
+import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator;
+
+class Kernels {
+  interface CellProcessor<S> extends SerializableBiFunction<GridOSHEntity, CellIterator, S> {}
+
+  interface CancelableProcessStatus {
+    boolean isActive();
+  }
+
+  private static class NonCancelableProcessStatus
+      implements CancelableProcessStatus, Serializable {
+    @Override
+    public boolean isActive() {
+      return true;
+    }
+  }
+
+  private static final CancelableProcessStatus NC = new NonCancelableProcessStatus();
+
+  // === map-reduce processors ===
+
+  @Nonnull
+  static <R, S> CellProcessor<S> getOSMContributionCellReducer(
+      SerializableFunction<OSMContribution, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator
+  ) {
+    return getOSMContributionCellReducer(mapper, identitySupplier, accumulator, NC);
+  }
+
+  @Nonnull
+  static <R, S> CellProcessor<S> getOSMContributionCellReducer(
+      SerializableFunction<OSMContribution, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      CancelableProcessStatus aborter
+  ) {
+    return (oshEntityCell, cellIterator) -> {
+      // iterate over the history of all OSM objects in the current cell
+      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
+      cellIterator.iterateByContribution(oshEntityCell)
+          .filter(ignored -> aborter.isActive())
+          .forEach(contribution -> {
+            OSMContribution osmContribution = new OSMContribution(contribution);
+            accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(osmContribution)));
+          });
+      return accInternal.get();
+    };
+  }
+
+  @Nonnull
+  static <R, S> CellProcessor<S> getOSMContributionGroupingCellReducer(
+      SerializableFunction<List<OSMContribution>, Iterable<R>> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator
+  ) {
+    return getOSMContributionGroupingCellReducer(mapper, identitySupplier, accumulator, NC);
+  }
+
+  @Nonnull
+  static <R, S> CellProcessor<S> getOSMContributionGroupingCellReducer(
+      SerializableFunction<List<OSMContribution>, Iterable<R>> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      CancelableProcessStatus aborter
+  ) {
+    return (oshEntityCell, cellIterator) -> {
+      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
+      // iterate over the history of all OSM objects in the current cell
+      List<OSMContribution> contributions = new ArrayList<>();
+      cellIterator.iterateByContribution(oshEntityCell)
+          .filter(ignored -> aborter.isActive())
+          .forEach(contribution -> {
+            OSMContribution thisContribution = new OSMContribution(contribution);
+            if (contributions.size() > 0
+                && thisContribution.getEntityAfter().getId() != contributions
+                .get(contributions.size() - 1).getEntityAfter().getId()) {
+              // immediately fold the results
+              for (R r : mapper.apply(contributions)) {
+                accInternal.set(accumulator.apply(accInternal.get(), r));
+              }
+              contributions.clear();
+            }
+            contributions.add(thisContribution);
+          });
+      // apply mapper and fold results one more time for last entity in current cell
+      if (contributions.size() > 0) {
+        for (R r : mapper.apply(contributions)) {
+          accInternal.set(accumulator.apply(accInternal.get(), r));
+        }
+      }
+      return accInternal.get();
+    };
+  }
+
+  @Nonnull
+  static <R, S> CellProcessor<S> getOSMEntitySnapshotCellReducer(
+      SerializableFunction<OSMEntitySnapshot, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator
+  ) {
+    return getOSMEntitySnapshotCellReducer(mapper, identitySupplier, accumulator, NC);
+  }
+
+  @Nonnull
+  static <R, S> CellProcessor<S> getOSMEntitySnapshotCellReducer(
+      SerializableFunction<OSMEntitySnapshot, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      CancelableProcessStatus aborter
+  ) {
+    return (oshEntityCell, cellIterator) -> {
+      // iterate over the history of all OSM objects in the current cell
+      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
+      cellIterator.iterateByTimestamps(oshEntityCell)
+          .filter(ignored -> aborter.isActive())
+          .forEach(data -> {
+            OSMEntitySnapshot snapshot = new OSMEntitySnapshot(data);
+            // immediately fold the result
+            accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(snapshot)));
+          });
+      return accInternal.get();
+    };
+  }
+
+  @Nonnull
+  static <R, S> CellProcessor<S> getOSMEntitySnapshotGroupingCellReducer(
+      SerializableFunction<List<OSMEntitySnapshot>, Iterable<R>> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator
+  ) {
+    return getOSMEntitySnapshotGroupingCellReducer(mapper, identitySupplier, accumulator, NC);
+  }
+
+  @Nonnull
+  static <R, S> CellProcessor<S> getOSMEntitySnapshotGroupingCellReducer(
+      SerializableFunction<List<OSMEntitySnapshot>, Iterable<R>> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      CancelableProcessStatus aborter
+  ) {
+    return (oshEntityCell, cellIterator) -> {
+      // iterate over the history of all OSM objects in the current cell
+      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
+      List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
+      cellIterator.iterateByTimestamps(oshEntityCell)
+          .filter(ignored -> aborter.isActive())
+          .forEach(data -> {
+            OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshot(data);
+            if (osmEntitySnapshots.size() > 0
+                && thisSnapshot.getEntity().getId() != osmEntitySnapshots
+                .get(osmEntitySnapshots.size() - 1).getEntity().getId()) {
+              // immediately fold the results
+              for (R r : mapper.apply(osmEntitySnapshots)) {
+                accInternal.set(accumulator.apply(accInternal.get(), r));
+              }
+              osmEntitySnapshots.clear();
+            }
+            osmEntitySnapshots.add(thisSnapshot);
+          });
+      // apply mapper and fold results one more time for last entity in current cell
+      if (osmEntitySnapshots.size() > 0) {
+        for (R r : mapper.apply(osmEntitySnapshots)) {
+          accInternal.set(accumulator.apply(accInternal.get(), r));
+        }
+      }
+      return accInternal.get();
+    };
+  }
+
+  // === stream processors ===
+
+  @Nonnull
+  static <S> CellProcessor<Stream<S>> getOSMContributionCellStreamer(
+      SerializableFunction<OSMContribution, S> mapper
+  ) {
+    return (oshEntityCell, cellIterator) -> {
+      // iterate over the history of all OSM objects in the current cell
+      return cellIterator.iterateByContribution(oshEntityCell)
+          .map(OSMContribution::new)
+          .map(mapper);
+    };
+  }
+
+  @Nonnull
+  static <S> CellProcessor<Stream<S>> getOSMContributionGroupingCellStreamer(
+      SerializableFunction<List<OSMContribution>, Iterable<S>> mapper
+  ) {
+    return (oshEntityCell, cellIterator) -> {
+      // iterate over the history of all OSM objects in the current cell
+      List<OSMContribution> contributions = new ArrayList<>();
+      List<S> result = new LinkedList<>();
+      cellIterator.iterateByContribution(oshEntityCell)
+          .map(OSMContribution::new)
+          .forEach(contribution -> {
+            if (contributions.size() > 0 && contribution.getEntityAfter().getId()
+                != contributions.get(contributions.size() - 1).getEntityAfter().getId()) {
+              // immediately flatten the results
+              Iterables.addAll(result, mapper.apply(contributions));
+              contributions.clear();
+            }
+            contributions.add(contribution);
+          });
+      // apply mapper and fold results one more time for last entity in current cell
+      if (contributions.size() > 0) {
+        Iterables.addAll(result, mapper.apply(contributions));
+      }
+      return result.stream();
+    };
+  }
+
+  @Nonnull
+  static <S> CellProcessor<Stream<S>> getOSMEntitySnapshotCellStreamer(
+      SerializableFunction<OSMEntitySnapshot, S> mapper
+  ) {
+    return (oshEntityCell, cellIterator) -> {
+      // iterate over the history of all OSM objects in the current cell
+      return cellIterator.iterateByTimestamps(oshEntityCell)
+          .map(OSMEntitySnapshot::new)
+          .map(mapper);
+    };
+  }
+
+  @Nonnull
+  static <S> CellProcessor<Stream<S>> getOSMEntitySnapshotGroupingCellStreamer(
+      SerializableFunction<List<OSMEntitySnapshot>, Iterable<S>> mapper
+  ) {
+    return (oshEntityCell, cellIterator) -> {
+      // iterate over the history of all OSM objects in the current cell
+      List<OSMEntitySnapshot> snapshots = new ArrayList<>();
+      List<S> result = new LinkedList<>();
+      cellIterator.iterateByTimestamps(oshEntityCell)
+          .map(OSMEntitySnapshot::new)
+          .forEach(contribution -> {
+            if (snapshots.size() > 0 && contribution.getEntity().getId()
+                != snapshots.get(snapshots.size() - 1).getEntity().getId()) {
+              // immediately flatten the results
+              Iterables.addAll(result, mapper.apply(snapshots));
+              snapshots.clear();
+            }
+            snapshots.add(contribution);
+          });
+      // apply mapper and fold results one more time for last entity in current cell
+      if (snapshots.size() > 0) {
+        Iterables.addAll(result, mapper.apply(snapshots));
+      }
+      return result.stream();
+    };
+  }
+}

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -111,7 +111,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
   }
 
   private Stream<X> stream(
-      CellProcessor<Stream<X>> processor
+      CellProcessor<Collection<X>> processor
   ) throws ParseException, SQLException, IOException {
     CellIterator cellIterator = new CellIterator(
         this._tstamps.get(),
@@ -135,12 +135,12 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
             @SuppressWarnings("SerializableStoresNonSerializable")
             GridOSHEntity oshEntityCell = cache.localPeek(cellLongId);
             if (oshEntityCell == null) {
-              return Stream.<X>empty();
+              return Collections.<X>emptyList();
             } else {
               return processor.apply(oshEntityCell, cellIterator);
             }
           }))
-          .flatMap(x -> x);
+          .flatMap(Collection::stream);
     }).flatMap(x -> x);
   }
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -1,12 +1,10 @@
 package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.io.Serializable;
 import java.sql.SQLException;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -15,18 +13,19 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCompute;
+import org.heigit.bigspatialdata.oshdb.TableNames;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.*;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CellProcessor;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
-import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator;
 import org.heigit.bigspatialdata.oshdb.grid.GridOSHEntity;
 import org.heigit.bigspatialdata.oshdb.osm.OSMType;
 import org.heigit.bigspatialdata.oshdb.util.CellId;
-import org.heigit.bigspatialdata.oshdb.TableNames;
+import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator;
 import org.jetbrains.annotations.NotNull;
 import org.json.simple.parser.ParseException;
 
@@ -70,15 +69,8 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
     };
   }
 
-  interface Callback<S> extends Serializable {
-    S apply(
-        GridOSHEntity oshEntityCell,
-        CellIterator cellIterator
-    );
-  }
-
-  private <S> S runOnIgnite(
-      Callback<S> callback,
+  private <S> S reduce(
+      CellProcessor<S> cellProcessor,
       SerializableSupplier<S> identitySupplier,
       SerializableBinaryOperator<S> combiner
   ) throws ParseException, SQLException, IOException {
@@ -105,13 +97,13 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
             GridOSHEntity oshEntityCell = cache.localPeek(cellLongId);
             if (oshEntityCell == null)
               return identitySupplier.get();
-            return callback.apply(oshEntityCell, cellIterator);
+            return cellProcessor.apply(oshEntityCell, cellIterator);
           })).reduce(identitySupplier.get(), combiner);
     }).reduce(identitySupplier.get(), combiner);
   }
 
-  private Stream<X> runOnIgnite(
-      Callback<Stream<X>> callback
+  private Stream<X> stream(
+      CellProcessor<Stream<X>> processor
   ) throws ParseException, SQLException, IOException {
     CellIterator cellIterator = new CellIterator(
         this._tstamps.get(),
@@ -137,184 +129,95 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
             if (oshEntityCell == null) {
               return Stream.<X>empty();
             } else {
-              return callback.apply(oshEntityCell, cellIterator);
+              return processor.apply(oshEntityCell, cellIterator);
             }
           }))
           .flatMap(x -> x);
     }).flatMap(x -> x);
   }
 
+  // === map-reduce operations ===
+
   @Override
-  protected <R, S> S mapReduceCellsOSMContribution(SerializableFunction<OSMContribution, R> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return runOnIgnite((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      cellIterator.iterateByContribution(oshEntityCell)
-          .forEach(contribution -> {
-            OSMContribution osmContribution = new OSMContribution(contribution);
-            accInternal
-                .set(accumulator.apply(accInternal.get(), mapper.apply(osmContribution)));
-          });
-      return accInternal.get();
-    }, identitySupplier, combiner);
+  protected <R, S> S mapReduceCellsOSMContribution(
+      SerializableFunction<OSMContribution, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return this.reduce(
+        Kernels.getOSMContributionCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
   @Override
   protected <R, S> S flatMapReduceCellsOSMContributionGroupedById(
       SerializableFunction<List<OSMContribution>, Iterable<R>> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return runOnIgnite((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      List<OSMContribution> contributions = new ArrayList<>();
-      cellIterator.iterateByContribution(oshEntityCell)
-          .forEach(contribution -> {
-            OSMContribution thisContribution = new OSMContribution(contribution);
-            if (contributions.size() > 0 && thisContribution.getEntityAfter().getId()
-                != contributions.get(contributions.size() - 1).getEntityAfter().getId()) {
-              // immediately fold the results
-              for (R r : mapper.apply(contributions)) {
-                accInternal.set(accumulator.apply(accInternal.get(), r));
-              }
-              contributions.clear();
-            }
-            contributions.add(thisContribution);
-          });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (contributions.size() > 0) {
-        for (R r : mapper.apply(contributions)) {
-          accInternal.set(accumulator.apply(accInternal.get(), r));
-        }
-      }
-      return accInternal.get();
-    }, identitySupplier, combiner);
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return reduce(
+        Kernels.getOSMContributionGroupingCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
 
   @Override
   protected <R, S> S mapReduceCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, R> mapper, SerializableSupplier<S> identitySupplier,
-      SerializableBiFunction<S, R, S> accumulator, SerializableBinaryOperator<S> combiner)
-      throws Exception {
-    return runOnIgnite((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      cellIterator.iterateByTimestamps(oshEntityCell).forEach(data -> {
-        OSMEntitySnapshot snapshot = new OSMEntitySnapshot(data);
-        // immediately fold the result
-        accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(snapshot)));
-      });
-      return accInternal.get();
-    }, identitySupplier, combiner);
+      SerializableFunction<OSMEntitySnapshot, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return reduce(
+        Kernels.getOSMEntitySnapshotCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
   @Override
   protected <R, S> S flatMapReduceCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<R>> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return runOnIgnite((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
-      cellIterator.iterateByTimestamps(oshEntityCell).forEach(data -> {
-        OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshot(data);
-        if (osmEntitySnapshots.size() > 0 && thisSnapshot.getEntity().getId()
-            != osmEntitySnapshots.get(osmEntitySnapshots.size() - 1).getEntity().getId()) {
-          // immediately fold the results
-          for (R r : mapper.apply(osmEntitySnapshots)) {
-            accInternal.set(accumulator.apply(accInternal.get(), r));
-          }
-          osmEntitySnapshots.clear();
-        }
-        osmEntitySnapshots.add(thisSnapshot);
-      });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (osmEntitySnapshots.size() > 0) {
-        for (R r : mapper.apply(osmEntitySnapshots)) {
-          accInternal.set(accumulator.apply(accInternal.get(), r));
-        }
-      }
-      return accInternal.get();
-    }, identitySupplier, combiner);
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return reduce(
+        Kernels.getOSMEntitySnapshotGroupingCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
-  // === streams ===
+  // === stream operations ===
 
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
       SerializableFunction<OSMContribution, X> mapper) throws Exception {
-    return runOnIgnite((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByContribution(oshEntityCell)
-          .map(OSMContribution::new)
-          .map(mapper);
-    });
+    return stream(Kernels.getOSMContributionCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMContributionGroupedById(
       SerializableFunction<List<OSMContribution>, Iterable<X>> mapper) throws Exception {
-    return runOnIgnite((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      List<OSMContribution> contributions = new ArrayList<>();
-      List<X> result = new LinkedList<>();
-      cellIterator.iterateByContribution(oshEntityCell)
-          .map(OSMContribution::new)
-          .forEach(contribution -> {
-            if (contributions.size() > 0 && contribution.getEntityAfter().getId()
-                != contributions.get(contributions.size() - 1).getEntityAfter().getId()) {
-              // immediately flatten the results
-              Iterables.addAll(result, mapper.apply(contributions));
-              contributions.clear();
-            }
-            contributions.add(contribution);
-          });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (contributions.size() > 0) {
-        Iterables.addAll(result, mapper.apply(contributions));
-      }
-      return result.stream();
-    });
+    return stream(Kernels.getOSMContributionGroupingCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
       SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
-    return runOnIgnite((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByTimestamps(oshEntityCell)
-          .map(OSMEntitySnapshot::new)
-          .map(mapper);
-    });
+    return stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> mapper) throws Exception {
-    return runOnIgnite((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      List<OSMEntitySnapshot> snapshots = new ArrayList<>();
-      List<X> result = new LinkedList<>();
-      cellIterator.iterateByTimestamps(oshEntityCell)
-          .map(OSMEntitySnapshot::new)
-          .forEach(contribution -> {
-            if (snapshots.size() > 0 && contribution.getEntity().getId()
-                != snapshots.get(snapshots.size() - 1).getEntity().getId()) {
-              // immediately flatten the results
-              Iterables.addAll(result, mapper.apply(snapshots));
-              snapshots.clear();
-            }
-            snapshots.add(contribution);
-          });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (snapshots.size() > 0) {
-        Iterables.addAll(result, mapper.apply(snapshots));
-      }
-      return result.stream();
-    });
+    return stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper));
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -4,7 +4,6 @@ import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygonal;
 import java.io.Serializable;
 import java.util.*;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -18,6 +17,8 @@ import org.apache.ignite.lang.IgniteFutureTimeoutException;
 import org.apache.ignite.resources.IgniteInstanceResource;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CancelableProcessStatus;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CellProcessor;
 import org.heigit.bigspatialdata.oshdb.util.CellId;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.tagInterpreter.TagInterpreter;
@@ -176,10 +177,10 @@ class IgniteLocalPeekHelper {
    * Compute closure that iterates over every partition owned by a node located in a partition.
    */
   private static abstract class MapReduceCellsOnIgniteCacheComputeJob<V, R, MR, S, P extends Geometry & Polygonal>
-      implements Serializable {
+      implements Serializable, CancelableProcessStatus {
     private static final Logger LOG =
         LoggerFactory.getLogger(MapReduceCellsOnIgniteCacheComputeJob.class);
-    boolean canceled = false;
+    private boolean notCanceled = true;
 
     /* computation settings */
     final List<String> cacheNames;
@@ -212,7 +213,12 @@ class IgniteLocalPeekHelper {
 
     void cancel() {
       LOG.info("compute job canceled");
-      this.canceled = true;
+      this.notCanceled = false;
+    }
+
+    @Override
+    public boolean isActive() {
+      return this.notCanceled;
     }
 
     public abstract S execute(Ignite node);
@@ -241,16 +247,12 @@ class IgniteLocalPeekHelper {
       return localKeys;
     }
 
-    interface Callback<S> extends Serializable {
-      S apply (GridOSHEntity oshEntityCell);
-    }
-
-    S execute(Ignite node, Callback<S> callback) {
+    S execute(Ignite node, CellProcessor<S> cellProcessor) {
       return this.localKeys(node).parallelStream()
           .map(cacheKey -> cacheKey.getLeft().localPeek(cacheKey.getRight()))
           .filter(Objects::nonNull) // filter out cache misses === empty oshdb cells
-          .filter(ignored -> !this.canceled)
-          .map(callback::apply)
+          .filter(ignored -> this.isActive())
+          .map(cell -> cellProcessor.apply(cell, this.cellIterator))
           .reduce(identitySupplier.get(), combiner);
     }
   }
@@ -269,20 +271,12 @@ class IgniteLocalPeekHelper {
 
     @Override
     public S execute(Ignite node) {
-      return super.execute(node, oshEntityCell -> {
-        // iterate over the history of all OSM objects in the current cell
-        AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-        cellIterator.iterateByContribution(oshEntityCell)
-            .forEach(contribution -> {
-              if (this.canceled)
-                return;
-              OSMContribution osmContribution =
-                  new OSMContribution(contribution);
-              accInternal
-                  .set(accumulator.apply(accInternal.get(), mapper.apply(osmContribution)));
-            });
-        return accInternal.get();
-      });
+      return super.execute(node, Kernels.getOSMContributionCellReducer(
+          this.mapper,
+          this.identitySupplier,
+          this.accumulator,
+          this
+      ));
     }
   }
 
@@ -301,34 +295,12 @@ class IgniteLocalPeekHelper {
 
     @Override
     public S execute(Ignite node) {
-      return super.execute(node, oshEntityCell -> {
-        // iterate over the history of all OSM objects in the current cell
-        AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-        List<OSMContribution> contributions = new ArrayList<>();
-        cellIterator.iterateByContribution(oshEntityCell)
-            .forEach(contribution -> {
-              if (this.canceled)
-                return;
-              OSMContribution thisContribution = new OSMContribution(contribution);
-              if (contributions.size() > 0
-                  && thisContribution.getEntityAfter().getId() != contributions
-                      .get(contributions.size() - 1).getEntityAfter().getId()) {
-                // immediately fold the results
-                for (R r : mapper.apply(contributions)) {
-                  accInternal.set(accumulator.apply(accInternal.get(), r));
-                }
-                contributions.clear();
-              }
-              contributions.add(thisContribution);
-            });
-        // apply mapper and fold results one more time for last entity in current cell
-        if (contributions.size() > 0) {
-          for (R r : mapper.apply(contributions)) {
-            accInternal.set(accumulator.apply(accInternal.get(), r));
-          }
-        }
-        return accInternal.get();
-      });
+      return super.execute(node, Kernels.getOSMContributionGroupingCellReducer(
+          this.mapper,
+          this.identitySupplier,
+          this.accumulator,
+          this
+      ));
     }
   }
 
@@ -346,17 +318,12 @@ class IgniteLocalPeekHelper {
 
     @Override
     public S execute(Ignite node) {
-      return super.execute(node, oshEntityCell -> {
-        // iterate over the history of all OSM objects in the current cell
-        AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-        cellIterator.iterateByTimestamps(oshEntityCell).forEach(data -> {
-          if (this.canceled) return;
-          OSMEntitySnapshot snapshot = new OSMEntitySnapshot(data);
-          // immediately fold the result
-          accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(snapshot)));
-        });
-        return accInternal.get();
-      });
+      return super.execute(node, Kernels.getOSMEntitySnapshotCellReducer(
+          this.mapper,
+          this.identitySupplier,
+          this.accumulator,
+          this
+      ));
     }
   }
 
@@ -375,33 +342,12 @@ class IgniteLocalPeekHelper {
 
     @Override
     public S execute(Ignite node) {
-      return super.execute(node, oshEntityCell -> {
-        // iterate over the history of all OSM objects in the current cell
-        AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-        List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
-        cellIterator.iterateByTimestamps(oshEntityCell).forEach(data -> {
-          if (this.canceled)
-            return;
-          OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshot(data);
-          if (osmEntitySnapshots.size() > 0
-              && thisSnapshot.getEntity().getId() != osmEntitySnapshots
-              .get(osmEntitySnapshots.size() - 1).getEntity().getId()) {
-            // immediately fold the results
-            for (R r : mapper.apply(osmEntitySnapshots)) {
-              accInternal.set(accumulator.apply(accInternal.get(), r));
-            }
-            osmEntitySnapshots.clear();
-          }
-          osmEntitySnapshots.add(thisSnapshot);
-        });
-        // apply mapper and fold results one more time for last entity in current cell
-        if (osmEntitySnapshots.size() > 0) {
-          for (R r : mapper.apply(osmEntitySnapshots)) {
-            accInternal.set(accumulator.apply(accInternal.get(), r));
-          }
-        }
-        return accInternal.get();
-      });
+      return super.execute(node, Kernels.getOSMEntitySnapshotGroupingCellReducer(
+          this.mapper,
+          this.identitySupplier,
+          this.accumulator,
+          this
+      ));
     }
   }
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
@@ -1,20 +1,10 @@
 package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
 
-import com.google.common.collect.Iterables;
 import java.io.IOException;
-import java.io.Serializable;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.NoSuchElementException;
-import java.util.Spliterators;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.tuple.Pair;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBiFunction;
@@ -22,12 +12,12 @@ import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBinaryOp
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableFunction;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableSupplier;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CellProcessor;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
-import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator;
-import org.heigit.bigspatialdata.oshdb.grid.GridOSHEntity;
 import org.heigit.bigspatialdata.oshdb.util.CellId;
+import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator;
 import org.jetbrains.annotations.NotNull;
 import org.json.simple.parser.ParseException;
 import org.slf4j.Logger;
@@ -52,15 +42,8 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
     return new MapReducerJdbcMultithread<X>(this);
   }
 
-  private interface Callback<S> extends Serializable {
-    S apply (
-        GridOSHEntity oshEntityCell,
-        CellIterator cellIterator
-    );
-  }
-
-  private <S> S run(
-      Callback<S> callback,
+  private <S> S reduce(
+      CellProcessor<S> processor,
       SerializableSupplier<S> identitySupplier,
       SerializableBinaryOperator<S> combiner
   ) throws ParseException, SQLException, IOException {
@@ -75,12 +58,12 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
 
     return cellIdRanges.parallelStream()
         .flatMap(this::getOshCellsStream)
-        .map(oshCell -> callback.apply(oshCell, cellIterator))
+        .map(oshCell -> processor.apply(oshCell, cellIterator))
         .reduce(identitySupplier.get(), combiner);
   }
 
-  private Stream<X> run(
-      Callback<Stream<X>> callback
+  private Stream<X> stream(
+      CellProcessor<Stream<X>> processor
   ) throws ParseException, SQLException, IOException {
     CellIterator cellIterator = new CellIterator(
         this._tstamps.get(),
@@ -93,178 +76,91 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
 
     return cellIdRanges.parallelStream()
         .flatMap(this::getOshCellsStream)
-        .flatMap(oshCell -> callback.apply(oshCell, cellIterator));
+        .flatMap(oshCell -> processor.apply(oshCell, cellIterator));
   }
 
+  // === map-reduce operations ===
+
   @Override
-  protected <R, S> S mapReduceCellsOSMContribution(SerializableFunction<OSMContribution, R> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      cellIterator.iterateByContribution(oshEntityCell).forEach(contribution -> {
-        OSMContribution osmContribution = new OSMContribution(contribution);
-        accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(osmContribution)));
-      });
-      return accInternal.get();
-    }, identitySupplier, combiner);
+  protected <R, S> S mapReduceCellsOSMContribution(
+      SerializableFunction<OSMContribution, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return this.reduce(
+        Kernels.getOSMContributionCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
   @Override
   protected <R, S> S flatMapReduceCellsOSMContributionGroupedById(
       SerializableFunction<List<OSMContribution>, Iterable<R>> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      List<OSMContribution> contributions = new ArrayList<>();
-      cellIterator.iterateByContribution(oshEntityCell).forEach(contribution -> {
-        OSMContribution thisContribution = new OSMContribution(contribution);
-        if (contributions.size() > 0 && thisContribution.getEntityAfter()
-            .getId() != contributions.get(contributions.size() - 1).getEntityAfter().getId()) {
-          // immediately fold the results
-          for (R r : mapper.apply(contributions)) {
-            accInternal.set(accumulator.apply(accInternal.get(), r));
-          }
-          contributions.clear();
-        }
-        contributions.add(thisContribution);
-      });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (contributions.size() > 0) {
-        for (R r : mapper.apply(contributions)) {
-          accInternal.set(accumulator.apply(accInternal.get(), r));
-        }
-      }
-      return accInternal.get();
-    }, identitySupplier, combiner);
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return this.reduce(
+        Kernels.getOSMContributionGroupingCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
   @Override
   protected <R, S> S mapReduceCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, R> mapper, SerializableSupplier<S> identitySupplier,
-      SerializableBiFunction<S, R, S> accumulator, SerializableBinaryOperator<S> combiner)
-      throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      cellIterator.iterateByTimestamps(oshEntityCell).forEach(data -> {
-        OSMEntitySnapshot snapshot = new OSMEntitySnapshot(data);
-        // immediately fold the result
-        accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(snapshot)));
-      });
-      return accInternal.get();
-    }, identitySupplier, combiner);
+      SerializableFunction<OSMEntitySnapshot, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return reduce(
+        Kernels.getOSMEntitySnapshotCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
   @Override
   protected <R, S> S flatMapReduceCellsOSMEntitySnapshotGroupedById(
-      SerializableFunction<List<OSMEntitySnapshot>, Iterable<R>> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
-      cellIterator.iterateByTimestamps(oshEntityCell).forEach(data -> {
-        OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshot(data);
-        if (osmEntitySnapshots.size() > 0
-            && thisSnapshot.getEntity().getId() != osmEntitySnapshots
-            .get(osmEntitySnapshots.size() - 1).getEntity().getId()) {
-          // immediately fold the results
-          for (R r : mapper.apply(osmEntitySnapshots)) {
-            accInternal.set(accumulator.apply(accInternal.get(), r));
-          }
-          osmEntitySnapshots.clear();
-        }
-        osmEntitySnapshots.add(thisSnapshot);
-      });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (osmEntitySnapshots.size() > 0) {
-        for (R r : mapper.apply(osmEntitySnapshots)) {
-          accInternal.set(accumulator.apply(accInternal.get(), r));
-        }
-      }
-      return accInternal.get();
-    }, identitySupplier, combiner);
+      SerializableFunction<List<OSMEntitySnapshot>,Iterable<R>> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return this.reduce(
+        Kernels.getOSMEntitySnapshotGroupingCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
-  // === streams ===
+  // === stream operations ===
 
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
       SerializableFunction<OSMContribution, X> mapper) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByContribution(oshEntityCell)
-          .map(OSMContribution::new)
-          .map(mapper);
-    });
+    return this.stream(Kernels.getOSMContributionCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMContributionGroupedById(
       SerializableFunction<List<OSMContribution>, Iterable<X>> mapper) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      List<OSMContribution> contributions = new ArrayList<>();
-      List<X> result = new LinkedList<>();
-      cellIterator.iterateByContribution(oshEntityCell)
-          .map(OSMContribution::new)
-          .forEach(contribution -> {
-            if (contributions.size() > 0 && contribution.getEntityAfter().getId()
-                != contributions.get(contributions.size() - 1).getEntityAfter().getId()) {
-              // immediately flatten the results
-              Iterables.addAll(result, mapper.apply(contributions));
-              contributions.clear();
-            }
-            contributions.add(contribution);
-          });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (contributions.size() > 0) {
-        Iterables.addAll(result, mapper.apply(contributions));
-      }
-      return result.stream();
-    });
+    return this.stream(Kernels.getOSMContributionGroupingCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
       SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByTimestamps(oshEntityCell)
-          .map(OSMEntitySnapshot::new)
-          .map(mapper);
-    });
+    return this.stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> mapper) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      List<OSMEntitySnapshot> snapshots = new ArrayList<>();
-      List<X> result = new LinkedList<>();
-      cellIterator.iterateByTimestamps(oshEntityCell)
-          .map(OSMEntitySnapshot::new)
-          .forEach(contribution -> {
-            if (snapshots.size() > 0 && contribution.getEntity().getId()
-                != snapshots.get(snapshots.size() - 1).getEntity().getId()) {
-              // immediately flatten the results
-              Iterables.addAll(result, mapper.apply(snapshots));
-              snapshots.clear();
-            }
-            snapshots.add(contribution);
-          });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (snapshots.size() > 0) {
-        Iterables.addAll(result, mapper.apply(snapshots));
-      }
-      return result.stream();
-    });
+    return this.stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper));
   }
 
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
@@ -3,6 +3,7 @@ package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
@@ -63,7 +64,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
   }
 
   private Stream<X> stream(
-      CellProcessor<Stream<X>> processor
+      CellProcessor<Collection<X>> processor
   ) throws ParseException, SQLException, IOException {
     CellIterator cellIterator = new CellIterator(
         this._tstamps.get(),
@@ -76,7 +77,8 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
 
     return cellIdRanges.parallelStream()
         .flatMap(this::getOshCellsStream)
-        .flatMap(oshCell -> processor.apply(oshCell, cellIterator));
+        .map(oshCell -> processor.apply(oshCell, cellIterator))
+        .flatMap(Collection::stream);
   }
 
   // === map-reduce operations ===

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
@@ -1,15 +1,10 @@
 package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
 
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import java.io.IOException;
-import java.io.Serializable;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
@@ -18,12 +13,13 @@ import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBinaryOp
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableFunction;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableSupplier;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CellProcessor;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
-import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator;
 import org.heigit.bigspatialdata.oshdb.grid.GridOSHEntity;
 import org.heigit.bigspatialdata.oshdb.util.CellId;
+import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator;
 import org.jetbrains.annotations.NotNull;
 import org.json.simple.parser.ParseException;
 
@@ -45,22 +41,8 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
   }
 
 
-  private interface Callback<S> extends Serializable {
-    void apply (
-        GridOSHEntity oshEntityCell,
-        CellIterator cellIterator,
-        AtomicReference<S> inputOutputReference
-    );
-  }
-  private interface StreamCallback<X> extends Serializable {
-    Stream<X> apply (
-        GridOSHEntity oshEntityCell,
-        CellIterator cellIterator
-    );
-  }
-
-  private <S> S run(
-      Callback<S> callback,
+  private <S> S reduce(
+      CellProcessor<S> cellProcessor,
       SerializableSupplier<S> identitySupplier,
       SerializableBinaryOperator<S> combiner
   ) throws ParseException, SQLException, IOException, ClassNotFoundException {
@@ -70,20 +52,23 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
         this._getTagInterpreter(), this._getPreFilter(), this._getFilter(), false
     );
 
-    AtomicReference<S> result = new AtomicReference<>(identitySupplier.get());
+    S result = identitySupplier.get();
     for (Pair<CellId, CellId> cellIdRange : this._getCellIdRanges()) {
       ResultSet oshCellsRawData = getOshCellsRawDataFromDb(cellIdRange);
 
       while (oshCellsRawData.next()) {
         GridOSHEntity oshCellRawData = readOshCellRawData(oshCellsRawData);
-        callback.apply(oshCellRawData, cellIterator, result);
+        result = combiner.apply(
+            result,
+            cellProcessor.apply(oshCellRawData, cellIterator)
+        );
       }
     }
-    return combiner.apply(identitySupplier.get(), result.get());
+    return result;
   }
 
-  private Stream<X> run(
-      StreamCallback<X> callback
+  private Stream<X> stream(
+      CellProcessor<Stream<X>> cellProcessor
   ) throws ParseException, SQLException, IOException, ClassNotFoundException {
     CellIterator cellIterator = new CellIterator(
         this._tstamps.get(),
@@ -93,174 +78,92 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
 
     return Streams.stream(this._getCellIdRanges())
         .flatMap(this::getOshCellsStream)
-        .flatMap(oshCellRawData -> callback.apply(oshCellRawData, cellIterator));
+        .flatMap(oshCellRawData -> cellProcessor.apply(oshCellRawData, cellIterator));
   }
 
+  // === map-reduce operations ===
+
   @Override
-  protected <R, S> S mapReduceCellsOSMContribution(SerializableFunction<OSMContribution, R> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return this.run((oshEntityCell, cellIterator, accInternal) -> {
-      // iterate over the history of all OSM objects in the current cell
-      cellIterator.iterateByContribution(oshEntityCell)
-          .forEach(contribution -> {
-            OSMContribution osmContribution = new OSMContribution(contribution);
-            accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(osmContribution)));
-          });
-    }, identitySupplier, combiner);
+  protected <R, S> S mapReduceCellsOSMContribution(
+      SerializableFunction<OSMContribution, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return this.reduce(
+        Kernels.getOSMContributionCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
   @Override
   protected <R, S> S flatMapReduceCellsOSMContributionGroupedById(
       SerializableFunction<List<OSMContribution>, Iterable<R>> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return this.run((oshEntityCell, cellIterator, accInternal) -> {
-      // iterate over the history of all OSM objects in the current cell
-      List<OSMContribution> contributions = new ArrayList<>();
-      cellIterator.iterateByContribution(oshEntityCell)
-          .forEach(contribution -> {
-            OSMContribution thisContribution = new OSMContribution(contribution);
-            if (contributions.size() > 0
-                && thisContribution.getEntityAfter().getId() != contributions
-                .get(contributions.size() - 1).getEntityAfter().getId()) {
-              // immediately fold the results
-              for (R r : mapper.apply(contributions)) {
-                accInternal.set(accumulator.apply(accInternal.get(), r));
-              }
-              contributions.clear();
-            }
-            contributions.add(thisContribution);
-          });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (contributions.size() > 0) {
-        for (R r : mapper.apply(contributions)) {
-          accInternal.set(accumulator.apply(accInternal.get(), r));
-        }
-      }
-    }, identitySupplier, combiner);
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return this.reduce(
+        Kernels.getOSMContributionGroupingCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
-
 
   @Override
   protected <R, S> S mapReduceCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, R> mapper, SerializableSupplier<S> identitySupplier,
-      SerializableBiFunction<S, R, S> accumulator, SerializableBinaryOperator<S> combiner)
-      throws Exception {
-    return this.run((oshEntityCell, cellIterator, accInternal) -> {
-      // iterate over the history of all OSM objects in the current cell
-      cellIterator.iterateByTimestamps(oshEntityCell).forEach(data -> {
-        OSMEntitySnapshot snapshot = new OSMEntitySnapshot(data);
-        // immediately fold the result
-        accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(snapshot)));
-      });
-    }, identitySupplier, combiner);
+      SerializableFunction<OSMEntitySnapshot, R> mapper,
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return this.reduce(
+        Kernels.getOSMEntitySnapshotCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
   @Override
   protected <R, S> S flatMapReduceCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<R>> mapper,
-      SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
-      SerializableBinaryOperator<S> combiner) throws Exception {
-    return this.run((oshEntityCell, cellIterator, accInternal) -> {
-        // iterate over the history of all OSM objects in the current cell
-        List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
-        cellIterator.iterateByTimestamps(oshEntityCell).forEach(data -> {
-          OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshot(data);
-          if (osmEntitySnapshots.size() > 0
-              && thisSnapshot.getEntity().getId() != osmEntitySnapshots
-              .get(osmEntitySnapshots.size() - 1).getEntity().getId()) {
-            // immediately fold the results
-            for (R r : mapper.apply(osmEntitySnapshots)) {
-              accInternal.set(accumulator.apply(accInternal.get(), r));
-            }
-            osmEntitySnapshots.clear();
-          }
-          osmEntitySnapshots.add(thisSnapshot);
-        });
-        // apply mapper and fold results one more time for last entity in current cell
-        if (osmEntitySnapshots.size() > 0) {
-          for (R r : mapper.apply(osmEntitySnapshots)) {
-            accInternal.set(accumulator.apply(accInternal.get(), r));
-          }
-        }
-    }, identitySupplier, combiner);
+      SerializableSupplier<S> identitySupplier,
+      SerializableBiFunction<S, R, S> accumulator,
+      SerializableBinaryOperator<S> combiner
+  ) throws Exception {
+    return this.reduce(
+        Kernels.getOSMEntitySnapshotGroupingCellReducer(mapper, identitySupplier, accumulator),
+        identitySupplier,
+        combiner
+    );
   }
 
-  // === streams ===
+  // === stream operations ===
 
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
       SerializableFunction<OSMContribution, X> mapper) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByContribution(oshEntityCell)
-          .map(OSMContribution::new)
-          .map(mapper);
-    });
+    return this.stream(Kernels.getOSMContributionCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMContributionGroupedById(
-      SerializableFunction<List<OSMContribution>, Iterable<X>> mapper) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      List<OSMContribution> contributions = new ArrayList<>();
-      List<X> result = new LinkedList<>();
-      cellIterator.iterateByContribution(oshEntityCell)
-          .map(OSMContribution::new)
-          .forEach(contribution -> {
-            if (contributions.size() > 0 && contribution.getEntityAfter().getId()
-                != contributions.get(contributions.size() - 1).getEntityAfter().getId()) {
-              // immediately flatten the results
-              Iterables.addAll(result, mapper.apply(contributions));
-              contributions.clear();
-            }
-            contributions.add(contribution);
-          });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (contributions.size() > 0) {
-        Iterables.addAll(result, mapper.apply(contributions));
-      }
-      return result.stream();
-    });
+      SerializableFunction<List<OSMContribution>, Iterable<X>> mapper
+  ) throws Exception {
+    return this.stream(Kernels.getOSMContributionGroupingCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
       SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByTimestamps(oshEntityCell)
-          .map(OSMEntitySnapshot::new)
-          .map(mapper);
-    });
+    return this.stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> mapper) throws Exception {
-    return this.run((oshEntityCell, cellIterator) -> {
-      // iterate over the history of all OSM objects in the current cell
-      List<OSMEntitySnapshot> snapshots = new ArrayList<>();
-      List<X> result = new LinkedList<>();
-      cellIterator.iterateByTimestamps(oshEntityCell)
-          .map(OSMEntitySnapshot::new)
-          .forEach(contribution -> {
-            if (snapshots.size() > 0 && contribution.getEntity().getId()
-                != snapshots.get(snapshots.size() - 1).getEntity().getId()) {
-              // immediately flatten the results
-              Iterables.addAll(result, mapper.apply(snapshots));
-              snapshots.clear();
-            }
-            snapshots.add(contribution);
-          });
-      // apply mapper and fold results one more time for last entity in current cell
-      if (snapshots.size() > 0) {
-        Iterables.addAll(result, mapper.apply(snapshots));
-      }
-      return result.stream();
-    });
+    return this.stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper));
   }
 
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
@@ -68,7 +69,7 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
   }
 
   private Stream<X> stream(
-      CellProcessor<Stream<X>> cellProcessor
+      CellProcessor<Collection<X>> cellProcessor
   ) throws ParseException, SQLException, IOException, ClassNotFoundException {
     CellIterator cellIterator = new CellIterator(
         this._tstamps.get(),
@@ -78,7 +79,8 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
 
     return Streams.stream(this._getCellIdRanges())
         .flatMap(this::getOshCellsStream)
-        .flatMap(oshCellRawData -> cellProcessor.apply(oshCellRawData, cellIterator));
+        .map(oshCellRawData -> cellProcessor.apply(oshCellRawData, cellIterator))
+        .flatMap(Collection::stream);
   }
 
   // === map-reduce operations ===

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
@@ -5,6 +5,7 @@
  */
 package org.heigit.bigspatialdata.oshdb.api.tests;
 
+import java.util.stream.Collectors;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBJdbc;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
@@ -90,6 +91,56 @@ abstract class TestMapReduce {
         .map(snapshot -> snapshot.getEntity().getUserId())
         .filter(uid -> uid > 0)
         .uniq();
+
+    assertEquals(3, result.size());
+  }
+
+  @Test
+  public void testOSMContributionViewStream() throws Exception {
+    // simple query
+    Set<Integer> result = createMapReducerOSMContribution()
+        .timestamps(timestamps72)
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .map(OSMContribution::getContributorUserId)
+        .stream()
+        .collect(Collectors.toSet());
+
+    /* should be 5: first version doesn't have the highway tag, remaining 7 versions have 5 different contributor user ids*/
+    assertEquals(5, result.size());
+
+    // "flatMap"
+    result = createMapReducerOSMContribution()
+        .timestamps(timestamps72)
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .map(OSMContribution::getContributorUserId)
+        .filter(uid -> uid > 0)
+        .stream()
+        .collect(Collectors.toSet());
+
+    /* should be 5: first version doesn't have the highway tag, remaining 7 versions have 5 different contributor user ids*/
+    assertEquals(5, result.size());
+  }
+
+  @Test
+  public void testOSMEntitySnapshotViewStream() throws Exception {
+    // simple stream query
+    Set<Integer> result = createMapReducerOSMEntitySnapshot()
+        .timestamps(timestamps6)
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .map(snapshot -> snapshot.getEntity().getUserId())
+        .stream()
+        .collect(Collectors.toSet());
+
+    assertEquals(3, result.size());
+
+    // "flatMap"
+    result = createMapReducerOSMEntitySnapshot()
+        .timestamps(timestamps6)
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .map(snapshot -> snapshot.getEntity().getUserId())
+        .filter(uid -> uid > 0)
+        .stream()
+        .collect(Collectors.toSet());
 
     assertEquals(3, result.size());
   }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_IgniteMissingCache.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_IgniteMissingCache.java
@@ -21,4 +21,16 @@ public class TestMapReduceOSHDB_IgniteMissingCache extends TestMapReduceOSHDB_Ig
   public void testOSMEntitySnapshotView() throws Exception {
     super.testOSMEntitySnapshotView();
   }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testOSMContributionViewStream() throws Exception {
+    super.testOSMEntitySnapshotView();
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testOSMEntitySnapshotViewStream() throws Exception {
+    super.testOSMEntitySnapshotView();
+  }
 }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_JdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_JdbcMissingTables.java
@@ -22,4 +22,16 @@ public class TestMapReduceOSHDB_JdbcMissingTables extends TestMapReduce {
   public void testOSMEntitySnapshotView() throws Exception {
     super.testOSMEntitySnapshotView();
   }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testOSMContributionViewStream() throws Exception {
+    super.testOSMEntitySnapshotView();
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testOSMEntitySnapshotViewStream() throws Exception {
+    super.testOSMEntitySnapshotView();
+  }
 }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestStream.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestStream.java
@@ -59,7 +59,6 @@ public class TestStream {
     assertEquals(42, result.entrySet().size());
   }
 
-  /*
   @Test
   public void testForEachAggregatedByTimestamp() throws Exception {
     ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
@@ -67,12 +66,9 @@ public class TestStream {
         .timestamps(timestamps72)
         .aggregateByTimestamp()
         .stream()
-        .forEach((ts, contributions) -> {
-          contributions.forEach(contribution -> {
-            result.put(contribution.getEntityAfter().getId(), true);
-          });
-        });
+        .forEach(entry ->
+          result.put(entry.getValue().getEntityAfter().getId(), true)
+        );
     assertEquals(42, result.entrySet().size());
   }
-  */
 }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestStream.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestStream.java
@@ -1,0 +1,78 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.heigit.bigspatialdata.oshdb.api.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.ConcurrentHashMap;
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMContributionView;
+import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
+import org.heigit.bigspatialdata.oshdb.osm.OSMType;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
+import org.heigit.bigspatialdata.oshdb.util.time.OSHDBTimestamps;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class TestStream {
+  private final OSHDBDatabase oshdb;
+
+  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8.651133,49.387611,8.6561,49.390513);
+  private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01", OSHDBTimestamps.Interval.MONTHLY);
+
+  public TestStream() throws Exception {
+    oshdb = new OSHDBH2("./src/test/resources/test-data").multithreading(false);
+  }
+
+  private MapReducer<OSMContribution> createMapReducerOSMContribution() throws Exception {
+    return OSMContributionView.on(oshdb).osmType(OSMType.WAY).osmTag("building", "yes").areaOfInterest(bbox);
+  }
+
+  @Test
+  public void testForEach() throws Exception {
+    ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
+    this.createMapReducerOSMContribution()
+        .timestamps(timestamps72)
+        .stream()
+        .forEach(contribution -> {
+          result.put(contribution.getEntityAfter().getId(), true);
+        });
+    assertEquals(42, result.entrySet().size());
+  }
+
+  @Test
+  public void testForEachGroupedById() throws Exception {
+    ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
+    this.createMapReducerOSMContribution()
+        .timestamps(timestamps72)
+        .groupByEntity()
+        .map(contributions -> contributions.get(0).getEntityAfter().getId())
+        .stream()
+        .forEach(id -> result.put(id, true));
+    assertEquals(42, result.entrySet().size());
+  }
+
+  /*
+  @Test
+  public void testForEachAggregatedByTimestamp() throws Exception {
+    ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
+    this.createMapReducerOSMContribution()
+        .timestamps(timestamps72)
+        .aggregateByTimestamp()
+        .stream()
+        .forEach((ts, contributions) -> {
+          contributions.forEach(contribution -> {
+            result.put(contribution.getEntityAfter().getId(), true);
+          });
+        });
+    assertEquals(42, result.entrySet().size());
+  }
+  */
+}


### PR DESCRIPTION
Implements the idea from #17 

Works in JDBC (singlethread/multithread) backends as well as the "AffinityCall" ignite backend (other backends fall back to `.collect().stream()`. For the other ignite backends it is not very straight-forward to implement. Maybe it can be implemented at some later stage, or the oshdb can (by default) fall back to another backend if it finds that the current one doesn't implement streaming?