### PR TITLE
More robust building of polygon geometries from bboxes

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -229,29 +229,29 @@ public class OSHDBGeometryBuilder {
         boolean joinable = false;
         for (int i = 0; i < ways.size(); i++) {
           List<OSMNode> what = ways.get(i);
-          if (lastId == what.get(0).getId()) { // end of partial ring matches to start of current
-                                               // line
+          if (lastId == what.get(0).getId()) {
+            // end of partial ring matches to start of current line
             what.remove(0);
             current.addAll(what);
             ways.remove(i);
             joinable = true;
             break;
-          } else if (firstId == what.get(what.size() - 1).getId()) { // start of partial ring
-                                                                     // matches end of current line
+          } else if (firstId == what.get(what.size() - 1).getId()) {
+            // start of partial ring matches end of current line
             what.remove(what.size() - 1);
             current.addAll(0, what);
             ways.remove(i);
             joinable = true;
             break;
-          } else if (lastId == what.get(what.size() - 1).getId()) { // end of partial ring matches
-                                                                    // end of current line
+          } else if (lastId == what.get(what.size() - 1).getId()) {
+            // end of partial ring matches end of current line
             what.remove(what.size() - 1);
             current.addAll(Lists.reverse(what));
             ways.remove(i);
             joinable = true;
             break;
-          } else if (firstId == what.get(0).getId()) { // start of partial ring matches start of
-                                                       // current line
+          } else if (firstId == what.get(0).getId()) {
+            // start of partial ring matches start of current line
             what.remove(0);
             current.addAll(0, Lists.reverse(what));
             ways.remove(i);
@@ -282,12 +282,16 @@ public class OSHDBGeometryBuilder {
   }
   
   /**
-   * Create the Geometry of an OSHDBBoundingBox. Will return a polygon with exactly 4 vertices even
-   * for point or line-like BoundingBox. Nevertheless the result might not pass the 
-   * {@link com.vividsolutions.jts.geom.Geometry#isRectangle() Geometry.isRectangle} test.
+   * Converts a OSHDBBoundingBox to a rectangular polygon.
+   *
+   * <p>
+   * Will return a polygon with exactly 4 vertices even for point or line-like BoundingBox.
+   * Nevertheless, for degenerate bounding boxes (width and/or height of 0) the result might
+   * not pass the {@link Geometry#isRectangle() Geometry.isRectangle} test.
+   * </p>
    *
    * @param bbox The BoundingBox the polygon should be created for.
-   * @return com.vividsolutions.jts.geom.Geometry Returns a Polygon for convenience.
+   * @return a rectangular Polygon
    */
   public static Polygon getGeometry(OSHDBBoundingBox bbox) {
     assert bbox != null : "a bounding box is not allowed to be null";
@@ -304,8 +308,8 @@ public class OSHDBGeometryBuilder {
     return gf.createPolygon(cordAr);
   }
   
- public static OSHDBBoundingBox boundingBoxOf(Envelope envelope){
-   return new OSHDBBoundingBox(envelope.getMinX(), envelope.getMinY(), envelope.getMaxX(), envelope.getMaxY());
- }
+  public static OSHDBBoundingBox boundingBoxOf(Envelope envelope){
+    return new OSHDBBoundingBox(envelope.getMinX(), envelope.getMinY(), envelope.getMaxX(), envelope.getMaxY());
+  }
 
 }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -279,24 +279,31 @@ public class OSHDBGeometryBuilder {
       T entity, OSHDBTimestamp timestamp, TagInterpreter areaDecider, P clipPoly) {
     Geometry geom = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     return Geo.clip(geom, clipPoly);
+  } 
+  
+  /**
+   * Create the Geometry of an OSHDBBoundingBox. Will always contain 5 Coordinates, even for
+   * point-like bbx -> point-like polygons for bbx of a Point.
+   *
+   * @param bbox The BoundingBox the polygon should be created for.
+   * @return com.vividsolutions.jts.geom.Geometry Returns JTS geometry object for convenience.
+   * Result is an empty polygon for a null BBX.
+   */
+  public static Polygon getGeometry(OSHDBBoundingBox bbox) {
+    GeometryFactory gf = new GeometryFactory();
+    if (bbox == null) {
+      return gf.createPolygon((LinearRing) null);
+    }
+    Coordinate sw = new Coordinate(bbox.getMinLon(), bbox.getMinLat());
+    Coordinate se = new Coordinate(bbox.getMaxLon(), bbox.getMinLat());
+    Coordinate nw = new Coordinate(bbox.getMaxLon(), bbox.getMaxLat());
+    Coordinate ne = new Coordinate(bbox.getMinLon(), bbox.getMaxLat());
+
+    Coordinate[] cordAr = {sw, se, nw, ne, sw};
+
+    return gf.createPolygon(cordAr);
   }
   
- 
- /**
-  * returns JTS geometry object for convenience
-  *
-  * @return com.vividsolutions.jts.geom.Geometry
-  */
- public static Polygon getGeometry(OSHDBBoundingBox bbox) {
-   GeometryFactory gf = new GeometryFactory();
-   Geometry g = gf.toGeometry(new Envelope(bbox.getMinLon(), bbox.getMaxLon(), bbox.getMinLat(), bbox.getMaxLat()));
-   if (g instanceof Polygon)
-     return (Polygon) g;
-   else
-    return gf.createPolygon((LinearRing) null);
- }
- 
- 
  public static OSHDBBoundingBox boundingBoxOf(Envelope envelope){
    return new OSHDBBoundingBox(envelope.getMinX(), envelope.getMinY(), envelope.getMaxX(), envelope.getMaxY());
  }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -279,21 +279,21 @@ public class OSHDBGeometryBuilder {
       T entity, OSHDBTimestamp timestamp, TagInterpreter areaDecider, P clipPoly) {
     Geometry geom = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     return Geo.clip(geom, clipPoly);
-  } 
+  }
   
   /**
-   * Create the Geometry of an OSHDBBoundingBox. Will always contain 5 Coordinates, even for
-   * point-like bbx -> point-like polygons for bbx of a Point.
+   * Create the Geometry of an OSHDBBoundingBox. Will return a polygon with exactly 4 vertices even
+   * for point or line-like BoundingBox. Nevertheless the result might not pass the 
+   * {@link com.vividsolutions.jts.geom.Geometry#isRectangle() Geometry.isRectangle} test.
    *
    * @param bbox The BoundingBox the polygon should be created for.
-   * @return com.vividsolutions.jts.geom.Geometry Returns JTS geometry object for convenience.
-   * Result is an empty polygon for a null BBX.
+   * @return com.vividsolutions.jts.geom.Geometry Returns a Polygon for convenience.
    */
   public static Polygon getGeometry(OSHDBBoundingBox bbox) {
+    assert bbox != null : "a bounding box is not allowed to be null";
+    
     GeometryFactory gf = new GeometryFactory();
-    if (bbox == null) {
-      return gf.createPolygon((LinearRing) null);
-    }
+        
     Coordinate sw = new Coordinate(bbox.getMinLon(), bbox.getMinLat());
     Coordinate se = new Coordinate(bbox.getMaxLon(), bbox.getMinLat());
     Coordinate nw = new Coordinate(bbox.getMaxLon(), bbox.getMaxLat());

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -19,6 +19,7 @@ import org.heigit.bigspatialdata.oshdb.util.tagInterpreter.TagInterpreter;
 import org.heigit.bigspatialdata.oshdb.util.test.OSMXmlReader;
 import org.heigit.bigspatialdata.oshdb.util.time.ISODateTimeParser;
 import org.junit.Test;
+import org.junit.Assert;
 
 public class OSHDBGeometryBuilderTest {
   private OSMXmlReader testData = new OSMXmlReader();

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -9,19 +9,16 @@ import org.heigit.bigspatialdata.oshdb.osm.OSMMember;
 import org.heigit.bigspatialdata.oshdb.osm.OSMRelation;
 import org.heigit.bigspatialdata.oshdb.osm.OSMWay;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
-
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import org.heigit.bigspatialdata.oshdb.util.tagInterpreter.TagInterpreter;
 import org.heigit.bigspatialdata.oshdb.util.test.OSMXmlReader;
 import org.heigit.bigspatialdata.oshdb.util.time.ISODateTimeParser;
-import org.junit.Test;
+
 import org.junit.Assert;
-import org.junit.Rule;
-import org.junit.rules.ExpectedException;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 public class OSHDBGeometryBuilderTest {
   private OSMXmlReader testData = new OSMXmlReader();
@@ -40,10 +37,6 @@ public class OSHDBGeometryBuilderTest {
       return null;
     }
   }
-  
-  @Rule
-  public final ExpectedException exception = ExpectedException.none();
-
   @Test
   public void testPointGetGeometry() {
     OSMEntity entity = testData.nodes().get(1L).get(1);
@@ -170,25 +163,27 @@ public class OSHDBGeometryBuilderTest {
   
   @Test
   public void testBoundingBoxGetGeometry() {
+    // regular bbox
     OSHDBBoundingBox bbox = new OSHDBBoundingBox(0, 0, 1, 1);
     Polygon geometry = OSHDBGeometryBuilder.getGeometry(bbox);
-    Coordinate[] test = {new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1), new Coordinate(0, 1), new Coordinate(0, 0)};
+    Coordinate[] test = { new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1),
+        new Coordinate(0, 1), new Coordinate(0, 0) };
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
+    // degenerate bbox: point
     bbox = new OSHDBBoundingBox(0, 0, 0, 0);
     geometry = OSHDBGeometryBuilder.getGeometry(bbox);
-    test = new Coordinate[]{new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0)};
+    test = new Coordinate[] { new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0),
+        new Coordinate(0, 0), new Coordinate(0, 0) };
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
+    // degenerate bbox: line
     bbox = new OSHDBBoundingBox(0, 0, 0, 1);
     geometry = OSHDBGeometryBuilder.getGeometry(bbox);
-    test = new Coordinate[]{new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 1), new Coordinate(0, 1), new Coordinate(0, 0)};
+    test = new Coordinate[]{new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 1),
+        new Coordinate(0, 1), new Coordinate(0, 0) };
     Assert.assertArrayEquals(test, geometry.getCoordinates());
-
-    bbox = null;
-    exception.expect(AssertionError.class);
-    OSHDBGeometryBuilder.getGeometry(bbox);
-  }  
+  }
 }
 
 

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -20,6 +20,8 @@ import org.heigit.bigspatialdata.oshdb.util.test.OSMXmlReader;
 import org.heigit.bigspatialdata.oshdb.util.time.ISODateTimeParser;
 import org.junit.Test;
 import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 public class OSHDBGeometryBuilderTest {
   private OSMXmlReader testData = new OSMXmlReader();
@@ -38,6 +40,9 @@ public class OSHDBGeometryBuilderTest {
       return null;
     }
   }
+  
+  @Rule
+  public final ExpectedException exception = ExpectedException.none();
 
   @Test
   public void testPointGetGeometry() {
@@ -165,24 +170,24 @@ public class OSHDBGeometryBuilderTest {
   
   @Test
   public void testBoundingBoxGetGeometry() {
-    OSHDBBoundingBox bbx = new OSHDBBoundingBox(0, 0, 0, 0);
-    Polygon geometry = OSHDBGeometryBuilder.getGeometry(bbx);
-    Coordinate[] test = {new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0)};
+    OSHDBBoundingBox bbox = new OSHDBBoundingBox(0, 0, 1, 1);
+    Polygon geometry = OSHDBGeometryBuilder.getGeometry(bbox);
+    Coordinate[] test = {new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1), new Coordinate(0, 1), new Coordinate(0, 0)};
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
-    bbx = new OSHDBBoundingBox(0, 0, 1, 1);
-    geometry = OSHDBGeometryBuilder.getGeometry(bbx);
-    test = new Coordinate[]{new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1), new Coordinate(0, 1), new Coordinate(0, 0)};
+    bbox = new OSHDBBoundingBox(0, 0, 0, 0);
+    geometry = OSHDBGeometryBuilder.getGeometry(bbox);
+    test = new Coordinate[]{new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0)};
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
-    bbx = new OSHDBBoundingBox(0, 0, 0, 1);
-    geometry = OSHDBGeometryBuilder.getGeometry(bbx);
+    bbox = new OSHDBBoundingBox(0, 0, 0, 1);
+    geometry = OSHDBGeometryBuilder.getGeometry(bbox);
     test = new Coordinate[]{new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 1), new Coordinate(0, 1), new Coordinate(0, 0)};
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
-    bbx = null;
-    geometry = OSHDBGeometryBuilder.getGeometry(bbx);
-    assertEquals(true, geometry.isEmpty());
+    bbox = null;
+    exception.expect(AssertionError.class);
+    OSHDBGeometryBuilder.getGeometry(bbox);
   }  
 }
 

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -1,5 +1,6 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry;
 
+import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.Point;
 import com.vividsolutions.jts.geom.Polygon;

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -160,6 +160,28 @@ public class OSHDBGeometryBuilderTest {
     assertEquals("GeometryCollection", result.getGeometryType());
     assertEquals(1, result.getNumGeometries());
   }
+  
+  @Test
+  public void testBoundingBoxGetGeometry() {
+    OSHDBBoundingBox bbx = new OSHDBBoundingBox(0, 0, 0, 0);
+    Polygon geometry = OSHDBGeometryBuilder.getGeometry(bbx);
+    Coordinate[] test = {new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 0)};
+    Assert.assertArrayEquals(test, geometry.getCoordinates());
+
+    bbx = new OSHDBBoundingBox(0, 0, 1, 1);
+    geometry = OSHDBGeometryBuilder.getGeometry(bbx);
+    test = new Coordinate[]{new Coordinate(0, 0), new Coordinate(1, 0), new Coordinate(1, 1), new Coordinate(0, 1), new Coordinate(0, 0)};
+    Assert.assertArrayEquals(test, geometry.getCoordinates());
+
+    bbx = new OSHDBBoundingBox(0, 0, 0, 1);
+    geometry = OSHDBGeometryBuilder.getGeometry(bbx);
+    test = new Coordinate[]{new Coordinate(0, 0), new Coordinate(0, 0), new Coordinate(0, 1), new Coordinate(0, 1), new Coordinate(0, 0)};
+    Assert.assertArrayEquals(test, geometry.getCoordinates());
+
+    bbx = null;
+    geometry = OSHDBGeometryBuilder.getGeometry(bbx);
+    assertEquals(true, geometry.isEmpty());
+  }  
 }
 
 


### PR DESCRIPTION
OSHDBGeometryBuilder was returning empty Geometry for a point-like Bounding-Box. Now we force rectangle-like polygons.