### PR TITLE
shuffle cells before parallel streaming

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -238,6 +238,7 @@ class IgniteLocalPeekHelper {
               .forEach(key -> localKeys.add(new ImmutablePair<>(cache, key)));
         });
       });
+      Collections.shuffle(localKeys);
       return localKeys;
     }
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -209,7 +209,6 @@ class IgniteScanQueryHelper {
       // Getting a list of the partitions owned by this node.
       List<Integer> myPartitions = nodesToPart.get(node.cluster().localNode().id());
       Collections.shuffle(myPartitions);
-      // ^ todo: check why this gives 2x speedup (regarding "uptime") on cluster!!??
       // run processing in parallel
       return myPartitions.parallelStream().map(part -> {
         // noinspection unchecked


### PR DESCRIPTION
Hack/Workaround to avoid having all low zoom level cells clumped up in a single thread, which unnecessarily delays the processing.

I believe there should be better solution to this – ideally, one would like to start processing with the lower zoom cells, but have them evenly distributed across all threads in the pool (e.g. in an interleaved way: cell 1 -> thread 1, cell 2 -> thread 2, …, cell n -> thread n, cell n+1 -> thread 1, etc.), but I'm not sure if that's easy to implement using the normal java streams.