### PR TITLE
improve parallelization in localPeek backend

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -17,7 +17,6 @@ import java.util.Spliterators;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.ignite.Ignite;


### PR DESCRIPTION
Sadly, #56 had some negative side effects regarding performance: Because the top-most stream in the pipeline was a super short one (i.e. max. 3 entries for the different osm types), the java stream implementation never parallelizes it, even though the `flatMap` step adds many many entries to the stream (at least in OpenJDK 8 – see https://stackoverflow.com/a/25706806/1627467). Also, the way the `cellIds` were distributed to the different threads was not optimal: A single thread was likely to receive a large portion of the typically large low zoom level cells (that's why the initial implementation had the
[`Collections.shuffle(localKeys);`](https://github.com/GIScience/oshdb/pull/56/files/d4a62091a5ae53a754cfc91c368b042c94c4b6a5#diff-2f3781c256730a1206a3368a569b94f6L249) in there).

Here's an improved solution (based on the idea by @rtroilo in the [original PR](https://github.com/GIScience/oshdb/pull/56#discussion_r249383013)):

* the stream is now based on an iterator which uses an internal buffer of 1 million cell ids
* these are shuffeled to ensure that no thread has too many large cells to work through
* then distributed accross threads using a parallel java stream
* for now, it also removes the initial [`igniteNode.affinity.mapKeysToNodes`](https://github.com/GIScience/oshdb/pull/56/files/d4a62091a5ae53a754cfc91c368b042c94c4b6a5#diff-2f3781c256730a1206a3368a569b94f6L244) "filtering" step (and just perform `localPeek` on all potential cell ids anyway), because it doesn't seem to make much of a difference (if anything, queries are a bit slower because of the increased amount of sequential code) and just adds unnecessary complexity to the code.