### PR TITLE
use custom object serialization/deserialization for geometrysplitter

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/GeometrySplitter.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/GeometrySplitter.java
@@ -27,8 +27,6 @@ import org.heigit.bigspatialdata.oshdb.util.geometry.fip.FastPolygonOperations;
  * @param <U> an arbitrary index type to identify supplied sub-regions
  */
 class GeometrySplitter<U extends Comparable<U>> {
-  private Set<U> indices;
-
   private STRtree spatialIndex = new STRtree();
   private Map<U, FastBboxInPolygon> bips = new HashMap<>();
   private Map<U, FastBboxOutsidePolygon> bops = new HashMap<>();
@@ -41,7 +39,6 @@ class GeometrySplitter<U extends Comparable<U>> {
       bops.put(index, new FastBboxOutsidePolygon(geometry));
       poops.put(index, new FastPolygonOperations(geometry));
     });
-    this.indices = subregions.keySet();
   }
 
   /**


### PR DESCRIPTION
_(sorry for hijacking this PR, but it seemed appropriate because it touched the same source file, which would otherwise have caused potential merge conflicts)_

Sometimes, a GeometrySplitter can end up containing many deeply nested child-objects. Which can lead to relatively slow object serialization (slowing down execution of such queries on distributed environments). It is then faster to just transfer the geometries and re-create the indices at the destination after de-serialization.

Some test results of an ohsome-api _groupByBoundary_ call:

|   | 30,000 ISEA3H grid cells |
| --- | --- |
| master | ~ 60 sec  |
| simple variant<br>(for comparison) | ~ 18 sec  |
| WKB (this branch) | ~ 12 sec  |

This branch uses WKB for serializing the JTS geometry objects. For comparison, I've also tested a slightly simpler implementation, where the default Java serialization is used for them:

```java
  private void writeObject(ObjectOutputStream out) throws IOException {
    out.writeObject(this.subregions);
  }
  private <P extends Geometry & Polygonal> void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
    this.subregions = (Map<U, ? extends Geometry>) in.readObject();
  }
```