### PR TITLE
ignite backend: add onClose callback

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -417,16 +417,21 @@ class IgniteLocalPeekHelper {
     ComputeTaskFuture<S> result = compute.executeAsync(
         new CancelableBroadcastTask<Object, S>(computeJob, identitySupplier, combiner), null);
 
+    S ret;
     if (!oshdb.timeoutInMilliseconds().isPresent()) {
-      return result.get();
+      ret = result.get();
     } else {
       try {
-        return result.get(oshdb.timeoutInMilliseconds().getAsLong());
+        ret = result.get(oshdb.timeoutInMilliseconds().getAsLong());
       } catch (IgniteFutureTimeoutException e) {
         result.cancel();
         throw new OSHDBTimeoutException();
       }
     }
+    if (oshdb.onClose().isPresent()) {
+      compute.broadcast(oshdb.onClose().get());
+    }
+    return ret;
   }
 
   static <R, S, P extends Geometry & Polygonal> S _mapReduceCellsOSMContributionOnIgniteCache(

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -393,6 +393,9 @@ class IgniteScanQueryHelper {
     IgniteCompute compute = ignite.compute(ignite.cluster().forNodeIds(nodesToPart.keySet()));
     computeJob.setNodesToPart(nodesToPart);
     Collection<S> nodeResults = compute.broadcast(computeJob);
+    if (oshdb.onClose().isPresent()) {
+      compute.broadcast(oshdb.onClose().get());
+    }
     return nodeResults.stream().reduce(identitySupplier.get(), combiner);
   }
 

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/LazyEvaluatedObject.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/LazyEvaluatedObject.java
@@ -35,4 +35,8 @@ public class LazyEvaluatedObject<T> implements Supplier<T> {
     }
     return false;
   }
+
+  public boolean wasEvaluated() {
+    return this.evaluated;
+  }
 }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/tagtranslator/TagTranslator.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/tagtranslator/TagTranslator.java
@@ -299,8 +299,9 @@ public class TagTranslator {
       return this.roleToString.get(role);
     }
     OSMRole roleString;
-    try (PreparedStatement Rolestmt = conn
-        .prepareStatement("select TXT from " + TableNames.E_ROLE.toString() + " WHERE ID = ?;")) {
+    try (PreparedStatement Rolestmt = conn.prepareStatement(
+        "select TXT from " + TableNames.E_ROLE.toString() + " WHERE ID = ?;"
+    )) {
       Rolestmt.setInt(1, role.toInt());
       ResultSet Roles = Rolestmt.executeQuery();
       Roles.next();
@@ -317,5 +318,9 @@ public class TagTranslator {
 
   private int getFakeId(String s) {
     return -Math.abs(s.hashCode());
+  }
+
+  public Connection getConnection() {
+    return conn;
   }
 }


### PR DESCRIPTION
This can be used to close connections to (temporary) databases that were used to store or retrieve intermediate data in a query. This PR also expose a few internal states (e.g. `TagTranslator.getConnection()`, `LazyEvaluatedObject.wasEvaluated()`) to be accessed from external applications.