### PR TITLE
fix using FastPolygonOperations on empty geometries

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -104,7 +104,7 @@ public class FastPolygonOperations implements Serializable {
   }
 
   public Geometry intersection(Geometry other) {
-    if (other == null) return null;
+    if (other == null || other.isEmpty()) return other;
     Envelope otherEnv = other.getEnvelopeInternal();
 
     int minBandX = Math.max(0, Math.min(numBands - 1, (int)Math.floor((otherEnv.getMinX() - env.getMinX())/envWidth * numBands)));

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
@@ -1,0 +1,37 @@
+package org.heigit.bigspatialdata.oshdb.util.geometry.fip;
+
+import static org.junit.Assert.assertEquals;
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import com.vividsolutions.jts.geom.Polygon;
+import org.junit.Test;
+
+public class FastPolygonOperationsTest {
+
+  @Test
+  public void testEmptyGeometryPolygon() {
+    Polygon p = FastPointInPolygonTest.createPolygon();
+    FastPolygonOperations pop = new FastPolygonOperations(p);
+
+    GeometryFactory gf = new GeometryFactory();
+
+    assertEquals(
+        pop.intersection(gf.createPoint((Coordinate) null)),
+        gf.createPoint((Coordinate) null)
+    );
+  }
+
+  @Test
+  public void testNullGeometryPolygon() {
+    Polygon p = FastPointInPolygonTest.createPolygon();
+    FastPolygonOperations pop = new FastPolygonOperations(p);
+
+    GeometryFactory gf = new GeometryFactory();
+
+    assertEquals(
+        pop.intersection((Polygon) null),
+        null
+    );
+  }
+}


### PR DESCRIPTION
The oshdb uses empty geometry objects to represent "error" cases such as an osm way with zero nodes (which can result from bugged edits in early versions of the OSM API, or data redactions). Because empty geometries don't return a proper envelope, the `intersects` method can crash with null pointer exceptions in these cases.