### PR TITLE
less memory intensive implementation of localKeys getter

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -5,6 +5,9 @@ import com.vividsolutions.jts.geom.Polygonal;
 import java.io.Serializable;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.ignite.Ignite;
@@ -225,33 +228,30 @@ class IgniteLocalPeekHelper {
 
     public abstract S execute(Ignite node);
 
-    List<Pair<IgniteCache<Long, GridOSHEntity>, Long>> localKeys(Ignite node) {
-      // calculate all cache keys we have to investigate
-      List<Pair<IgniteCache<Long, GridOSHEntity>, Long>> localKeys = new ArrayList<>();
-      this.cacheNames.forEach(cacheName -> {
+    Stream<Pair<IgniteCache<Long, GridOSHEntity>, Long>> localKeys(Ignite node) {
+      return this.cacheNames.stream().flatMap(cacheName -> {
         IgniteCache<Long, GridOSHEntity> cache = node.cache(cacheName);
-        List<Long> cellIdRangeIds = new ArrayList<>();
-        this.cellIdRanges.forEach(cellIdRange -> {
-          cellIdRangeIds.clear();
-          int level = cellIdRange.getLeft().getZoomLevel();
-          long from = CellId.getLevelId(level, cellIdRange.getLeft().getId());
-          long to = CellId.getLevelId(level, cellIdRange.getRight().getId());
-          for (long key = from; key <= to; key++) {
-            cellIdRangeIds.add(key);
-          }
-          // Map keys to ignite nodes and remember the local ones
-          node.<Long>affinity(cache.getName())
-              .mapKeysToNodes(cellIdRangeIds)
-              .getOrDefault(node.cluster().localNode(), Collections.emptyList())
-              .forEach(key -> localKeys.add(new ImmutablePair<>(cache, key)));
-        });
+        return StreamSupport.stream(this.cellIdRanges.spliterator(), false)
+            .flatMap(cellIdRange -> {
+              int level = cellIdRange.getLeft().getZoomLevel();
+              long fromId = cellIdRange.getLeft().getId();
+              long toId = cellIdRange.getRight().getId();
+              List<Long> cellIdRangeKeys = LongStream.rangeClosed(
+                  CellId.getLevelId(level, fromId),
+                  CellId.getLevelId(level, toId)
+              ).boxed().collect(Collectors.toList());
+              // Map keys to ignite nodes and remember the local ones
+              return node.<Long>affinity(cache.getName())
+                  .mapKeysToNodes(cellIdRangeKeys)
+                  .getOrDefault(node.cluster().localNode(), Collections.emptyList())
+                  .stream()
+                  .map(key -> new ImmutablePair<>(cache, key));
+            });
       });
-      Collections.shuffle(localKeys);
-      return localKeys;
     }
 
     S execute(Ignite node, CellProcessor<S> cellProcessor) {
-      return this.localKeys(node).parallelStream()
+      return this.localKeys(node).parallel()
           .map(cacheKey -> cacheKey.getLeft().localPeek(cacheKey.getRight()))
           .filter(Objects::nonNull) // filter out cache misses === empty oshdb cells
           .filter(ignored -> this.isActive())


### PR DESCRIPTION
Especially with large queries that span over a lot of cells, the existing implementation (storing every cell key in a long list) is not very memory efficient. Using a stream for this should be much more efficient.