### PR TITLE
improve performance of FastPolygonOperations constructor

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastInPolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastInPolygon.java
@@ -26,7 +26,7 @@ abstract class FastInPolygon implements Serializable {
     }
   }
 
-  private final int AvgSegmentsPerBand = 10; // something in the order of 10-20 works fine according to the link above
+  private final int AVERAGE_SEGMENTS_PER_BAND = 10; // something in the order of 10-20 works fine according to the link above
 
   private int numBands;
 
@@ -62,7 +62,7 @@ abstract class FastInPolygon implements Serializable {
         }
       }
     }
-    this.numBands = Math.max(1, segments.size() / AvgSegmentsPerBand); // possible optimization: start with this value of numBands, and if the result has over-full bands, increase numBands (e.g. x2) and do it again
+    this.numBands = Math.max(1, segments.size() / AVERAGE_SEGMENTS_PER_BAND); // possible optimization: start with this value of numBands, and if the result has over-full bands, increase numBands (e.g. x2) and do it again
     this.horizBands = new ArrayList<>(numBands);
     for (int i = 0; i < numBands; i++) this.horizBands.add(new LinkedList<>());
     this.vertBands = new ArrayList<>(numBands);

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -6,9 +6,10 @@ import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.geom.Polygonal;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 
 public class FastPolygonOperations implements Serializable {
-  private final int AvgVerticesPerBlock = 40; // todo: finetune this value
+  private final int AVERAGE_VERTICES_PER_BLOCK = 40; // todo: finetune this value
 
   private int numBands;
 
@@ -18,10 +19,10 @@ public class FastPolygonOperations implements Serializable {
   private double envWidth;
   private double envHeight;
 
-
   public <P extends Geometry & Polygonal> FastPolygonOperations(P geom) {
-    numBands = (int)Math.ceil(Math.sqrt(1.0*geom.getNumPoints()/AvgVerticesPerBlock));
-    blocks = new ArrayList<>(numBands*numBands);
+    double optNumBands = Math.sqrt(1.0 * geom.getNumPoints() / AVERAGE_VERTICES_PER_BLOCK);
+    final int bandIterations = (int) Math.ceil(Math.log(optNumBands) / Math.log(2));
+    numBands = (int) Math.pow(2, bandIterations);
 
     env = geom.getEnvelopeInternal();
     envWidth = env.getMaxX() - env.getMinX();
@@ -29,18 +30,76 @@ public class FastPolygonOperations implements Serializable {
 
     GeometryFactory gf = new GeometryFactory();
 
-    for (int x = 0; x < numBands; x++) {
-      for (int y = 0; y < numBands; y++) {
-        Envelope envPart = new Envelope(
-            env.getMinX() + envWidth * x/numBands,
-            env.getMinX() + envWidth * (x+1)/numBands,
-            env.getMinY() + envHeight * y/numBands,
-            env.getMinY() + envHeight * (y+1)/numBands
-        );
-        blocks.add(// index: y + x*numBands,
-            geom.intersection(gf.toGeometry(envPart))
-        );
-      }
+    Geometry[] result = new Geometry[numBands*numBands];
+    traverseQuads(bandIterations, 0,0, env, geom, gf, result);
+
+    blocks = new ArrayList<>(Arrays.asList(result));
+  }
+
+  private void traverseQuads(
+      int level,
+      int x, int y,
+      Envelope quadEnv,
+      Geometry theGeom,
+      GeometryFactory gf,
+      Geometry[] resultBuffer
+  ) {
+    if (level == 0) {
+      int index = y + x * numBands;
+      resultBuffer[index] = theGeom;
+    } else {
+      Envelope bottomLeftPart = new Envelope(
+          quadEnv.getMinX(),
+          (quadEnv.getMinX() + quadEnv.getMaxX()) / 2,
+          quadEnv.getMinY(),
+          (quadEnv.getMinY() + quadEnv.getMaxY()) / 2
+      );
+      Envelope topLeftPart = new Envelope(
+          quadEnv.getMinX(),
+          (quadEnv.getMinX() + quadEnv.getMaxX()) / 2,
+          (quadEnv.getMinY() + quadEnv.getMaxY()) / 2,
+          quadEnv.getMaxY()
+      );
+      Envelope bottomRightPart = new Envelope(
+          (quadEnv.getMinX() + quadEnv.getMaxX()) / 2,
+          quadEnv.getMaxX(),
+          quadEnv.getMinY(),
+          (quadEnv.getMinY() + quadEnv.getMaxY()) / 2
+      );
+      Envelope topRightPart = new Envelope(
+          (quadEnv.getMinX() + quadEnv.getMaxX()) / 2,
+          quadEnv.getMaxX(),
+          (quadEnv.getMinY() + quadEnv.getMaxY()) / 2,
+          quadEnv.getMaxY()
+      );
+      traverseQuads(level - 1,
+          x * 2, y * 2,
+          bottomLeftPart,
+          theGeom.intersection(gf.toGeometry(bottomLeftPart)),
+          gf,
+          resultBuffer
+      );
+      traverseQuads(level - 1,
+          x * 2, y * 2 + 1,
+          topLeftPart,
+          theGeom.intersection(gf.toGeometry(topLeftPart)),
+          gf,
+          resultBuffer
+      );
+      traverseQuads(level - 1,
+          x * 2 + 1, y * 2,
+          bottomRightPart,
+          theGeom.intersection(gf.toGeometry(bottomRightPart)),
+          gf,
+          resultBuffer
+      );
+      traverseQuads(level - 1,
+          x * 2 + 1, y * 2 + 1,
+          topRightPart,
+          theGeom.intersection(gf.toGeometry(topRightPart)),
+          gf,
+          resultBuffer
+      );
     }
   }
 
@@ -58,13 +117,15 @@ public class FastPolygonOperations implements Serializable {
     for (int x = minBandX; x <= maxBandX; x++) {
       for (int y = minBandY; y <= maxBandY; y++) {
         Geometry block = blocks.get(y + x*numBands);
-        if (intersector == null)
+        if (intersector == null) {
           intersector = block;
-        else
+        } else {
           intersector = intersector.union(block);
+        }
       }
     }
 
+    assert intersector != null;
     return other.intersection(intersector);
   }
 

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -20,7 +20,7 @@ public class FastPolygonOperations implements Serializable {
   private double envHeight;
 
   public <P extends Geometry & Polygonal> FastPolygonOperations(P geom) {
-    double optNumBands = Math.sqrt(1.0 * geom.getNumPoints() / AVERAGE_VERTICES_PER_BLOCK);
+    double optNumBands = Math.max(1.0, Math.sqrt(1.0 * geom.getNumPoints() / AVERAGE_VERTICES_PER_BLOCK));
     final int bandIterations = (int) Math.ceil(Math.log(optNumBands) / Math.log(2));
     numBands = (int) Math.pow(2, bandIterations);
 


### PR DESCRIPTION
Replaces the straight-forward `O(n²)` polygon slicing implementation with a quad-recursive `O(n log(n))` algorithm (assuming that JTS' intersection method takes O(n) time to compute the intersection of a n-vertex polygon with another 4 vertex polygon). A minor additional change is that now, the number of bands is rounded up to the next power of two (mainly to make the implementation easier).