### PR TITLE
make isArea check more robust

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -72,16 +72,16 @@ public class OSHDBGeometryBuilder {
               .map(nd -> new Coordinate(nd.getLongitude(), nd.getLatitude()))
               .toArray(Coordinate[]::new);
       if (areaDecider.isArea(entity)) {
-        try {
+        if (coords.length >= 4 && coords[0].equals2D(coords[coords.length - 1])) {
           return geometryFactory.createPolygon(coords);
-        } catch (IllegalArgumentException e) {
-          LOG.warn("way/{} should be closed - falling back to linestring geometry", way.getId());
-          System.out.println("way/"+way.getId()+" should be closed - falling back to linestring geometry");
-          return geometryFactory.createLineString(coords);
+        } else {
+          LOG.warn("way/{} doesn't form a linear ring - falling back to linestring", way.getId());
         }
-      } else if (coords.length >= 2) {
+      }
+      if (coords.length >= 2) {
         return geometryFactory.createLineString(coords);
-      } else if (coords.length == 1) {
+      }
+      if (coords.length == 1) {
         LOG.info("way/{} is single-noded - falling back to point geometry", way.getId());
         return geometryFactory.createPoint(coords[0]);
       } else {


### PR DESCRIPTION
Very rarely osm data is not consistent (e.g. after partial data redactions), which can cause some of the affected osm data to produce invalid geometries (e.g. polygons that don't form closed rings) – one example for this is https://www.openstreetmap.org/way/265512886/ during the years 2015 and 2016.

This makes the GeometryBuilder robust enough to detect these cases and fall back to the next steps of the geometry building pipeline.

(also removes one accidentally committed debug sysout)