### PR TITLE
remove unused statement

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMContribution.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMContribution.java
@@ -186,7 +186,6 @@ public class OSMContribution implements OSHDBMapReducible {
     // todo: optimizable if done directly in CellIterator??
     OSMEntity entity = this.getEntityAfter();
     OSHDBTimestamp contributionTimestamp = this.getTimestamp();
-    EnumSet<ContributionType> contributionTypes = this.getContributionTypes();
     // if the entity itself was modified at this exact timestamp, or we know from the contribution type that the entity
     // must also have been modified, we can just return the uid directly
     if (contributionTimestamp.equals(entity.getTimestamp()) ||


### PR DESCRIPTION
this should make "number of contributors" (and similar ones) queries (which don't need the exact object geometries) a bit faster, e.g. `OSMContributionView.….map(OSMContribution::getContributorUserId).countUniq()`.