### PR TITLE
work around casting issues on remote ignite execution (groupByEntity query)

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -937,16 +937,25 @@ public abstract class MapReducer<X> implements
           flatMapper = this._getFlatMapper();
         }
         if (this._forClass.equals(OSMContribution.class)) {
+          //noinspection Convert2MethodRef having just `flatMapper::apply` here is problematic, see https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094
+          final SerializableFunction<List<OSMContribution>, Iterable<X>> contributionFlatMapper =
+              data -> flatMapper.apply(data);
           return this.flatMapReduceCellsOSMContributionGroupedById(
-              (SerializableFunction<List<OSMContribution>, Iterable<X>>) flatMapper::apply,
+              contributionFlatMapper,
               identitySupplier,
               accumulator,
               combiner
           );
         } else if (this._forClass.equals(OSMEntitySnapshot.class)) {
+          //noinspection Convert2MethodRef having just `flatMapper::apply` here is problematic, see https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094
+          final SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> snapshotFlatMapper =
+              data -> flatMapper.apply(data);
           return this.flatMapReduceCellsOSMEntitySnapshotGroupedById(
-              (SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>>) flatMapper::apply,
-              identitySupplier, accumulator, combiner);
+              snapshotFlatMapper,
+              identitySupplier,
+              accumulator,
+              combiner
+          );
         } else {
           throw new UnsupportedOperationException(
               "Unimplemented data view: " + this._forClass.toString());

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -878,7 +878,7 @@ public abstract class MapReducer<X> implements
         if (this._mappers.stream().noneMatch(MapFunction::isFlatMapper)) {
           final SerializableFunction<Object, X> mapper = this._getMapper();
           if (this._forClass.equals(OSMContribution.class)) {
-            //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094
+            //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://github.com/GIScience/oshdb/pull/37
             final SerializableFunction<OSMContribution, X> contributionMapper =
                 data -> mapper.apply(data);
             return this.mapReduceCellsOSMContribution(
@@ -888,7 +888,7 @@ public abstract class MapReducer<X> implements
                 combiner
             );
           } else if (this._forClass.equals(OSMEntitySnapshot.class)) {
-            //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094
+            //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://github.com/GIScience/oshdb/pull/37
             final SerializableFunction<OSMEntitySnapshot, X> snapshotMapper =
                 data -> mapper.apply(data);
             return this.mapReduceCellsOSMEntitySnapshot(
@@ -937,7 +937,7 @@ public abstract class MapReducer<X> implements
           flatMapper = this._getFlatMapper();
         }
         if (this._forClass.equals(OSMContribution.class)) {
-          //noinspection Convert2MethodRef having just `flatMapper::apply` here is problematic, see https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094
+          //noinspection Convert2MethodRef having just `flatMapper::apply` here is problematic, see https://github.com/GIScience/oshdb/pull/37
           final SerializableFunction<List<OSMContribution>, Iterable<X>> contributionFlatMapper =
               data -> flatMapper.apply(data);
           return this.flatMapReduceCellsOSMContributionGroupedById(
@@ -947,7 +947,7 @@ public abstract class MapReducer<X> implements
               combiner
           );
         } else if (this._forClass.equals(OSMEntitySnapshot.class)) {
-          //noinspection Convert2MethodRef having just `flatMapper::apply` here is problematic, see https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094
+          //noinspection Convert2MethodRef having just `flatMapper::apply` here is problematic, see https://github.com/GIScience/oshdb/pull/37
           final SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> snapshotFlatMapper =
               data -> flatMapper.apply(data);
           return this.flatMapReduceCellsOSMEntitySnapshotGroupedById(
@@ -1353,12 +1353,12 @@ public abstract class MapReducer<X> implements
         if (this._mappers.stream().noneMatch(MapFunction::isFlatMapper)) {
           final SerializableFunction<Object, X> mapper = this._getMapper();
           if (this._forClass.equals(OSMContribution.class)) {
-            //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094
+            //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://github.com/GIScience/oshdb/pull/37
             final SerializableFunction<OSMContribution, X> contributionMapper =
                 data -> mapper.apply(data);
             return this.mapStreamCellsOSMContribution(contributionMapper);
           } else if (this._forClass.equals(OSMEntitySnapshot.class)) {
-            //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094
+            //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://github.com/GIScience/oshdb/pull/37
             final SerializableFunction<OSMEntitySnapshot, X> snapshotMapper =
                 data -> mapper.apply(data);
             return this.mapStreamCellsOSMEntitySnapshot(snapshotMapper);
@@ -1402,13 +1402,15 @@ public abstract class MapReducer<X> implements
           flatMapper = this._getFlatMapper();
         }
         if (this._forClass.equals(OSMContribution.class)) {
-          return this.flatMapStreamCellsOSMContributionGroupedById(
-              (SerializableFunction<List<OSMContribution>, Iterable<X>>) flatMapper::apply
-          );
+          //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://github.com/GIScience/oshdb/pull/37
+          final SerializableFunction<List<OSMContribution>, Iterable<X>> contributionFlatMapper =
+              data -> flatMapper.apply(data);
+          return this.flatMapStreamCellsOSMContributionGroupedById(contributionFlatMapper);
         } else if (this._forClass.equals(OSMEntitySnapshot.class)) {
-          return this.flatMapStreamCellsOSMEntitySnapshotGroupedById(
-              (SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>>) flatMapper::apply
-          );
+          //noinspection Convert2MethodRef having just `mapper::apply` here is problematic, see https://github.com/GIScience/oshdb/pull/37
+          final SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> snapshotFlatMapper =
+              data -> flatMapper.apply(data);
+          return this.flatMapStreamCellsOSMEntitySnapshotGroupedById(snapshotFlatMapper);
         } else {
           throw new UnsupportedOperationException(
               "Unimplemented data view: " + this._forClass.toString());

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
@@ -5,6 +5,7 @@
  */
 package org.heigit.bigspatialdata.oshdb.api.tests;
 
+import java.util.List;
 import java.util.stream.Collectors;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBJdbc;
@@ -71,6 +72,15 @@ abstract class TestMapReduce {
 
     /* should be 5: first version doesn't have the highway tag, remaining 7 versions have 5 different contributor user ids*/
     assertEquals(5, result.size());
+
+    // "groupByEntity"
+    assertEquals(7, createMapReducerOSMContribution()
+        .timestamps(timestamps72)
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .groupByEntity()
+        .map(List::size)
+        .sum()
+    );
   }
 
   @Test
@@ -93,6 +103,15 @@ abstract class TestMapReduce {
         .uniq();
 
     assertEquals(3, result.size());
+
+    // "groupByEntity"
+    assertEquals(5, createMapReducerOSMEntitySnapshot()
+        .timestamps(timestamps6)
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .groupByEntity()
+        .map(List::size)
+        .sum()
+    );
   }
 
   @Test
@@ -119,6 +138,17 @@ abstract class TestMapReduce {
 
     /* should be 5: first version doesn't have the highway tag, remaining 7 versions have 5 different contributor user ids*/
     assertEquals(5, result.size());
+
+    // "groupByEntity"
+    assertEquals(7, createMapReducerOSMContribution()
+        .timestamps(timestamps72)
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .groupByEntity()
+        .map(List::size)
+        .stream()
+        .mapToInt(x -> x)
+        .reduce(0, (a,b) -> a+b)
+    );
   }
 
   @Test
@@ -143,5 +173,16 @@ abstract class TestMapReduce {
         .collect(Collectors.toSet());
 
     assertEquals(3, result.size());
+
+    // "groupByEntity"
+    assertEquals(5, createMapReducerOSMEntitySnapshot()
+        .timestamps(timestamps6)
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .groupByEntity()
+        .map(List::size)
+        .stream()
+        .mapToInt(x -> x)
+        .reduce(0, (a,b) -> a+b)
+    );
   }
 }


### PR DESCRIPTION
For some reason, not doing this additional (but actually unnecessary) nesting of the "mapper" lambdas results in the strangest casting exceptions on remote ignite workers with peer class loading.

We already [had](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/commit/adeb425d969fe58116989d9b2e678c623a26de11#note_2094) this workaround in place for the normal "map-reduce" routines (see adeb425d969fe58116989d9b2e678c623a26de11, 3c3b8a792def8755d995809567949fd487971130), but not for the code path handling the `groupByEntity` mode.

For [example](https://github.com/GIScience/oshdb/blob/3668619/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/Kernels.java#L172):

> java.lang.ClassCastException
> Caused by: java.lang.ClassCastException: java.util.ArrayList cannot be cast to org.heigit.bigspatialdata.oshdb.api.object.OSMContribution

The affected code works just fine locally (H2 or local Ignite without peer class loading), but not on a remote ignite cluster with peer class loading enabled (i.e. after serializing->deserializing of the respective lambdas), this produces the mentioned class cast exceptions:

```
final SerializableFunction<Object, X> mapper = this._getMapper();
final SerializableFunction<OSMContribution, X> contributionMapper = (SerializableFunction<OSMContribution, X>)mapper::apply
```

but this works:

```
final SerializableFunction<Object, X> mapper = this._getMapper();
final SerializableFunction<OSMContribution, X> contributionMapper = data -> mapper.apply(data);
```

Downside to this workaround is one additional level of lambda invocation, but what can you do :shrug: