### PR TITLE
fix calculating of absolute value of hash codes

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/tagtranslator/TagTranslator.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/tagtranslator/TagTranslator.java
@@ -317,7 +317,7 @@ public class TagTranslator {
   }
 
   private int getFakeId(String s) {
-    return -Math.abs(s.hashCode());
+    return -(s.hashCode() & 0x7fffffff);
   }
 
   public Connection getConnection() {


### PR DESCRIPTION
fixes an [`RV_ABSOLUTE_VALUE_OF_HASHCODE`](https://sbforge.org/sonar/rules/show/findbugs:RV_ABSOLUTE_VALUE_OF_HASHCODE?layout=false) warning by [findbugs](https://jenkins.ohsome.org/job/oshdb/job/master/154/findbugs/Normal/source.8b6e4bba-5a82-4972-b236-534a4c3c2b54/#320). reason is that hash codes cover the full range of an int, but `Math.abs(Integer.MIN_VALUE) == Integer.MIN_VALUE` :see_no_evil: 