### PR TITLE
Various quality-of-life improvements for oshdb database backends

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBDatabase.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBDatabase.java
@@ -4,7 +4,7 @@ import org.heigit.bigspatialdata.oshdb.OSHDB;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 
-public abstract class OSHDBDatabase extends OSHDB {
+public abstract class OSHDBDatabase extends OSHDB implements AutoCloseable {
     protected String prefix = "";
 
     /**

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBDatabase.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBDatabase.java
@@ -5,7 +5,7 @@ import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 
 public abstract class OSHDBDatabase extends OSHDB implements AutoCloseable {
-    protected String prefix = "";
+    private String prefix = "";
 
     /**
      * Factory function that creates a mapReducer object of the appropriate data type class for this oshdb backend implemenation

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBH2.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBH2.java
@@ -24,9 +24,14 @@ public class OSHDBH2 extends OSHDBJdbc {
     super(conn);
   }
 
+  @Override
+  public OSHDBH2 prefix(String prefix) {
+    return (OSHDBH2) super.prefix(prefix);
+  }
+
+  @Override
   public OSHDBH2 multithreading(boolean useMultithreading) {
-    super.multithreading(useMultithreading);
-    return this;
+    return (OSHDBH2) super.multithreading(useMultithreading);
   }
 
   /**

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
@@ -31,7 +31,7 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable, Seriali
 
   public OSHDBIgnite(Ignite ignite) {
     this._ignite = ignite;
-    this._ignite.active(true);
+    this._ignite.cluster().active(true);
   }
 
   public OSHDBIgnite(String igniteConfigFilePath) {
@@ -42,7 +42,7 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable, Seriali
     Ignition.setClientMode(true);
 
     this._ignite = Ignition.start(igniteConfig.toString());
-    this._ignite.active(true);
+    this._ignite.cluster().active(true);
   }
 
   @Override

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
@@ -46,6 +46,11 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable, Seriali
   }
 
   @Override
+  public OSHDBIgnite prefix(String prefix) {
+    return (OSHDBIgnite) super.prefix(prefix);
+  }
+
+  @Override
   public <X extends OSHDBMapReducible> MapReducer<X> createMapReducer(Class<X> forClass) {
     MapReducer<X> mapReducer;
     switch (this.computeMode()) {

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
@@ -3,10 +3,18 @@ package org.heigit.bigspatialdata.oshdb.api.db;
 import java.io.File;
 import java.io.Serializable;
 import java.sql.SQLException;
+import java.util.Collection;
+import java.util.Optional;
 import java.util.OptionalLong;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.Ignition;
+import org.heigit.bigspatialdata.oshdb.TableNames;
+import org.heigit.bigspatialdata.oshdb.osm.OSMType;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTableNotFoundException;
 import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTimeoutException;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.MapReducerIgniteLocalPeek;
@@ -53,6 +61,14 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable, Seriali
   @Override
   public <X extends OSHDBMapReducible> MapReducer<X> createMapReducer(Class<X> forClass) {
     MapReducer<X> mapReducer;
+    Collection<String> allCaches = this.getIgnite().cacheNames();
+    Collection<String> expectedCaches = Stream.of(OSMType.values())
+        .map(TableNames::forOSMType).filter(Optional::isPresent).map(Optional::get)
+        .map(t -> t.toString(this.prefix()))
+        .collect(Collectors.toList());
+    if (!allCaches.containsAll(expectedCaches)) {
+      throw new OSHDBTableNotFoundException(StringUtils.join(expectedCaches, ", "));
+    }
     switch (this.computeMode()) {
       case LocalPeek:
         mapReducer = new MapReducerIgniteLocalPeek<X>(this, forClass);

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBJdbc.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBJdbc.java
@@ -6,11 +6,20 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
 import org.heigit.bigspatialdata.oshdb.TableNames;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.MapReducerJdbcMultithread;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.MapReducerJdbcSinglethread;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
+import org.heigit.bigspatialdata.oshdb.osm.OSMType;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTableNotFoundException;
 
 public class OSHDBJdbc extends OSHDBDatabase implements AutoCloseable {
 
@@ -37,6 +46,22 @@ public class OSHDBJdbc extends OSHDBDatabase implements AutoCloseable {
 
   @Override
   public <X extends OSHDBMapReducible> MapReducer<X> createMapReducer(Class<X> forClass) {
+    try {
+      Collection<String> expectedTables = Stream.of(OSMType.values())
+          .map(TableNames::forOSMType).filter(Optional::isPresent).map(Optional::get)
+          .map(t -> t.toString(this.prefix()).toLowerCase())
+          .collect(Collectors.toList());
+      List<String> allTables = new LinkedList<>();
+      ResultSet rs = this.getConnection().getMetaData().getTables(null, null, "%", new String[]{"TABLE"});
+      while (rs.next()) {
+        allTables.add(rs.getString("TABLE_NAME").toLowerCase());
+      }
+      if (!allTables.containsAll(expectedTables)) {
+        throw new OSHDBTableNotFoundException(StringUtils.join(expectedTables, ", "));
+      }
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
     MapReducer<X> mapReducer;
     if (this.useMultithreading)
       mapReducer = new MapReducerJdbcMultithread<X>(this, forClass);

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBJdbc.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBJdbc.java
@@ -31,6 +31,11 @@ public class OSHDBJdbc extends OSHDBDatabase implements AutoCloseable {
   }
 
   @Override
+  public OSHDBJdbc prefix(String prefix) {
+    return (OSHDBJdbc) super.prefix(prefix);
+  }
+
+  @Override
   public <X extends OSHDBMapReducible> MapReducer<X> createMapReducer(Class<X> forClass) {
     MapReducer<X> mapReducer;
     if (this.useMultithreading)

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_Ignite.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_Ignite.java
@@ -34,10 +34,8 @@ abstract class TestMapReduceOSHDB_Ignite extends TestMapReduce {
     this.keytables = oshdb_h2;
 
     Ignite ignite = ((OSHDBIgnite) this.oshdb).getIgnite();
-    ignite.active(true);
+    ignite.cluster().active(true);
 
-    // todo: also ways+relations? (at the moment we don't use them in the actual TestMapReduce
-    // tests)
     CacheConfiguration<Long, GridOSHNodes> cacheCfg =
         new CacheConfiguration<>(TableNames.T_NODES.toString(prefix));
     cacheCfg.setStatisticsEnabled(true);
@@ -45,6 +43,9 @@ abstract class TestMapReduceOSHDB_Ignite extends TestMapReduce {
     cacheCfg.setCacheMode(CacheMode.PARTITIONED);
     IgniteCache<Long, GridOSHNodes> cache = ignite.getOrCreateCache(cacheCfg);
     cache.clear();
+    // dummy caches for ways+relations (at the moment we don't use them in the actual TestMapReduce)
+    ignite.getOrCreateCache(new CacheConfiguration<>(TableNames.T_WAYS.toString(prefix)));
+    ignite.getOrCreateCache(new CacheConfiguration<>(TableNames.T_RELATIONS.toString(prefix)));
 
     // load test data into ignite cache
     try (IgniteDataStreamer<Long, GridOSHNodes> streamer = ignite.dataStreamer(cache.getName())) {

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_IgniteMissingCache.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_IgniteMissingCache.java
@@ -1,0 +1,24 @@
+package org.heigit.bigspatialdata.oshdb.api.tests;
+
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTableNotFoundException;
+import org.junit.Test;
+
+public class TestMapReduceOSHDB_IgniteMissingCache extends TestMapReduceOSHDB_Ignite {
+  public TestMapReduceOSHDB_IgniteMissingCache() throws Exception {
+    super(new OSHDBIgnite(ignite));
+    this.oshdb.prefix("<test caches not present>");
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testOSMContributionView() throws Exception {
+    super.testOSMContributionView();
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testOSMEntitySnapshotView() throws Exception {
+    super.testOSMEntitySnapshotView();
+  }
+}

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_JdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_JdbcMissingTables.java
@@ -1,0 +1,25 @@
+package org.heigit.bigspatialdata.oshdb.api.tests;
+
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTableNotFoundException;
+import org.junit.Test;
+
+public class TestMapReduceOSHDB_JdbcMissingTables extends TestMapReduce {
+  public TestMapReduceOSHDB_JdbcMissingTables() throws Exception {
+    super((new OSHDBH2("./src/test/resources/test-data"))
+        .prefix("<test tables not present>")
+    );
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testOSMContributionView() throws Exception {
+    super.testOSMContributionView();
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testOSMEntitySnapshotView() throws Exception {
+    super.testOSMEntitySnapshotView();
+  }
+}

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/exceptions/OSHDBKeytablesNotFoundException.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/exceptions/OSHDBKeytablesNotFoundException.java
@@ -1,8 +1,8 @@
 package org.heigit.bigspatialdata.oshdb.util.exceptions;
 
 public class OSHDBKeytablesNotFoundException extends Exception {
-    public OSHDBKeytablesNotFoundException() {
-        super("Keytables database not found, or db doesn't contain the required \"keytables\" tables. "
-            + "Make sure you have specified the right keytables database, for example by calling `keytables()` when using the OSHDB-API.");
-    }
+  public OSHDBKeytablesNotFoundException() {
+    super("Keytables database not found, or db doesn't contain the required \"keytables\" tables. "
+        + "Make sure you have specified the right keytables database, for example by calling `keytables()` when using the OSHDB-API.");
+  }
 }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/exceptions/OSHDBTableNotFoundException.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/exceptions/OSHDBTableNotFoundException.java
@@ -1,0 +1,7 @@
+package org.heigit.bigspatialdata.oshdb.util.exceptions;
+
+public class OSHDBTableNotFoundException extends RuntimeException {
+  public OSHDBTableNotFoundException(String missingTable) {
+    super("Database doesn't contain the required table(s)/cache(s): " + missingTable + ".");
+  }
+}


### PR DESCRIPTION
* make all oshdb backends auto-closable
* override some "setting" method to return less generic database classes, so that the methods can be chained more easily
* checks if required tables/caches are present before executing a query (and throws a specific exception early, if that's not the case) #24 