### PR TITLE
fix bug where flatMap queries don't work properly on ignite

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -72,7 +72,13 @@ public class OSHDBGeometryBuilder {
               .map(nd -> new Coordinate(nd.getLongitude(), nd.getLatitude()))
               .toArray(Coordinate[]::new);
       if (areaDecider.isArea(entity)) {
-        return geometryFactory.createPolygon(coords);
+        try {
+          return geometryFactory.createPolygon(coords);
+        } catch (IllegalArgumentException e) {
+          LOG.warn("way/{} should be closed - falling back to linestring geometry", way.getId());
+          System.out.println("way/"+way.getId()+" should be closed - falling back to linestring geometry");
+          return geometryFactory.createLineString(coords);
+        }
       } else if (coords.length >= 2) {
         return geometryFactory.createLineString(coords);
       } else if (coords.length == 1) {


### PR DESCRIPTION
The bug caused all queries that use `flatMap` to not work on all ignite backends (because after serialization-deserialization, the lambda objects can't be [compared](https://github.com/GIScience/oshdb/blob/c326e644069db1081d8e7eda1b31b8a336109f4e/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java#L1463) directly anymore), causing the following exception:

    java.lang.ClassCastException: java.util.LinkedList cannot be cast to org.apache.commons.lang3.tuple.Pair

It is fixed by replacing the implementation which used to have separate mappers+flatmappers lists with a more clean implementation using a single list of `MapFunction`s that have a built-in flag indicating whether they are a normal map or a flatMap function.