### PR TITLE
improved splitting of "large" snapshot and contribution objects

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/GeometrySplitter.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/GeometrySplitter.java
@@ -77,7 +77,7 @@ class GeometrySplitter<U extends Comparable<U>> implements Serializable {
             return Stream.of(new ImmutablePair<>(index, data));
           }
 
-          // now we need to check against the actual snapshot geometry
+          // now we can check against the actual contribution geometry
           Geometry snapshotGeometry = data.getGeometry();
           OSHDBBoundingBox snapshotBbox = OSHDBGeometryBuilder.boundingBoxOf(
               snapshotGeometry.getEnvelopeInternal()
@@ -138,7 +138,7 @@ class GeometrySplitter<U extends Comparable<U>> implements Serializable {
             return Stream.of(new ImmutablePair<>(index, data));
           }
 
-          // now we need to check against the actual snapshot geometry
+          // now we can check against the actual contribution geometry
           Geometry contributionGeometryBefore = data.getGeometryBefore();
           Geometry contributionGeometryAfter = data.getGeometryAfter();
           OSHDBBoundingBox contributionGeometryBbox;

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/GeometrySplitter.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/GeometrySplitter.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
+import org.heigit.bigspatialdata.oshdb.util.celliterator.ContributionType;
 import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.bigspatialdata.oshdb.util.geometry.fip.FastBboxInPolygon;
 import org.heigit.bigspatialdata.oshdb.util.geometry.fip.FastBboxOutsidePolygon;
@@ -78,16 +79,16 @@ class GeometrySplitter<U extends Comparable<U>> implements Serializable {
 
           // now we need to check against the actual snapshot geometry
           Geometry snapshotGeometry = data.getGeometry();
-          OSHDBBoundingBox osmEntityBbox = OSHDBGeometryBuilder.boundingBoxOf(
+          OSHDBBoundingBox snapshotBbox = OSHDBGeometryBuilder.boundingBoxOf(
               snapshotGeometry.getEnvelopeInternal()
           );
 
           // OSM entity fully outside -> skip
-          if (bops.get(index).test(osmEntityBbox)) {
+          if (bops.get(index).test(snapshotBbox)) {
             return Stream.empty();
           }
           // OSM entity fully inside -> directly return
-          if (bips.get(index).test(osmEntityBbox)) {
+          if (bips.get(index).test(snapshotBbox)) {
             return Stream.of(new ImmutablePair<>(index, data));
           }
 
@@ -129,15 +130,48 @@ class GeometrySplitter<U extends Comparable<U>> implements Serializable {
         OSHDBGeometryBuilder.getGeometry(oshBoundingBox).getEnvelopeInternal()
     );
     return candidates.stream()
-        .filter(index -> !bops.get(index).test(oshBoundingBox)) // fully outside -> skip
+        // OSH entity fully outside -> skip
+        .filter(index -> !bops.get(index).test(oshBoundingBox))
         .flatMap(index -> {
+          // OSH entity fully inside -> directly return
           if (bips.get(index).test(oshBoundingBox)) {
-            return Stream.of(new ImmutablePair<>(index, data)); // fully inside -> directly return
+            return Stream.of(new ImmutablePair<>(index, data));
           }
+
+          // now we need to check against the actual snapshot geometry
+          Geometry contributionGeometryBefore = data.getGeometryBefore();
+          Geometry contributionGeometryAfter = data.getGeometryAfter();
+          OSHDBBoundingBox contributionGeometryBbox;
+          if (data.is(ContributionType.CREATION)) {
+            contributionGeometryBbox = OSHDBGeometryBuilder.boundingBoxOf(
+                contributionGeometryAfter.getEnvelopeInternal()
+            );
+          } else if (data.is(ContributionType.DELETION)) {
+            contributionGeometryBbox = OSHDBGeometryBuilder.boundingBoxOf(
+                contributionGeometryBefore.getEnvelopeInternal()
+            );
+          } else {
+            contributionGeometryBbox = OSHDBGeometryBuilder.boundingBoxOf(
+                contributionGeometryBefore.getEnvelopeInternal()
+            );
+            contributionGeometryBbox.add(OSHDBGeometryBuilder.boundingBoxOf(
+                contributionGeometryAfter.getEnvelopeInternal()
+            ));
+          }
+
+          // contribution fully outside -> skip
+          if (bops.get(index).test(contributionGeometryBbox)) {
+            return Stream.empty();
+          }
+          // contribution fully inside -> directly return
+          if (bips.get(index).test(contributionGeometryBbox)) {
+            return Stream.of(new ImmutablePair<>(index, data));
+          }
+
           FastPolygonOperations poop = poops.get(index);
           try {
-            Geometry intersectionBefore = poop.intersection(data.getGeometryBefore());
-            Geometry intersectionAfter = poop.intersection(data.getGeometryAfter());
+            Geometry intersectionBefore = poop.intersection(contributionGeometryBefore);
+            Geometry intersectionAfter = poop.intersection(contributionGeometryAfter);
             if ((intersectionBefore == null || intersectionBefore.isEmpty())
                 && (intersectionAfter == null || intersectionAfter.isEmpty())) {
               return Stream.empty(); // not actually intersecting -> skip


### PR DESCRIPTION
Sometimes one has to deal with OSH entities with a large extent (e.g. when one of its nodes was moved across the globe by mistake). In such cases, the geometry was intersected with a potentially large number of `subregions`. However, if the consisting geometries are small, one can often skip most of these intersect operations at the expense of a few additional (fast and cheap) _fast polygon_ tests (which are already available at that point anyway).