### PR TITLE
quantiles

### DIFF
--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -90,6 +90,12 @@
       <artifactId>annotations</artifactId>
       <version>${jetbrainsannotations.version}</version>
     </dependency>
+
+    <dependency>
+      <groupId>com.tdunning</groupId>
+      <artifactId>t-digest</artifactId>
+      <version>3.2</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -482,8 +482,8 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    * @return estimated median
    */
   @Contract(pure = true)
-  public SortedMap<U, Double> median() throws Exception {
-    return this.quantile(0.5);
+  public SortedMap<U, Double> estimatedMedian() throws Exception {
+    return this.estimatedQuantile(0.5);
   }
 
   /**
@@ -496,8 +496,8 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    * @return estimated median
    */
   @Contract(pure = true)
-  public <R extends Number> SortedMap<U, Double> median(SerializableFunction<X, R> mapper) throws Exception {
-    return this.quantile(mapper, 0.5);
+  public <R extends Number> SortedMap<U, Double> estimatedMedian(SerializableFunction<X, R> mapper) throws Exception {
+    return this.estimatedQuantile(mapper, 0.5);
   }
 
   /**
@@ -510,8 +510,8 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    * @return estimated quantile boundary
    */
   @Contract(pure = true)
-  public SortedMap<U, Double> quantile(double q) throws Exception {
-    return this.makeNumeric().quantile(n -> n, q);
+  public SortedMap<U, Double> estimatedQuantile(double q) throws Exception {
+    return this.makeNumeric().estimatedQuantile(n -> n, q);
   }
 
   /**
@@ -526,11 +526,11 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    * @return estimated quantile boundary
    */
   @Contract(pure = true)
-  public <R extends Number> SortedMap<U, Double> quantile(
+  public <R extends Number> SortedMap<U, Double> estimatedQuantile(
       SerializableFunction<X, R> mapper,
       double q
   ) throws Exception {
-    return transformSortedMap(this.quantiles(mapper), qFunction -> qFunction.applyAsDouble(q));
+    return transformSortedMap(this.estimatedQuantiles(mapper), qFunction -> qFunction.applyAsDouble(q));
   }
 
   /**
@@ -543,8 +543,8 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    * @return estimated quantile boundaries
    */
   @Contract(pure = true)
-  public SortedMap<U, List<Double>> quantiles(Iterable<Double> q) throws Exception {
-    return this.makeNumeric().quantiles(n -> n, q);
+  public SortedMap<U, List<Double>> estimatedQuantiles(Iterable<Double> q) throws Exception {
+    return this.makeNumeric().estimatedQuantiles(n -> n, q);
   }
 
   /**
@@ -558,12 +558,12 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    * @return estimated quantile boundaries
    */
   @Contract(pure = true)
-  public <R extends Number> SortedMap<U, List<Double>> quantiles(
+  public <R extends Number> SortedMap<U, List<Double>> estimatedQuantiles(
       SerializableFunction<X, R> mapper,
       Iterable<Double> q
   ) throws Exception {
     return transformSortedMap(
-        this.quantiles(mapper),
+        this.estimatedQuantiles(mapper),
         quantileFunction -> StreamSupport.stream(q.spliterator(), false)
             .mapToDouble(Double::doubleValue)
             .map(quantileFunction)
@@ -581,8 +581,8 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    * @return a function that computes estimated quantile boundaries
    */
   @Contract(pure = true)
-  public SortedMap<U, DoubleUnaryOperator> quantiles() throws Exception {
-    return this.makeNumeric().quantiles(n -> n);
+  public SortedMap<U, DoubleUnaryOperator> estimatedQuantiles() throws Exception {
+    return this.makeNumeric().estimatedQuantiles(n -> n);
   }
 
   /**
@@ -596,7 +596,7 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    * @return a function that computes estimated quantile boundaries
    */
   @Contract(pure = true)
-  public <R extends Number> SortedMap<U, DoubleUnaryOperator> quantiles(
+  public <R extends Number> SortedMap<U, DoubleUnaryOperator> estimatedQuantiles(
       SerializableFunction<X, R> mapper
   ) throws Exception {
     return transformSortedMap(this.digest(mapper), d -> d::quantile);

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -1,10 +1,14 @@
 package org.heigit.bigspatialdata.oshdb.api.mapreducer;
 
 import com.google.common.collect.Lists;
+import com.tdunning.math.stats.TDigest;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygonal;
 import java.util.Map.Entry;
+import java.util.function.DoubleUnaryOperator;
+import java.util.function.Function;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.heigit.bigspatialdata.oshdb.api.generic.*;
@@ -19,7 +23,6 @@ import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTag;
 import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTagInterface;
-import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTagKey;
 import org.jetbrains.annotations.Contract;
 
 import java.util.*;
@@ -416,14 +419,7 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    */
   @Contract(pure = true)
   public SortedMap<U, Integer> countUniq() throws Exception {
-    return this
-        .uniq().entrySet().stream()
-        .collect(Collectors.toMap(
-            Map.Entry::getKey,
-            e -> e.getValue().size(),
-            (v1, v2) -> v1, // can't happen, actually since input is already a map
-            TreeMap::new
-        ));
+    return transformSortedMap(this.uniq(), Set::size);
   }
 
   /**
@@ -463,9 +459,8 @@ public class MapAggregator<U extends Comparable<U>, X> implements
    */
   @Contract(pure = true)
   public SortedMap<U, Double> weightedAverage(SerializableFunction<X, WeightedValue> mapper) throws Exception {
-    return this
-        .map(mapper)
-        .reduce(
+    return transformSortedMap(
+        this.map(mapper).reduce(
             () -> new PayloadWithWeight<>(0.0,0.0),
             (acc, cur) -> {
               acc.num = NumberUtils.add(acc.num, cur.getValue().doubleValue()*cur.getWeight());
@@ -473,12 +468,151 @@ public class MapAggregator<U extends Comparable<U>, X> implements
               return acc;
             },
             (a, b) -> new PayloadWithWeight<>(NumberUtils.add(a.num, b.num), a.weight+b.weight)
-        ).entrySet().stream().collect(Collectors.toMap(
-            Map.Entry::getKey,
-            e -> e.getValue().num / e.getValue().weight,
-            (v1, v2) -> v1,
-            TreeMap::new
-        ));
+        ),
+        x -> x.num / x.weight
+    );
+  }
+
+  /**
+   * Returns an estimate of the median of the results.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @return estimated median
+   */
+  @Contract(pure = true)
+  public SortedMap<U, Double> median() throws Exception {
+    return this.quantile(0.5);
+  }
+
+  /**
+   * Returns an estimate of the median of the results after applying the given map function.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param mapper function that returns the numbers to generate the mean for
+   * @return estimated median
+   */
+  @Contract(pure = true)
+  public <R extends Number> SortedMap<U, Double> median(SerializableFunction<X, R> mapper) throws Exception {
+    return this.quantile(mapper, 0.5);
+  }
+
+  /**
+   * Returns an estimate of a requested quantile of the results.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param q the desired quantile to calculate (as a number between 0 and 1)
+   * @return estimated quantile boundary
+   */
+  @Contract(pure = true)
+  public SortedMap<U, Double> quantile(double q) throws Exception {
+    return this.makeNumeric().quantile(n -> n, q);
+  }
+
+  /**
+   * Returns an estimate of a requested quantile of the results after applying the given map
+   * function.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param mapper function that returns the numbers to generate the quantile for
+   * @param q the desired quantile to calculate (as a number between 0 and 1)
+   * @return estimated quantile boundary
+   */
+  @Contract(pure = true)
+  public <R extends Number> SortedMap<U, Double> quantile(
+      SerializableFunction<X, R> mapper,
+      double q
+  ) throws Exception {
+    return transformSortedMap(this.quantiles(mapper), qFunction -> qFunction.applyAsDouble(q));
+  }
+
+  /**
+   * Returns an estimate of the quantiles of the results
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param q the desired quantiles to calculate (as a collection of numbers between 0 and 1)
+   * @return estimated quantile boundaries
+   */
+  @Contract(pure = true)
+  public SortedMap<U, List<Double>> quantiles(Iterable<Double> q) throws Exception {
+    return this.makeNumeric().quantiles(n -> n, q);
+  }
+
+  /**
+   * Returns an estimate of the quantiles of the results after applying the given map function.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param mapper function that returns the numbers to generate the quantiles for
+   * @param q the desired quantiles to calculate (as a collection of numbers between 0 and 1)
+   * @return estimated quantile boundaries
+   */
+  @Contract(pure = true)
+  public <R extends Number> SortedMap<U, List<Double>> quantiles(
+      SerializableFunction<X, R> mapper,
+      Iterable<Double> q
+  ) throws Exception {
+    return transformSortedMap(
+        this.quantiles(mapper),
+        quantileFunction -> StreamSupport.stream(q.spliterator(), false)
+            .mapToDouble(Double::doubleValue)
+            .map(quantileFunction)
+            .boxed()
+            .collect(Collectors.toList())
+    );
+  }
+
+  /**
+   * Returns a function that computes estimates of arbitrary quantiles of the results
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @return a function that computes estimated quantile boundaries
+   */
+  @Contract(pure = true)
+  public SortedMap<U, DoubleUnaryOperator> quantiles() throws Exception {
+    return this.makeNumeric().quantiles(n -> n);
+  }
+
+  /**
+   * Returns a function that computes estimates of arbitrary quantiles of the results after applying
+   * the given map function.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param mapper function that returns the numbers to generate the quantiles for
+   * @return a function that computes estimated quantile boundaries
+   */
+  @Contract(pure = true)
+  public <R extends Number> SortedMap<U, DoubleUnaryOperator> quantiles(
+      SerializableFunction<X, R> mapper
+  ) throws Exception {
+    return transformSortedMap(this.digest(mapper), d -> d::quantile);
+  }
+
+  /**
+   * generates the t-digest of the complete result set. see:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   */
+  @Contract(pure = true)
+  private <R extends Number> SortedMap<U, TDigest> digest(SerializableFunction<X, R> mapper) throws Exception {
+    return this.map(mapper).reduce(
+        TDigestReducer::identitySupplier,
+        TDigestReducer::accumulator,
+        TDigestReducer::combiner
+    );
   }
 
   // -----------------------------------------------------------------------------------------------
@@ -731,5 +865,15 @@ public class MapAggregator<U extends Comparable<U>, X> implements
           seen.stream().map(v -> new OSHDBCombinedIndex<>(u, v))
       ).collect(Collectors.toList());
     }
+  }
+
+  // transforms the values of a sorted map by a given function (similar to Stream::map)
+  private <A, B> SortedMap<U, B> transformSortedMap(SortedMap<U, A> in, Function<A, B> transform) {
+    return in.entrySet().stream().collect(Collectors.toMap(
+        Entry::getKey,
+        e -> transform.apply(e.getValue()),
+        (v1, v2) -> { assert false; return v1; },
+        TreeMap::new
+    ));
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -1150,8 +1150,8 @@ public abstract class MapReducer<X> implements
    * @return estimated median
    */
   @Contract(pure = true)
-  public Double median() throws Exception {
-    return this.quantile(0.5);
+  public Double estimatedMedian() throws Exception {
+    return this.estimatedQuantile(0.5);
   }
 
   /**
@@ -1164,8 +1164,8 @@ public abstract class MapReducer<X> implements
    * @return estimated median
    */
   @Contract(pure = true)
-  public <R extends Number> Double median(SerializableFunction<X, R> mapper) throws Exception {
-    return this.quantile(mapper, 0.5);
+  public <R extends Number> Double estimatedMedian(SerializableFunction<X, R> mapper) throws Exception {
+    return this.estimatedQuantile(mapper, 0.5);
   }
 
   /**
@@ -1178,8 +1178,8 @@ public abstract class MapReducer<X> implements
    * @return estimated quantile boundary
    */
   @Contract(pure = true)
-  public Double quantile(double q) throws Exception {
-    return this.makeNumeric().quantile(n -> n, q);
+  public Double estimatedQuantile(double q) throws Exception {
+    return this.makeNumeric().estimatedQuantile(n -> n, q);
   }
 
   /**
@@ -1194,9 +1194,9 @@ public abstract class MapReducer<X> implements
    * @return estimated quantile boundary
    */
   @Contract(pure = true)
-  public <R extends Number> Double quantile(SerializableFunction<X, R> mapper, double q)
+  public <R extends Number> Double estimatedQuantile(SerializableFunction<X, R> mapper, double q)
       throws Exception {
-    return this.quantiles(mapper).applyAsDouble(q);
+    return this.estimatedQuantiles(mapper).applyAsDouble(q);
   }
 
   /**
@@ -1209,8 +1209,8 @@ public abstract class MapReducer<X> implements
    * @return estimated quantile boundaries
    */
   @Contract(pure = true)
-  public List<Double> quantiles(Iterable<Double> q) throws Exception {
-    return this.makeNumeric().quantiles(n -> n, q);
+  public List<Double> estimatedQuantiles(Iterable<Double> q) throws Exception {
+    return this.makeNumeric().estimatedQuantiles(n -> n, q);
   }
 
   /**
@@ -1224,13 +1224,13 @@ public abstract class MapReducer<X> implements
    * @return estimated quantile boundaries
    */
   @Contract(pure = true)
-  public <R extends Number> List<Double> quantiles(
+  public <R extends Number> List<Double> estimatedQuantiles(
       SerializableFunction<X, R> mapper,
       Iterable<Double> q
   ) throws Exception {
     return StreamSupport.stream(q.spliterator(), false)
         .mapToDouble(Double::doubleValue)
-        .map(this.quantiles(mapper))
+        .map(this.estimatedQuantiles(mapper))
         .boxed()
         .collect(Collectors.toList());
   }
@@ -1244,8 +1244,8 @@ public abstract class MapReducer<X> implements
    * @return a function that computes estimated quantile boundaries
    */
   @Contract(pure = true)
-  public DoubleUnaryOperator quantiles() throws Exception {
-    return this.makeNumeric().quantiles(n -> n);
+  public DoubleUnaryOperator estimatedQuantiles() throws Exception {
+    return this.makeNumeric().estimatedQuantiles(n -> n);
   }
 
   /**
@@ -1259,7 +1259,7 @@ public abstract class MapReducer<X> implements
    * @return a function that computes estimated quantile boundaries
    */
   @Contract(pure = true)
-  public <R extends Number> DoubleUnaryOperator quantiles(
+  public <R extends Number> DoubleUnaryOperator estimatedQuantiles(
       SerializableFunction<X, R> mapper
   ) throws Exception {
     TDigest digest = this.digest(mapper);

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -1630,6 +1630,9 @@ public abstract class MapReducer<X> implements
   protected TagTranslator _getTagTranslator() {
     if (this._tagTranslator == null) {
       try {
+        if (this._oshdbForTags == null) {
+          throw new OSHDBKeytablesNotFoundException();
+        }
         this._tagTranslator = new TagTranslator(this._oshdbForTags.getConnection());
       } catch (OSHDBKeytablesNotFoundException e) {
         LOG.error(e.getMessage());

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -1794,8 +1794,17 @@ class MapFunction implements SerializableFunction {
   }
 }
 
-class TDigestReducer /*implements Serializable*/ {
-  private final static int COMPRESSION = 1000; // todo: tweak?
+class TDigestReducer {
+
+  /**
+   * a COMPRESSION parameter of 1000 should provide relatively precise results, while not being
+   * too demanding on memory usage. See page 20 in the paper [1]:
+   *
+   * > Compression parameter (1/δ) was […] 1000 in order to reliably achieve 0.1% accuracy
+   *
+   * [1] https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   */
+  private final static int COMPRESSION = 1000;
 
   static TDigest identitySupplier() {
     return new MergingDigest(COMPRESSION);

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerAggregations.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerAggregations.java
@@ -145,9 +145,109 @@ interface MapReducerAggregations<X> {
   Object weightedAverage(SerializableFunction<X, WeightedValue> mapper) throws Exception;
 
   /**
+   * Returns an estimate of the median of the results.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @return estimated median
+   */
+  Object median() throws Exception;
+
+  /**
+   * Returns an estimate of the median of the results after applying the given map function.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param mapper function that returns the numbers to generate the mean for
+   * @return estimated median
+   */
+  <R extends Number> Object median(SerializableFunction<X, R> mapper) throws Exception;
+
+  /**
+   * Returns an estimate of a requested quantile of the results.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param q the desired quantile to calculate (as a number between 0 and 1)
+   * @return estimated quantile boundary
+   */
+  Object quantile(double q) throws Exception;
+
+  /**
+   * Returns an estimate of a requested quantile of the results after applying the given map
+   * function.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param mapper function that returns the numbers to generate the quantile for
+   * @param q the desired quantile to calculate (as a number between 0 and 1)
+   * @return estimated quantile boundary
+   */
+  <R extends Number> Object quantile(SerializableFunction<X, R> mapper, double q) throws Exception;
+
+  /**
+   * Returns an estimate of the quantiles of the results
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param q the desired quantiles to calculate (as a collection of numbers between 0 and 1)
+   * @return estimated quantile boundaries
+   */
+  Object quantiles(Iterable<Double> q) throws Exception;
+
+  /**
+   * Returns an estimate of the quantiles of the results after applying the given map function.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param mapper function that returns the numbers to generate the quantiles for
+   * @param q the desired quantiles to calculate (as a collection of numbers between 0 and 1)
+   * @return estimated quantile boundaries
+   */
+  <R extends Number> Object quantiles(
+      SerializableFunction<X, R> mapper,
+      Iterable<Double> q
+  ) throws Exception;
+
+  /**
+   * Returns a function that computes estimates of arbitrary quantiles of the results
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @return a function that computes estimated quantile boundaries
+   */
+  Object quantiles() throws Exception;
+
+  /**
+   * Returns a function that computes estimates of arbitrary quantiles of the results after applying
+   * the given map function.
+   *
+   * uses the t-digest algorithm to calculate estimates for the quantiles in a map-reduce system:
+   * https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf
+   *
+   * @param mapper function that returns the numbers to generate the quantiles for
+   * @return a function that computes estimated quantile boundaries
+   */
+  <R extends Number> Object quantiles(SerializableFunction<X, R> mapper) throws Exception;
+
+  /**
    * Collects all results into List(s)
    *
    * @return list(s) with all results returned by the `mapper` function
    */
   Object collect() throws Exception;
+
+  /**
+   * Returns all results as a Stream
+   *
+   * @return a stream with all results returned by the `mapper` function
+   */
+  Object stream() throws Exception;
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerAggregations.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerAggregations.java
@@ -152,7 +152,7 @@ interface MapReducerAggregations<X> {
    *
    * @return estimated median
    */
-  Object median() throws Exception;
+  Object estimatedMedian() throws Exception;
 
   /**
    * Returns an estimate of the median of the results after applying the given map function.
@@ -163,7 +163,7 @@ interface MapReducerAggregations<X> {
    * @param mapper function that returns the numbers to generate the mean for
    * @return estimated median
    */
-  <R extends Number> Object median(SerializableFunction<X, R> mapper) throws Exception;
+  <R extends Number> Object estimatedMedian(SerializableFunction<X, R> mapper) throws Exception;
 
   /**
    * Returns an estimate of a requested quantile of the results.
@@ -174,7 +174,7 @@ interface MapReducerAggregations<X> {
    * @param q the desired quantile to calculate (as a number between 0 and 1)
    * @return estimated quantile boundary
    */
-  Object quantile(double q) throws Exception;
+  Object estimatedQuantile(double q) throws Exception;
 
   /**
    * Returns an estimate of a requested quantile of the results after applying the given map
@@ -187,7 +187,7 @@ interface MapReducerAggregations<X> {
    * @param q the desired quantile to calculate (as a number between 0 and 1)
    * @return estimated quantile boundary
    */
-  <R extends Number> Object quantile(SerializableFunction<X, R> mapper, double q) throws Exception;
+  <R extends Number> Object estimatedQuantile(SerializableFunction<X, R> mapper, double q) throws Exception;
 
   /**
    * Returns an estimate of the quantiles of the results
@@ -198,7 +198,7 @@ interface MapReducerAggregations<X> {
    * @param q the desired quantiles to calculate (as a collection of numbers between 0 and 1)
    * @return estimated quantile boundaries
    */
-  Object quantiles(Iterable<Double> q) throws Exception;
+  Object estimatedQuantiles(Iterable<Double> q) throws Exception;
 
   /**
    * Returns an estimate of the quantiles of the results after applying the given map function.
@@ -210,7 +210,7 @@ interface MapReducerAggregations<X> {
    * @param q the desired quantiles to calculate (as a collection of numbers between 0 and 1)
    * @return estimated quantile boundaries
    */
-  <R extends Number> Object quantiles(
+  <R extends Number> Object estimatedQuantiles(
       SerializableFunction<X, R> mapper,
       Iterable<Double> q
   ) throws Exception;
@@ -223,7 +223,7 @@ interface MapReducerAggregations<X> {
    *
    * @return a function that computes estimated quantile boundaries
    */
-  Object quantiles() throws Exception;
+  Object estimatedQuantiles() throws Exception;
 
   /**
    * Returns a function that computes estimates of arbitrary quantiles of the results after applying
@@ -235,7 +235,7 @@ interface MapReducerAggregations<X> {
    * @param mapper function that returns the numbers to generate the quantiles for
    * @return a function that computes estimated quantile boundaries
    */
-  <R extends Number> Object quantiles(SerializableFunction<X, R> mapper) throws Exception;
+  <R extends Number> Object estimatedQuantiles(SerializableFunction<X, R> mapper) throws Exception;
 
   /**
    * Collects all results into List(s)

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestQuantiles.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestQuantiles.java
@@ -8,28 +8,19 @@ package org.heigit.bigspatialdata.oshdb.api.tests;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 import java.util.SortedMap;
 import java.util.function.DoubleUnaryOperator;
-import java.util.stream.IntStream;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
-import org.heigit.bigspatialdata.oshdb.api.generic.WeightedValue;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapAggregator;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
-import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMContributionView;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMEntitySnapshotView;
-import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
 import org.heigit.bigspatialdata.oshdb.osm.OSMType;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
-import org.heigit.bigspatialdata.oshdb.util.celliterator.ContributionType;
 import org.heigit.bigspatialdata.oshdb.util.time.OSHDBTimestamps;
 import org.junit.Test;
 
@@ -42,20 +33,11 @@ public class TestQuantiles {
   private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8.651133,49.387611,8.6561,49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2015-01-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2015-01-01");
-  private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01", OSHDBTimestamps.Interval.MONTHLY);
 
   private final double REQUIRED_ACCURACY = 1E-4;
 
   public TestQuantiles() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
-  }
-
-  private MapReducer<OSMEntitySnapshot> createMapReducer() {
-    return OSMEntitySnapshotView.on(oshdb)
-        .timestamps(timestamps1)
-        .osmType(OSMType.WAY)
-        .osmTag("building", "yes")
-        .areaOfInterest(bbox);
   }
 
   private void assertApproximateQuantiles(
@@ -72,6 +54,16 @@ public class TestQuantiles {
     );
 
     assertEquals(expectedResult, result, expectedResult * REQUIRED_ACCURACY);
+  }
+
+  // MapReducer
+
+  private MapReducer<OSMEntitySnapshot> createMapReducer() {
+    return OSMEntitySnapshotView.on(oshdb)
+        .timestamps(timestamps1)
+        .osmType(OSMType.WAY)
+        .osmTag("building", "yes")
+        .areaOfInterest(bbox);
   }
 
   @Test
@@ -122,6 +114,87 @@ public class TestQuantiles {
     for (Double q : qs) {
       assertApproximateQuantiles(fullResult, q, quantilesFunction.applyAsDouble(q));
     }
+  }
+
+  // MapAggregator
+
+  private MapAggregator<OSHDBTimestamp, OSMEntitySnapshot> createMapAggregator() {
+    return OSMEntitySnapshotView.on(oshdb)
+        .timestamps(timestamps2)
+        .osmType(OSMType.WAY)
+        .osmTag("building", "yes")
+        .areaOfInterest(bbox)
+        .aggregateByTimestamp();
+  }
+
+  @Test
+  public void testMedianMapAggregator() throws Exception {
+    MapAggregator<OSHDBTimestamp, Integer> mr = this.createMapAggregator()
+        .map(s -> s.getGeometry().getCoordinates().length);
+    SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
+    fullResult.values().forEach(Collections::sort);
+
+    SortedMap<OSHDBTimestamp, Double> medians = mr.quantile(0.8);
+
+    medians.forEach((ts, median) ->
+        assertApproximateQuantiles(fullResult.get(ts), 0.8, median)
+    );
+  }
+
+  @Test
+  public void testQuantileMapAggregator() throws Exception {
+    MapAggregator<OSHDBTimestamp, Integer> mr = this.createMapAggregator()
+        .map(s -> s.getGeometry().getCoordinates().length);
+    SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
+    fullResult.values().forEach(Collections::sort);
+
+    SortedMap<OSHDBTimestamp, Double> quantiles = mr.quantile(0.8);
+
+    quantiles.forEach((ts, quantile) ->
+        assertApproximateQuantiles(fullResult.get(ts), 0.8, quantile)
+    );
+  }
+
+  @Test
+  public void testQuantilesMapAggregator() throws Exception {
+    MapAggregator<OSHDBTimestamp, Integer> mr = this.createMapAggregator()
+        .map(s -> s.getGeometry().getCoordinates().length);
+    SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
+    fullResult.values().forEach(Collections::sort);
+
+    List<Double> qs = Arrays.asList(0.0, 0.2, 0.4, 0.6, 0.8, 1.0);
+    SortedMap<OSHDBTimestamp, List<Double>> quantiless = mr.quantiles(qs);
+
+    quantiless.forEach((ts, quantiles) -> {
+      for (Double quantile : quantiles) {
+        assertApproximateQuantiles(
+            fullResult.get(ts),
+            qs.get(quantiles.indexOf(quantile)),
+            quantile
+        );
+      }
+    });
+  }
+
+  @Test
+  public void testQuantilesFunctionMapAggregator() throws Exception {
+    MapAggregator<OSHDBTimestamp, Integer> mr = this.createMapAggregator()
+        .map(s -> s.getGeometry().getCoordinates().length);
+    SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
+    fullResult.values().forEach(Collections::sort);
+
+    List<Double> qs = Arrays.asList(0.0, 0.2, 0.4, 0.6, 0.8, 1.0);
+    SortedMap<OSHDBTimestamp, DoubleUnaryOperator> quantilesFunctions = mr.quantiles();
+
+    quantilesFunctions.forEach((ts, quantilesFunction) -> {
+      for (Double q : qs) {
+        assertApproximateQuantiles(
+            fullResult.get(ts),
+            q,
+            quantilesFunction.applyAsDouble(q)
+        );
+      }
+    });
   }
 
 }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestQuantiles.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestQuantiles.java
@@ -1,0 +1,127 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package org.heigit.bigspatialdata.oshdb.api.tests;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.function.DoubleUnaryOperator;
+import java.util.stream.IntStream;
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
+import org.heigit.bigspatialdata.oshdb.api.generic.WeightedValue;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMContributionView;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMEntitySnapshotView;
+import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
+import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
+import org.heigit.bigspatialdata.oshdb.osm.OSMType;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
+import org.heigit.bigspatialdata.oshdb.util.celliterator.ContributionType;
+import org.heigit.bigspatialdata.oshdb.util.time.OSHDBTimestamps;
+import org.junit.Test;
+
+/**
+ *
+ */
+public class TestQuantiles {
+  private final OSHDBDatabase oshdb;
+
+  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8.651133,49.387611,8.6561,49.390513);
+  private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2015-01-01");
+  private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2015-01-01");
+  private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01", OSHDBTimestamps.Interval.MONTHLY);
+
+  private final double REQUIRED_ACCURACY = 1E-4;
+
+  public TestQuantiles() throws Exception {
+    oshdb = new OSHDBH2("./src/test/resources/test-data");
+  }
+
+  private MapReducer<OSMEntitySnapshot> createMapReducer() {
+    return OSMEntitySnapshotView.on(oshdb)
+        .timestamps(timestamps1)
+        .osmType(OSMType.WAY)
+        .osmTag("building", "yes")
+        .areaOfInterest(bbox);
+  }
+
+  private void assertApproximateQuantiles(
+      List<? extends Number> values, double quantile, double result) {
+
+    double quantileIndex = (values.size() - 1) * quantile;
+    int quantileBoundLower = (int) Math.floor(quantileIndex);
+    double quantileAmountUpper = quantileIndex - quantileBoundLower;
+    int quantileBoundUpper = (int) Math.ceil(quantileIndex);
+    double quantileAmountLower = 1 - quantileAmountUpper;
+    double expectedResult = (
+        quantileAmountLower * values.get(quantileBoundLower).doubleValue() +
+        quantileAmountUpper * values.get(quantileBoundUpper).doubleValue()
+    );
+
+    assertEquals(expectedResult, result, expectedResult * REQUIRED_ACCURACY);
+  }
+
+  @Test
+  public void testMedian() throws Exception {
+    MapReducer<Integer> mr = this.createMapReducer()
+        .map(s -> s.getGeometry().getCoordinates().length);
+    List<Integer> fullResult = mr.collect();
+    Collections.sort(fullResult);
+
+    assertApproximateQuantiles(fullResult, 0.5, mr.median());
+  }
+
+  @Test
+  public void testQuantile() throws Exception {
+    MapReducer<Integer> mr = this.createMapReducer()
+        .map(s -> s.getGeometry().getCoordinates().length);
+    List<Integer> fullResult = mr.collect();
+    Collections.sort(fullResult);
+
+    assertApproximateQuantiles(fullResult, 0.8, mr.quantile(0.8));
+  }
+
+  @Test
+  public void testQuantiles() throws Exception {
+    MapReducer<Integer> mr = this.createMapReducer()
+        .map(s -> s.getGeometry().getCoordinates().length);
+    List<Integer> fullResult = mr.collect();
+    Collections.sort(fullResult);
+
+    List<Double> qs = Arrays.asList(0.0, 0.2, 0.4, 0.6, 0.8, 1.0);
+    List<Double> quantiles = mr.quantiles(qs);
+
+    for (Double quantile : quantiles) {
+      assertApproximateQuantiles(fullResult, qs.get(quantiles.indexOf(quantile)), quantile);
+    }
+  }
+
+  @Test
+  public void testQuantilesFunction() throws Exception {
+    MapReducer<Integer> mr = this.createMapReducer()
+        .map(s -> s.getGeometry().getCoordinates().length);
+    List<Integer> fullResult = mr.collect();
+    Collections.sort(fullResult);
+
+    List<Double> qs = Arrays.asList(0.0, 0.2, 0.4, 0.6, 0.8, 1.0);
+    DoubleUnaryOperator quantilesFunction = mr.quantiles();
+
+    for (Double q : qs) {
+      assertApproximateQuantiles(fullResult, q, quantilesFunction.applyAsDouble(q));
+    }
+  }
+
+}

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestQuantiles.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestQuantiles.java
@@ -73,7 +73,7 @@ public class TestQuantiles {
     List<Integer> fullResult = mr.collect();
     Collections.sort(fullResult);
 
-    assertApproximateQuantiles(fullResult, 0.5, mr.median());
+    assertApproximateQuantiles(fullResult, 0.5, mr.estimatedMedian());
   }
 
   @Test
@@ -83,7 +83,7 @@ public class TestQuantiles {
     List<Integer> fullResult = mr.collect();
     Collections.sort(fullResult);
 
-    assertApproximateQuantiles(fullResult, 0.8, mr.quantile(0.8));
+    assertApproximateQuantiles(fullResult, 0.8, mr.estimatedQuantile(0.8));
   }
 
   @Test
@@ -94,7 +94,7 @@ public class TestQuantiles {
     Collections.sort(fullResult);
 
     List<Double> qs = Arrays.asList(0.0, 0.2, 0.4, 0.6, 0.8, 1.0);
-    List<Double> quantiles = mr.quantiles(qs);
+    List<Double> quantiles = mr.estimatedQuantiles(qs);
 
     for (Double quantile : quantiles) {
       assertApproximateQuantiles(fullResult, qs.get(quantiles.indexOf(quantile)), quantile);
@@ -109,7 +109,7 @@ public class TestQuantiles {
     Collections.sort(fullResult);
 
     List<Double> qs = Arrays.asList(0.0, 0.2, 0.4, 0.6, 0.8, 1.0);
-    DoubleUnaryOperator quantilesFunction = mr.quantiles();
+    DoubleUnaryOperator quantilesFunction = mr.estimatedQuantiles();
 
     for (Double q : qs) {
       assertApproximateQuantiles(fullResult, q, quantilesFunction.applyAsDouble(q));
@@ -134,7 +134,7 @@ public class TestQuantiles {
     SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
     fullResult.values().forEach(Collections::sort);
 
-    SortedMap<OSHDBTimestamp, Double> medians = mr.quantile(0.8);
+    SortedMap<OSHDBTimestamp, Double> medians = mr.estimatedQuantile(0.8);
 
     medians.forEach((ts, median) ->
         assertApproximateQuantiles(fullResult.get(ts), 0.8, median)
@@ -148,7 +148,7 @@ public class TestQuantiles {
     SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
     fullResult.values().forEach(Collections::sort);
 
-    SortedMap<OSHDBTimestamp, Double> quantiles = mr.quantile(0.8);
+    SortedMap<OSHDBTimestamp, Double> quantiles = mr.estimatedQuantile(0.8);
 
     quantiles.forEach((ts, quantile) ->
         assertApproximateQuantiles(fullResult.get(ts), 0.8, quantile)
@@ -163,7 +163,7 @@ public class TestQuantiles {
     fullResult.values().forEach(Collections::sort);
 
     List<Double> qs = Arrays.asList(0.0, 0.2, 0.4, 0.6, 0.8, 1.0);
-    SortedMap<OSHDBTimestamp, List<Double>> quantiless = mr.quantiles(qs);
+    SortedMap<OSHDBTimestamp, List<Double>> quantiless = mr.estimatedQuantiles(qs);
 
     quantiless.forEach((ts, quantiles) -> {
       for (Double quantile : quantiles) {
@@ -184,7 +184,7 @@ public class TestQuantiles {
     fullResult.values().forEach(Collections::sort);
 
     List<Double> qs = Arrays.asList(0.0, 0.2, 0.4, 0.6, 0.8, 1.0);
-    SortedMap<OSHDBTimestamp, DoubleUnaryOperator> quantilesFunctions = mr.quantiles();
+    SortedMap<OSHDBTimestamp, DoubleUnaryOperator> quantilesFunctions = mr.estimatedQuantiles();
 
     quantilesFunctions.forEach((ts, quantilesFunction) -> {
       for (Double q : qs) {


### PR DESCRIPTION
This uses the [t-digest](https://raw.githubusercontent.com/tdunning/t-digest/master/docs/t-digest-paper/histo.pdf) method (and code) by Ted Dunning and Otmar Ertl to estimate quantiles of the distribution of the result set. A short description of the method can be [found here](https://dataorigami.net/blogs/napkin-folding/19055451-percentile-and-quantile-estimation-of-big-data-the-t-digest).

Todo:
* [x] tweak t-disgest parameters (`compression`)?
* [x] implement for `MapAggregator`
* [x] unit tests