### PR TITLE
implement timeout in all backends

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBDatabase.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBDatabase.java
@@ -1,14 +1,17 @@
 package org.heigit.bigspatialdata.oshdb.api.db;
 
+import java.util.OptionalLong;
 import org.heigit.bigspatialdata.oshdb.OSHDB;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTimeoutException;
 
 /**
  * OSHDB database backend connector.
  */
 public abstract class OSHDBDatabase extends OSHDB implements AutoCloseable {
   private String prefix = "";
+  private Long timeout = null;
 
   /**
    * Factory function that creates a mapReducer object of the appropriate data type class for this
@@ -40,5 +43,45 @@ public abstract class OSHDBDatabase extends OSHDB implements AutoCloseable {
    */
   public String prefix() {
     return this.prefix;
+  }
+
+  /**
+   * Set a timeout for queries on this ignite oshdb backend.
+   *
+   * <p>If a query takes longer than the given time limit, a {@link OSHDBTimeoutException} will be
+   * thrown.</p>
+   *
+   * @param seconds time (in seconds) a query is allowed to run for.
+   * @return the current oshdb object
+   */
+  public OSHDBDatabase timeout(double seconds) {
+    return this.timeoutInMilliseconds((long) Math.ceil(seconds * 1000));
+  }
+
+  /**
+   * Set a timeout for queries on this ignite oshdb backend.
+   *
+   * <p>If a query takes longer than the given time limit, a {@link OSHDBTimeoutException} will be
+   * thrown.</p>
+   *
+   * @param milliSeconds time (in milliseconds) a query is allowed to run for.
+   * @return the current oshdb object
+   */
+  public OSHDBDatabase timeoutInMilliseconds(long milliSeconds) {
+    this.timeout = milliSeconds;
+    return this;
+  }
+
+  /**
+   * Gets the timeout for queries on this ignite oshdb backend, if present.
+   *
+   * @return the currently set query timeout in milliseconds
+   */
+  public OptionalLong timeoutInMilliseconds() {
+    if (this.timeout == null) {
+      return OptionalLong.empty();
+    } else {
+      return OptionalLong.of(this.timeout);
+    }
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBDatabase.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBDatabase.java
@@ -59,6 +59,16 @@ public abstract class OSHDBDatabase extends OSHDB implements AutoCloseable {
   }
 
   /**
+   * Clears a previously set timeout for queries on this ignite oshdb backend.
+   *
+   * @return the current oshdb object
+   */
+  public OSHDBDatabase clearTimeout() {
+    this.timeout = null;
+    return this;
+  }
+
+  /**
    * Set a timeout for queries on this ignite oshdb backend.
    *
    * <p>If a query takes longer than the given time limit, a {@link OSHDBTimeoutException} will be

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
@@ -3,7 +3,6 @@ package org.heigit.bigspatialdata.oshdb.api.db;
 import java.io.File;
 import java.util.Collection;
 import java.util.Optional;
-import java.util.OptionalLong;
 
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -19,7 +18,6 @@ import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.MapReducerIgniteSc
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 import org.heigit.bigspatialdata.oshdb.osm.OSMType;
 import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTableNotFoundException;
-import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTimeoutException;
 
 /**
  * OSHDB database backend connector to a Ignite system.
@@ -33,7 +31,6 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
 
   private final transient Ignite ignite;
   private ComputeMode computeMode = ComputeMode.LocalPeek;
-  private Long timeout = null;
 
   private IgniteRunnable onCloseCallback = null;
 
@@ -126,47 +123,6 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
    */
   public ComputeMode computeMode() {
     return this.computeMode;
-  }
-
-  /**
-   * Set a timeout for queries on this ignite oshdb backend.
-   *
-   * <p>If a query takes longer than the given time limit, a {@link OSHDBTimeoutException} will be
-   * thrown.</p>
-   *
-   * @param seconds time (in seconds) a query is allowed to run for.
-   * @return the current oshdb object
-   */
-  public OSHDBIgnite timeout(double seconds) {
-    this.timeout = (long) Math.ceil(seconds * 1000);
-    return this;
-  }
-
-  /**
-   * Set a timeout for queries on this ignite oshdb backend.
-   *
-   * <p>If a query takes longer than the given time limit, a {@link OSHDBTimeoutException} will be
-   * thrown.</p>
-   *
-   * @param milliSeconds time (in milliseconds) a query is allowed to run for.
-   * @return the current oshdb object
-   */
-  public OSHDBIgnite timeoutInMilliseconds(long milliSeconds) {
-    this.timeout = milliSeconds;
-    return this;
-  }
-
-  /**
-   * Gets the timeout for queries on this ignite oshdb backend, if present.
-   *
-   * @return the currently set query timeout in milliseconds
-   */
-  public OptionalLong timeoutInMilliseconds() {
-    if (this.timeout == null) {
-      return OptionalLong.empty();
-    } else {
-      return OptionalLong.of(this.timeout);
-    }
   }
 
   /**

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
@@ -155,9 +155,6 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
    * @return the current oshdb object
    */
   public OSHDBIgnite timeoutInMilliseconds(long milliSeconds) {
-    if (this.computeMode() == ComputeMode.ScanQuery) {
-      throw new UnsupportedOperationException("Query timeouts not implemented in ScanQuery mode");
-    }
     this.timeout = milliSeconds;
     return this;
   }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/db/OSHDBIgnite.java
@@ -138,9 +138,6 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
    * @return the current oshdb object
    */
   public OSHDBIgnite timeout(double seconds) {
-    if (this.computeMode() == ComputeMode.ScanQuery) {
-      throw new UnsupportedOperationException("Query timeouts not implemented in ScanQuery mode");
-    }
     this.timeout = (long) Math.ceil(seconds * 1000);
     return this;
   }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -28,7 +28,6 @@ import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.tuple.Pair;
 import org.heigit.bigspatialdata.oshdb.OSHDB;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
-import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBJdbc;
 import org.heigit.bigspatialdata.oshdb.api.generic.NumberUtils;
 import org.heigit.bigspatialdata.oshdb.api.generic.WeightedValue;
@@ -1892,11 +1891,9 @@ public abstract class MapReducer<X> implements
    * Produces a log message if not.
     */
   private void checkCancelable() {
-    if (this.oshdb instanceof OSHDBIgnite) {
-      if (((OSHDBIgnite) this.oshdb).timeoutInMilliseconds().isPresent()) {
-        if (!this.isCancelable()) {
-          LOG.error("A query timeout was set but the database backend isn't cancelable");
-        }
+    if (this.oshdb.timeoutInMilliseconds().isPresent()) {
+      if (!this.isCancelable()) {
+        LOG.error("A query timeout was set but the database backend isn't cancelable");
       }
     }
   }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/Kernels.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/Kernels.java
@@ -50,13 +50,13 @@ class Kernels implements Serializable {
       SerializableFunction<OSMContribution, R> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
-      CancelableProcessStatus aborter
+      CancelableProcessStatus process
   ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       cellIterator.iterateByContribution(oshEntityCell)
-          .filter(ignored -> aborter.isActive())
+          .filter(ignored -> process.isActive())
           .forEach(contribution -> {
             OSMContribution osmContribution = new OSMContribution(contribution);
             accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(osmContribution)));
@@ -79,14 +79,14 @@ class Kernels implements Serializable {
       SerializableFunction<List<OSMContribution>, Iterable<R>> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
-      CancelableProcessStatus aborter
+      CancelableProcessStatus process
   ) {
     return (oshEntityCell, cellIterator) -> {
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       // iterate over the history of all OSM objects in the current cell
       List<OSMContribution> contributions = new ArrayList<>();
       cellIterator.iterateByContribution(oshEntityCell)
-          .filter(ignored -> aborter.isActive())
+          .filter(ignored -> process.isActive())
           .forEach(contribution -> {
             OSMContribution thisContribution = new OSMContribution(contribution);
             if (contributions.size() > 0
@@ -124,13 +124,13 @@ class Kernels implements Serializable {
       SerializableFunction<OSMEntitySnapshot, R> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
-      CancelableProcessStatus aborter
+      CancelableProcessStatus process
   ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       cellIterator.iterateByTimestamps(oshEntityCell)
-          .filter(ignored -> aborter.isActive())
+          .filter(ignored -> process.isActive())
           .forEach(data -> {
             OSMEntitySnapshot snapshot = new OSMEntitySnapshot(data);
             // immediately fold the result
@@ -154,14 +154,14 @@ class Kernels implements Serializable {
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<R>> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
-      CancelableProcessStatus aborter
+      CancelableProcessStatus process
   ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
       cellIterator.iterateByTimestamps(oshEntityCell)
-          .filter(ignored -> aborter.isActive())
+          .filter(ignored -> process.isActive())
           .forEach(data -> {
             OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshot(data);
             if (osmEntitySnapshots.size() > 0
@@ -191,9 +191,18 @@ class Kernels implements Serializable {
   static <S> CellProcessor<Collection<S>> getOSMContributionCellStreamer(
       SerializableFunction<OSMContribution, S> mapper
   ) {
+    return getOSMContributionCellStreamer(mapper, NC);
+  }
+
+  @Nonnull
+  static <S> CellProcessor<Collection<S>> getOSMContributionCellStreamer(
+      SerializableFunction<OSMContribution, S> mapper,
+      CancelableProcessStatus process
+  ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       return cellIterator.iterateByContribution(oshEntityCell)
+          .filter(ignored -> process.isActive())
           .map(OSMContribution::new)
           .map(mapper)
           .collect(Collectors.toList());
@@ -204,11 +213,20 @@ class Kernels implements Serializable {
   static <S> CellProcessor<Collection<S>> getOSMContributionGroupingCellStreamer(
       SerializableFunction<List<OSMContribution>, Iterable<S>> mapper
   ) {
+    return getOSMContributionGroupingCellStreamer(mapper, NC);
+  }
+
+  @Nonnull
+  static <S> CellProcessor<Collection<S>> getOSMContributionGroupingCellStreamer(
+      SerializableFunction<List<OSMContribution>, Iterable<S>> mapper,
+      CancelableProcessStatus process
+  ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       List<OSMContribution> contributions = new ArrayList<>();
       List<S> result = new LinkedList<>();
       cellIterator.iterateByContribution(oshEntityCell)
+          .filter(ignored -> process.isActive())
           .map(OSMContribution::new)
           .forEach(contribution -> {
             if (contributions.size() > 0 && contribution.getEntityAfter().getId()
@@ -231,9 +249,18 @@ class Kernels implements Serializable {
   static <S> CellProcessor<Collection<S>> getOSMEntitySnapshotCellStreamer(
       SerializableFunction<OSMEntitySnapshot, S> mapper
   ) {
+    return getOSMEntitySnapshotCellStreamer(mapper, NC);
+  }
+
+  @Nonnull
+  static <S> CellProcessor<Collection<S>> getOSMEntitySnapshotCellStreamer(
+      SerializableFunction<OSMEntitySnapshot, S> mapper,
+      CancelableProcessStatus process
+  ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       return cellIterator.iterateByTimestamps(oshEntityCell)
+          .filter(ignored -> process.isActive())
           .map(OSMEntitySnapshot::new)
           .map(mapper)
           .collect(Collectors.toList());
@@ -244,11 +271,20 @@ class Kernels implements Serializable {
   static <S> CellProcessor<Collection<S>> getOSMEntitySnapshotGroupingCellStreamer(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<S>> mapper
   ) {
+    return getOSMEntitySnapshotGroupingCellStreamer(mapper, NC);
+  }
+
+  @Nonnull
+  static <S> CellProcessor<Collection<S>> getOSMEntitySnapshotGroupingCellStreamer(
+      SerializableFunction<List<OSMEntitySnapshot>, Iterable<S>> mapper,
+      CancelableProcessStatus process
+  ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       List<OSMEntitySnapshot> snapshots = new ArrayList<>();
       List<S> result = new LinkedList<>();
       cellIterator.iterateByTimestamps(oshEntityCell)
+          .filter(ignored -> process.isActive())
           .map(OSMEntitySnapshot::new)
           .forEach(contribution -> {
             if (snapshots.size() > 0 && contribution.getEntity().getId()

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -87,12 +87,8 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
 
   @Override
   public boolean isActive() {
-    OptionalLong timeout = this.oshdb.timeoutInMilliseconds();
-
-    if (timeout.isPresent()) {
-      if (System.currentTimeMillis() - executionStartTimeMillis > timeout.getAsLong()) {
-        throw new OSHDBTimeoutException();
-      }
+    if (timeout != null && System.currentTimeMillis() - executionStartTimeMillis > timeout) {
+      throw new OSHDBTimeoutException();
     }
     return true;
   }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -6,6 +6,7 @@ import java.sql.SQLException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -14,6 +15,8 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCompute;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.lang.IgniteFuture;
 import org.apache.ignite.lang.IgniteRunnable;
 import org.heigit.bigspatialdata.oshdb.TableNames;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
@@ -23,6 +26,7 @@ import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBinaryOp
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableFunction;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableSupplier;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CancelableProcessStatus;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CellProcessor;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
@@ -31,6 +35,7 @@ import org.heigit.bigspatialdata.oshdb.grid.GridOSHEntity;
 import org.heigit.bigspatialdata.oshdb.osm.OSMType;
 import org.heigit.bigspatialdata.oshdb.util.CellId;
 import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTimeoutException;
 import org.jetbrains.annotations.NotNull;
 import org.json.simple.parser.ParseException;
 
@@ -50,7 +55,15 @@ import org.json.simple.parser.ParseException;
  * the (~linear) inefficiency with this implementation.
  * </p>
  */
-public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
+public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> implements
+    CancelableProcessStatus {
+
+  /**
+   * Stores the start time of reduce/stream operation as returned by
+   * {@link System#currentTimeMillis()}. Used to determine query timeouts.
+   */
+  private long executionStartTimeMillis;
+
   public MapReducerIgniteAffinityCall(OSHDBDatabase oshdb,
       Class<? extends OSHDBMapReducible> forClass) {
     super(oshdb, forClass);
@@ -59,6 +72,24 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
   // copy constructor
   private MapReducerIgniteAffinityCall(MapReducerIgniteAffinityCall obj) {
     super(obj);
+  }
+
+  @Override
+  public boolean isCancelable() {
+    return true;
+  }
+
+  @Override
+  public boolean isActive() {
+    OSHDBIgnite oshdb = (OSHDBIgnite) this.oshdb;
+    OptionalLong timeout = oshdb.timeoutInMilliseconds();
+
+    if (timeout.isPresent()) {
+      if (System.currentTimeMillis() - executionStartTimeMillis > timeout.getAsLong()) {
+        throw new OSHDBTimeoutException();
+      }
+    }
+    return true;
   }
 
   @NotNull
@@ -77,11 +108,30 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
     };
   }
 
+  private static <T> T asyncGetHandleTimeouts(IgniteFuture<T> async) {
+    try {
+      return async.get();
+    } catch (IgniteException e) {
+      if (e.getCause().getCause() instanceof OSHDBTimeoutException) {
+        throw (OSHDBTimeoutException) e.getCause().getCause();
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  /**
+   * Implements a generic reduce operation.
+   *
+   * @throws OSHDBTimeoutException if a timeout was set and the computations took too long.
+   */
   private <S> S reduce(
       CellProcessor<S> cellProcessor,
       SerializableSupplier<S> identitySupplier,
       SerializableBinaryOperator<S> combiner
   ) throws ParseException, SQLException, IOException {
+    this.executionStartTimeMillis = System.currentTimeMillis();
+
     CellIterator cellIterator = new CellIterator(
         this.tstamps.get(),
         this.bboxFilter, this.getPolyFilter(),
@@ -103,24 +153,36 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
       return Streams.stream(cellIdRanges)
           .flatMapToLong(cellIdRangeToCellIds())
           .parallel()
-          .mapToObj(cellLongId -> compute.affinityCall(cacheName, cellLongId, () -> {
-            @SuppressWarnings("SerializableStoresNonSerializable")
-            GridOSHEntity oshEntityCell = cache.localPeek(cellLongId);
-            S ret;
-            if (oshEntityCell == null) {
-              ret = identitySupplier.get();
-            } else {
-              ret = cellProcessor.apply(oshEntityCell, cellIterator);
-            }
-            onClose.run();
-            return ret;
-          })).reduce(identitySupplier.get(), combiner);
+          .filter(ignored -> this.isActive())
+          .mapToObj(cellLongId -> asyncGetHandleTimeouts(
+              compute.affinityCallAsync(cacheName, cellLongId, () -> {
+                @SuppressWarnings("SerializableStoresNonSerializable")
+                GridOSHEntity oshEntityCell = cache.localPeek(cellLongId);
+                S ret;
+                if (oshEntityCell == null) {
+                  ret = identitySupplier.get();
+
+                } else {
+                  ret = cellProcessor.apply(oshEntityCell, cellIterator);
+                }
+                onClose.run();
+                return ret;
+              })
+          ))
+          .reduce(identitySupplier.get(), combiner);
     }).reduce(identitySupplier.get(), combiner);
   }
 
+  /**
+   * Implements a generic stream operation.
+   *
+   * @throws OSHDBTimeoutException if a timeout was set and the computations took too long.
+   */
   private Stream<X> stream(
       CellProcessor<Collection<X>> processor
   ) throws ParseException, SQLException, IOException {
+    this.executionStartTimeMillis = System.currentTimeMillis();
+
     CellIterator cellIterator = new CellIterator(
         this.tstamps.get(),
         this.bboxFilter, this.getPolyFilter(),
@@ -142,18 +204,21 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
       return Streams.stream(cellIdRanges)
           .flatMapToLong(cellIdRangeToCellIds())
           .parallel()
-          .mapToObj(cellLongId -> compute.affinityCall(cacheName, cellLongId, () -> {
-            @SuppressWarnings("SerializableStoresNonSerializable")
-            GridOSHEntity oshEntityCell = cache.localPeek(cellLongId);
-            Collection<X> ret;
-            if (oshEntityCell == null) {
-              ret = Collections.<X>emptyList();
-            } else {
-              ret = processor.apply(oshEntityCell, cellIterator);
-            }
-            onClose.run();
-            return ret;
-          }))
+          .filter(ignored -> this.isActive())
+          .mapToObj(cellLongId -> asyncGetHandleTimeouts(
+                compute.affinityCallAsync(cacheName, cellLongId, () -> {
+                  @SuppressWarnings("SerializableStoresNonSerializable")
+                  GridOSHEntity oshEntityCell = cache.localPeek(cellLongId);
+                  Collection<X> ret;
+                  if (oshEntityCell == null) {
+                    ret = Collections.<X>emptyList();
+                  } else {
+                    ret = processor.apply(oshEntityCell, cellIterator);
+                  }
+                  onClose.run();
+                  return ret;
+                })
+          ))
           .flatMap(Collection::stream);
     }).flatMap(x -> x);
   }
@@ -167,8 +232,13 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
       SerializableBiFunction<S, R, S> accumulator,
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
-    return this.reduce(
-        Kernels.getOSMContributionCellReducer(mapper, identitySupplier, accumulator),
+    return reduce(
+        Kernels.getOSMContributionCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -182,7 +252,12 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return reduce(
-        Kernels.getOSMContributionGroupingCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMContributionGroupingCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -197,7 +272,12 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return reduce(
-        Kernels.getOSMEntitySnapshotCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMEntitySnapshotCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -211,7 +291,12 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return reduce(
-        Kernels.getOSMEntitySnapshotGroupingCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMEntitySnapshotGroupingCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -222,24 +307,24 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> {
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
       SerializableFunction<OSMContribution, X> mapper) throws Exception {
-    return stream(Kernels.getOSMContributionCellStreamer(mapper));
+    return stream(Kernels.getOSMContributionCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMContributionGroupedById(
       SerializableFunction<List<OSMContribution>, Iterable<X>> mapper) throws Exception {
-    return stream(Kernels.getOSMContributionGroupingCellStreamer(mapper));
+    return stream(Kernels.getOSMContributionGroupingCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
       SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
-    return stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper));
+    return stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> mapper) throws Exception {
-    return stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper));
+    return stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper, this));
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -55,8 +55,8 @@ import org.json.simple.parser.ParseException;
  * the (~linear) inefficiency with this implementation.
  * </p>
  */
-public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> implements
-    CancelableProcessStatus {
+public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
+    implements CancelableProcessStatus {
 
   /**
    * Stores the start time of reduce/stream operation as returned by
@@ -74,6 +74,12 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> implements
     super(obj);
   }
 
+  @NotNull
+  @Override
+  protected MapReducer<X> copy() {
+    return new MapReducerIgniteAffinityCall<X>(this);
+  }
+
   @Override
   public boolean isCancelable() {
     return true;
@@ -81,8 +87,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> implements
 
   @Override
   public boolean isActive() {
-    OSHDBIgnite oshdb = (OSHDBIgnite) this.oshdb;
-    OptionalLong timeout = oshdb.timeoutInMilliseconds();
+    OptionalLong timeout = this.oshdb.timeoutInMilliseconds();
 
     if (timeout.isPresent()) {
       if (System.currentTimeMillis() - executionStartTimeMillis > timeout.getAsLong()) {
@@ -90,12 +95,6 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X> implements
       }
     }
     return true;
-  }
-
-  @NotNull
-  @Override
-  protected MapReducer<X> copy() {
-    return new MapReducerIgniteAffinityCall<X>(this);
   }
 
   @Nonnull

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -66,6 +66,11 @@ public class MapReducerIgniteLocalPeek<X> extends MapReducer<X> {
     super(obj);
   }
 
+  @Override
+  public boolean isCancelable() {
+    return true;
+  }
+
   @NotNull
   @Override
   protected MapReducer<X> copy() {

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -66,11 +66,6 @@ public class MapReducerIgniteLocalPeek<X> extends MapReducer<X> {
     super(obj);
   }
 
-  @Override
-  public boolean isCancelable() {
-    return true;
-  }
-
   @NotNull
   @Override
   protected MapReducer<X> copy() {
@@ -80,6 +75,11 @@ public class MapReducerIgniteLocalPeek<X> extends MapReducer<X> {
   private List<String> cacheNames(String prefix) {
     return this.typeFilter.stream().map(TableNames::forOSMType).filter(Optional::isPresent)
         .map(Optional::get).map(tn -> tn.toString(prefix)).collect(Collectors.toList());
+  }
+
+  @Override
+  public boolean isCancelable() {
+    return true;
   }
 
   @Override

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -2,13 +2,10 @@ package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
 
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Polygonal;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -22,19 +19,9 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCompute;
-import org.apache.ignite.IgniteException;
-import org.apache.ignite.cluster.ClusterNode;
-import org.apache.ignite.compute.ComputeJob;
-import org.apache.ignite.compute.ComputeJobResult;
-import org.apache.ignite.compute.ComputeJobResultPolicy;
-import org.apache.ignite.compute.ComputeTask;
-import org.apache.ignite.compute.ComputeTaskAdapter;
 import org.apache.ignite.compute.ComputeTaskFuture;
-import org.apache.ignite.compute.ComputeTaskNoResultCache;
 import org.apache.ignite.compute.ComputeTaskTimeoutException;
 import org.apache.ignite.lang.IgniteFutureTimeoutException;
-import org.apache.ignite.lang.IgniteRunnable;
-import org.apache.ignite.resources.IgniteInstanceResource;
 import org.heigit.bigspatialdata.oshdb.TableNames;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
@@ -43,8 +30,8 @@ import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBinaryOp
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableFunction;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableSupplier;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
-import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CancelableProcessStatus;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CellProcessor;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.OSHDBIgniteMapReduceComputeTask.CancelableIgniteMapReduceJob;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
@@ -142,75 +129,11 @@ public class MapReducerIgniteLocalPeek<X> extends MapReducer<X> {
 
 class IgniteLocalPeekHelper {
   /**
-   * A cancelable ignite broadcast task.
-   *
-   * @param <T> Type of the task argument.
-   * @param <R> Type of the task result returning from {@link ComputeTask#reduce(List)} method.
-   */
-  @ComputeTaskNoResultCache
-  static class CancelableBroadcastTask<T, R> extends ComputeTaskAdapter<T, R>
-      implements Serializable {
-    private final MapReduceCellsOnIgniteCacheComputeJob job;
-    private final SerializableBinaryOperator<R> combiner;
-    private final IgniteRunnable onClose;
-
-    private R resultAccumulator;
-
-    public CancelableBroadcastTask(
-        MapReduceCellsOnIgniteCacheComputeJob job,
-        SerializableSupplier<R> identitySupplier,
-        SerializableBinaryOperator<R> combiner,
-        IgniteRunnable onClose
-    ) {
-      this.job = job;
-      this.combiner = combiner;
-      this.resultAccumulator = identitySupplier.get();
-      this.onClose = onClose;
-    }
-
-    @Override
-    public Map<? extends ComputeJob, ClusterNode> map(List<ClusterNode> subgrid, T arg)
-        throws IgniteException {
-      Map<ComputeJob, ClusterNode> map = new HashMap<>(subgrid.size());
-      subgrid.forEach(node -> map.put(new ComputeJob() {
-        @IgniteInstanceResource
-        private Ignite ignite;
-
-        @Override
-        public void cancel() {
-          job.cancel();
-        }
-
-        @Override
-        public Object execute() throws IgniteException {
-          Object result = job.execute(ignite);
-          onClose.run();
-          return result;
-        }
-      }, node));
-      return map;
-    }
-
-    @Override
-    public ComputeJobResultPolicy result(ComputeJobResult res, List<ComputeJobResult> rcvd)
-        throws IgniteException {
-      R data = res.getData();
-      resultAccumulator = combiner.apply(resultAccumulator, data);
-      return ComputeJobResultPolicy.WAIT;
-    }
-
-    @Override
-    public R reduce(List<ComputeJobResult> results) throws IgniteException {
-      return resultAccumulator;
-    }
-  }
-
-  /**
    * Compute closure that iterates over every partition owned by a node located in a partition.
    */
   private abstract static class MapReduceCellsOnIgniteCacheComputeJob
       <V, R, M, S, P extends Geometry & Polygonal>
-      implements Serializable, CancelableProcessStatus {
+      implements CancelableIgniteMapReduceJob<S> {
     private static final Logger LOG =
         LoggerFactory.getLogger(MapReduceCellsOnIgniteCacheComputeJob.class);
     private boolean notCanceled = true;
@@ -244,7 +167,8 @@ class IgniteLocalPeekHelper {
       this.combiner = combiner;
     }
 
-    void cancel() {
+    @Override
+    public void cancel() {
       LOG.info("compute job canceled");
       this.notCanceled = false;
     }
@@ -433,16 +357,20 @@ class IgniteLocalPeekHelper {
     }
   }
 
+  /**
+   * Executes a compute job on all ignite nodes and further reduces and returns result(s).
+   *
+   * @throws IgniteFutureTimeoutException if a timeout was set and the computations took too long.
+   */
   private static <V, R, M, S, P extends Geometry & Polygonal> S mapReduceOnIgniteCache(
       OSHDBIgnite oshdb, SerializableSupplier<S> identitySupplier,
       SerializableBinaryOperator<S> combiner,
       MapReduceCellsOnIgniteCacheComputeJob<V, R, M, S, P> computeJob) {
-    // execute compute job on all ignite nodes and further reduce+return result(s)
     Ignite ignite = oshdb.getIgnite();
     IgniteCompute compute = ignite.compute();
 
     ComputeTaskFuture<S> asyncResult = compute.executeAsync(
-        new CancelableBroadcastTask<Object, S>(
+        new OSHDBIgniteMapReduceComputeTask<Object, S>(
             computeJob,
             identitySupplier,
             combiner,

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -365,7 +365,7 @@ class IgniteLocalPeekHelper {
   /**
    * Executes a compute job on all ignite nodes and further reduces and returns result(s).
    *
-   * @throws IgniteFutureTimeoutException if a timeout was set and the computations took too long.
+   * @throws OSHDBTimeoutException if a timeout was set and the computations took too long.
    */
   private static <V, R, M, S, P extends Geometry & Polygonal> S mapReduceOnIgniteCache(
       OSHDBIgnite oshdb, SerializableSupplier<S> identitySupplier,

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -73,15 +73,15 @@ public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
     super(obj);
   }
 
-  @Override
-  public boolean isCancelable() {
-    return true;
-  }
-
   @NotNull
   @Override
   protected MapReducer<X> copy() {
     return new MapReducerIgniteScanQuery<X>(this);
+  }
+
+  @Override
+  public boolean isCancelable() {
+    return true;
   }
 
   @Override

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -61,8 +61,6 @@ import org.slf4j.LoggerFactory;
  * </p>
  */
 public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
-  public static final boolean IS_CANCELABLE = true;
-
   public MapReducerIgniteScanQuery(OSHDBDatabase oshdb,
       Class<? extends OSHDBMapReducible> forClass) {
     super(oshdb, forClass);

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -288,7 +288,8 @@ class IgniteScanQueryHelper {
       return super.execute(node, Kernels.getOSMContributionCellReducer(
           this.mapper,
           this.identitySupplier,
-          this.accumulator
+          this.accumulator,
+          this
       ));
     }
   }
@@ -312,7 +313,8 @@ class IgniteScanQueryHelper {
       return super.execute(node, Kernels.getOSMContributionGroupingCellReducer(
           this.mapper,
           this.identitySupplier,
-          this.accumulator
+          this.accumulator,
+          this
       ));
     }
   }
@@ -336,7 +338,8 @@ class IgniteScanQueryHelper {
       return super.execute(node, Kernels.getOSMEntitySnapshotCellReducer(
           this.mapper,
           this.identitySupplier,
-          this.accumulator
+          this.accumulator,
+          this
       ));
     }
   }
@@ -360,7 +363,8 @@ class IgniteScanQueryHelper {
       return super.execute(node, Kernels.getOSMEntitySnapshotGroupingCellReducer(
           this.mapper,
           this.identitySupplier,
-          this.accumulator
+          this.accumulator,
+          this
       ));
     }
   }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -383,7 +383,7 @@ class IgniteScanQueryHelper {
   /**
    * Executes a compute job on all ignite nodes and further reduces and returns result(s).
    *
-   * @throws IgniteFutureTimeoutException if a timeout was set and the computations took too long.
+   * @throws OSHDBTimeoutException if a timeout was set and the computations took too long.
    */
   private static <V, R, M, S, P extends Geometry & Polygonal> S mapReduceOnIgniteCache(
       OSHDBIgnite oshdb, String cacheName, SerializableSupplier<S> identitySupplier,

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -60,6 +60,8 @@ import org.slf4j.LoggerFactory;
  * </p>
  */
 public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
+  public static final boolean IS_CANCELABLE = true;
+
   public MapReducerIgniteScanQuery(OSHDBDatabase oshdb,
       Class<? extends OSHDBMapReducible> forClass) {
     super(oshdb, forClass);
@@ -68,6 +70,11 @@ public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
   // copy constructor
   private MapReducerIgniteScanQuery(MapReducerIgniteScanQuery obj) {
     super(obj);
+  }
+
+  @Override
+  public boolean isCancelable() {
+    return true;
   }
 
   @NotNull

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbc.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbc.java
@@ -8,6 +8,7 @@ import java.sql.SQLException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 import java.util.Optional;
+import java.util.OptionalLong;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -16,13 +17,23 @@ import javax.annotation.Nonnull;
 import org.apache.commons.lang3.tuple.Pair;
 import org.heigit.bigspatialdata.oshdb.TableNames;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBJdbc;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CancelableProcessStatus;
 import org.heigit.bigspatialdata.oshdb.api.object.OSHDBMapReducible;
 import org.heigit.bigspatialdata.oshdb.grid.GridOSHEntity;
 import org.heigit.bigspatialdata.oshdb.util.CellId;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTimeoutException;
 
-abstract class MapReducerJdbc<X> extends MapReducer<X> {
+abstract class MapReducerJdbc<X> extends MapReducer<X> implements CancelableProcessStatus {
+
+  /**
+   * Stores the start time of reduce/stream operation as returned by
+   * {@link System#currentTimeMillis()}. Used to determine query timeouts.
+   */
+  protected long executionStartTimeMillis;
+
   MapReducerJdbc(OSHDBDatabase oshdb, Class<? extends OSHDBMapReducible> forClass) {
     super(oshdb, forClass);
   }
@@ -30,6 +41,19 @@ abstract class MapReducerJdbc<X> extends MapReducer<X> {
   // copy constructor
   MapReducerJdbc(MapReducerJdbc obj) {
     super(obj);
+  }
+
+  @Override
+  public boolean isActive() {
+    OSHDBIgnite oshdb = (OSHDBIgnite) this.oshdb;
+    OptionalLong timeout = oshdb.timeoutInMilliseconds();
+
+    if (timeout.isPresent()) {
+      if (System.currentTimeMillis() - executionStartTimeMillis > timeout.getAsLong()) {
+        throw new OSHDBTimeoutException();
+      }
+    }
+    return true;
   }
 
   protected ResultSet getOshCellsRawDataFromDb(Pair<CellId, CellId> cellIdRange)

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbc.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbc.java
@@ -45,8 +45,7 @@ abstract class MapReducerJdbc<X> extends MapReducer<X> implements CancelableProc
 
   @Override
   public boolean isActive() {
-    OSHDBIgnite oshdb = (OSHDBIgnite) this.oshdb;
-    OptionalLong timeout = oshdb.timeoutInMilliseconds();
+    OptionalLong timeout = this.oshdb.timeoutInMilliseconds();
 
     if (timeout.isPresent()) {
       if (System.currentTimeMillis() - executionStartTimeMillis > timeout.getAsLong()) {

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbc.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbc.java
@@ -45,12 +45,8 @@ abstract class MapReducerJdbc<X> extends MapReducer<X> implements CancelableProc
 
   @Override
   public boolean isActive() {
-    OptionalLong timeout = this.oshdb.timeoutInMilliseconds();
-
-    if (timeout.isPresent()) {
-      if (System.currentTimeMillis() - executionStartTimeMillis > timeout.getAsLong()) {
-        throw new OSHDBTimeoutException();
-      }
+    if (timeout != null && System.currentTimeMillis() - executionStartTimeMillis > timeout) {
+      throw new OSHDBTimeoutException();
     }
     return true;
   }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
@@ -51,6 +51,8 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
       SerializableSupplier<S> identitySupplier,
       SerializableBinaryOperator<S> combiner
   ) throws ParseException, SQLException, IOException {
+    this.executionStartTimeMillis = System.currentTimeMillis();
+
     CellIterator cellIterator = new CellIterator(
         this.tstamps.get(),
         this.bboxFilter, this.getPolyFilter(),
@@ -71,6 +73,8 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
   private Stream<X> stream(
       CellProcessor<Collection<X>> processor
   ) throws ParseException, SQLException, IOException {
+    this.executionStartTimeMillis = System.currentTimeMillis();
+
     CellIterator cellIterator = new CellIterator(
         this.tstamps.get(),
         this.bboxFilter, this.getPolyFilter(),

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
@@ -41,6 +41,11 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
     return new MapReducerJdbcMultithread<X>(this);
   }
 
+  @Override
+  public boolean isCancelable() {
+    return true;
+  }
+
   private <S> S reduce(
       CellProcessor<S> processor,
       SerializableSupplier<S> identitySupplier,
@@ -56,7 +61,9 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
     this.getCellIdRanges().forEach(cellIdRanges::add);
 
     return cellIdRanges.parallelStream()
+        .filter(ignored -> this.isActive())
         .flatMap(this::getOshCellsStream)
+        .filter(ignored -> this.isActive())
         .map(oshCell -> processor.apply(oshCell, cellIterator))
         .reduce(identitySupplier.get(), combiner);
   }
@@ -74,7 +81,9 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
     this.getCellIdRanges().forEach(cellIdRanges::add);
 
     return cellIdRanges.parallelStream()
+        .filter(ignored -> this.isActive())
         .flatMap(this::getOshCellsStream)
+        .filter(ignored -> this.isActive())
         .map(oshCell -> processor.apply(oshCell, cellIterator))
         .flatMap(Collection::stream);
   }
@@ -89,7 +98,12 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return this.reduce(
-        Kernels.getOSMContributionCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMContributionCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -103,7 +117,12 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return this.reduce(
-        Kernels.getOSMContributionGroupingCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMContributionGroupingCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -117,7 +136,12 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return reduce(
-        Kernels.getOSMEntitySnapshotCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMEntitySnapshotCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -131,7 +155,12 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return this.reduce(
-        Kernels.getOSMEntitySnapshotGroupingCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMEntitySnapshotGroupingCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
@@ -175,25 +175,25 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
       SerializableFunction<OSMContribution, X> mapper) throws Exception {
-    return this.stream(Kernels.getOSMContributionCellStreamer(mapper));
+    return this.stream(Kernels.getOSMContributionCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMContributionGroupedById(
       SerializableFunction<List<OSMContribution>, Iterable<X>> mapper) throws Exception {
-    return this.stream(Kernels.getOSMContributionGroupingCellStreamer(mapper));
+    return this.stream(Kernels.getOSMContributionGroupingCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
       SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
-    return this.stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper));
+    return this.stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> mapper) throws Exception {
-    return this.stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper));
+    return this.stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper, this));
   }
 
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
@@ -41,12 +41,18 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
     return new MapReducerJdbcSinglethread<X>(this);
   }
 
+  @Override
+  public boolean isCancelable() {
+    return true;
+  }
 
   private <S> S reduce(
       CellProcessor<S> cellProcessor,
       SerializableSupplier<S> identitySupplier,
       SerializableBinaryOperator<S> combiner
   ) throws ParseException, SQLException, IOException, ClassNotFoundException {
+    this.executionStartTimeMillis = System.currentTimeMillis();
+
     CellIterator cellIterator = new CellIterator(
         this.tstamps.get(),
         this.bboxFilter, this.getPolyFilter(),
@@ -93,7 +99,12 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return this.reduce(
-        Kernels.getOSMContributionCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMContributionCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -107,7 +118,12 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return this.reduce(
-        Kernels.getOSMContributionGroupingCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMContributionGroupingCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -121,7 +137,12 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return this.reduce(
-        Kernels.getOSMEntitySnapshotCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMEntitySnapshotCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );
@@ -135,7 +156,12 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
       SerializableBinaryOperator<S> combiner
   ) throws Exception {
     return this.reduce(
-        Kernels.getOSMEntitySnapshotGroupingCellReducer(mapper, identitySupplier, accumulator),
+        Kernels.getOSMEntitySnapshotGroupingCellReducer(
+            mapper,
+            identitySupplier,
+            accumulator,
+            this
+        ),
         identitySupplier,
         combiner
     );

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
@@ -77,6 +77,8 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
   private Stream<X> stream(
       CellProcessor<Collection<X>> cellProcessor
   ) throws ParseException, SQLException, IOException, ClassNotFoundException {
+    this.executionStartTimeMillis = System.currentTimeMillis();
+
     CellIterator cellIterator = new CellIterator(
         this.tstamps.get(),
         this.bboxFilter, this.getPolyFilter(),

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
@@ -174,26 +174,26 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
       SerializableFunction<OSMContribution, X> mapper) throws Exception {
-    return this.stream(Kernels.getOSMContributionCellStreamer(mapper));
+    return this.stream(Kernels.getOSMContributionCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMContributionGroupedById(
       SerializableFunction<List<OSMContribution>, Iterable<X>> mapper
   ) throws Exception {
-    return this.stream(Kernels.getOSMContributionGroupingCellStreamer(mapper));
+    return this.stream(Kernels.getOSMContributionGroupingCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
       SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
-    return this.stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper));
+    return this.stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper, this));
   }
 
   @Override
   protected Stream<X> flatMapStreamCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> mapper) throws Exception {
-    return this.stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper));
+    return this.stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper, this));
   }
 
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/OSHDBIgniteMapReduceComputeTask.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/OSHDBIgniteMapReduceComputeTask.java
@@ -1,0 +1,89 @@
+package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
+
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.ignite.Ignite;
+import org.apache.ignite.IgniteException;
+import org.apache.ignite.cluster.ClusterNode;
+import org.apache.ignite.compute.ComputeJob;
+import org.apache.ignite.compute.ComputeJobResult;
+import org.apache.ignite.compute.ComputeJobResultPolicy;
+import org.apache.ignite.compute.ComputeTask;
+import org.apache.ignite.compute.ComputeTaskAdapter;
+import org.apache.ignite.lang.IgniteRunnable;
+import org.apache.ignite.resources.IgniteInstanceResource;
+import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBinaryOperator;
+import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableSupplier;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.backend.Kernels.CancelableProcessStatus;
+
+/**
+ * A cancelable ignite broadcast task.
+ *
+ * @param <T> Type of the task argument.
+ * @param <R> Type of the task result returning from {@link ComputeTask#reduce(List)} method.
+ */
+@org.apache.ignite.compute.ComputeTaskNoResultCache
+class OSHDBIgniteMapReduceComputeTask<T, R> extends ComputeTaskAdapter<T, R>
+    implements Serializable {
+  interface CancelableIgniteMapReduceJob<S> extends Serializable, CancelableProcessStatus {
+    void cancel();
+
+    S execute(Ignite node);
+  }
+
+  private final CancelableIgniteMapReduceJob job;
+  private final SerializableBinaryOperator<R> combiner;
+  private final IgniteRunnable onClose;
+
+  private R resultAccumulator;
+
+  public OSHDBIgniteMapReduceComputeTask(
+      CancelableIgniteMapReduceJob job,
+      SerializableSupplier<R> identitySupplier,
+      SerializableBinaryOperator<R> combiner,
+      IgniteRunnable onClose
+  ) {
+    this.job = job;
+    this.combiner = combiner;
+    this.resultAccumulator = identitySupplier.get();
+    this.onClose = onClose;
+  }
+
+  @Override
+  public Map<? extends ComputeJob, ClusterNode> map(List<ClusterNode> subgrid, T arg)
+      throws IgniteException {
+    Map<ComputeJob, ClusterNode> map = new HashMap<>(subgrid.size());
+    subgrid.forEach(node -> map.put(new ComputeJob() {
+      @IgniteInstanceResource
+      private Ignite ignite;
+
+      @Override
+      public void cancel() {
+        job.cancel();
+      }
+
+      @Override
+      public Object execute() throws IgniteException {
+        Object result = job.execute(ignite);
+        onClose.run();
+        return result;
+      }
+    }, node));
+    return map;
+  }
+
+  @Override
+  public ComputeJobResultPolicy result(ComputeJobResult res, List<ComputeJobResult> rcvd)
+      throws IgniteException {
+    R data = res.getData();
+    resultAccumulator = combiner.apply(resultAccumulator, data);
+    return ComputeJobResultPolicy.WAIT;
+  }
+
+  @Override
+  public R reduce(List<ComputeJobResult> results) throws IgniteException {
+    return resultAccumulator;
+  }
+}

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSHDBMapReducible.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSHDBMapReducible.java
@@ -1,7 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.api.object;
 
 /**
- * Marks a class as possible data type of an OSHDB-MapReducer
+ * Marks a class as possible data type of an OSHDB-MapReducer.
  */
 public interface OSHDBMapReducible {
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMEntitySnapshot.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMEntitySnapshot.java
@@ -2,15 +2,15 @@ package org.heigit.bigspatialdata.oshdb.api.object;
 
 import com.vividsolutions.jts.geom.Geometry;
 import org.heigit.bigspatialdata.oshdb.osh.OSHEntity;
-import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator.IterateByTimestampEntry;
 import org.heigit.bigspatialdata.oshdb.util.celliterator.LazyEvaluatedObject;
 
 /**
  * Stores information about a single data entity at a specific time "snapshot".
  *
- * Alongside the entity and the timestamp, also the entity's geometry is provided.
+ * <p>Alongside the entity and the timestamp, also the entity's geometry is provided.</p>
  */
 public class OSMEntitySnapshot implements OSHDBMapReducible {
   private final IterateByTimestampEntry data;
@@ -20,7 +20,7 @@ public class OSMEntitySnapshot implements OSHDBMapReducible {
   }
 
   /**
-   * creates a copy of the current entity snapshot with an updated geometry
+   * Creates a copy of the current entity snapshot with an updated geometry.
    */
   public OSMEntitySnapshot(OSMEntitySnapshot other, Geometry reclippedGeometry) {
     this.data = new IterateByTimestampEntry(
@@ -64,7 +64,8 @@ public class OSMEntitySnapshot implements OSHDBMapReducible {
   /**
    * The entity for which the snapshot has been obtained.
    *
-   * This is the (not deleted) version of a OSHEntity that was valid at the provided snapshot timestamp.
+   * <p>This is the (not deleted) version of a OSHEntity that was valid at the provided snapshot
+   * timestamp.</p>
    *
    * @return the OSMEntity object of this snapshot
    */

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
@@ -8,6 +8,7 @@ import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMContributionView;
 import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMEntitySnapshotView;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTableNotFoundException;
 import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTimeoutException;
 import org.heigit.bigspatialdata.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.heigit.bigspatialdata.oshdb.api.tests;
 
 import java.util.List;
@@ -23,8 +18,6 @@ import org.junit.Test;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 /**
  *

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_IgniteMissingCache.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_IgniteMissingCache.java
@@ -33,4 +33,16 @@ public class TestMapReduceOSHDB_IgniteMissingCache extends TestMapReduceOSHDB_Ig
   public void testOSMEntitySnapshotViewStream() throws Exception {
     super.testOSMEntitySnapshotView();
   }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testTimeoutMapReduce() throws Exception {
+    super.testTimeoutMapReduce();
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testTimeoutStream() throws Exception {
+    super.testTimeoutStream();
+  }
 }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_JdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_JdbcMissingTables.java
@@ -2,6 +2,7 @@ package org.heigit.bigspatialdata.oshdb.api.tests;
 
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
 import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTableNotFoundException;
+import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBTimeoutException;
 import org.junit.Test;
 
 public class TestMapReduceOSHDB_JdbcMissingTables extends TestMapReduce {
@@ -33,5 +34,17 @@ public class TestMapReduceOSHDB_JdbcMissingTables extends TestMapReduce {
   @Test(expected = OSHDBTableNotFoundException.class)
   public void testOSMEntitySnapshotViewStream() throws Exception {
     super.testOSMEntitySnapshotView();
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testTimeoutMapReduce() throws Exception {
+    super.testTimeoutMapReduce();
+  }
+
+  @Override
+  @Test(expected = OSHDBTableNotFoundException.class)
+  public void testTimeoutStream() throws Exception {
+    super.testTimeoutStream();
   }
 }


### PR DESCRIPTION
This implements timeouts for the remaining backends

* [x] Ignite->ScanQuery
* [x] Ignite->AffinityCall
* [x] JDBC->singlethread
* [x] JDBC->multithread

also add supports for the data streaming functionality

* [x] MapReducer.stream