### PR TITLE
Jenkins: Check for updated Dependencies once a month

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,56 +160,55 @@ pipeline {
         scipt{
           dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates').trim()
         }
-        rocketSend channel: 'jenkinsohsome', message: "!!!!! This is your monthly notice that the following dependencies need update: ${dependenciesU}" , rawMessage: true
-      }
-      post {
-        failure {
-          rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Checking for updates in oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
-        }
-      }
-    }
-
-
-
-    stage ('Encourage') {
-      when {
-        expression {
-          if(currentBuild.number > 1){
-            datepre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis()).clearTime()
-            echo datepre.format( 'yyyyMMdd' )
-            datenow=new Date(currentBuild.rawBuild.getStartTimeInMillis()).clearTime()
-            echo datenow.format( 'yyyyMMdd' )
-            return datepre.numberAwareCompareTo(datenow)<0
+        post {
+          failure {
+            rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Checking for updates in oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
           }
-          return false
         }
       }
-      steps {
-        rocketSend channel: 'jenkinsohsome', message: "Hey, this is just your daily notice that Jenkins is still working for you on OSHDB-Branch ${env.BRANCH_NAME}! Happy and for free! Keep it up!" , rawMessage: true
-      }
-      post {
-        failure {
-          rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Reporting of oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
+
+
+
+      stage ('Encourage') {
+        when {
+          expression {
+            if(currentBuild.number > 1){
+              datepre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis()).clearTime()
+              echo datepre.format( 'yyyyMMdd' )
+              datenow=new Date(currentBuild.rawBuild.getStartTimeInMillis()).clearTime()
+              echo datenow.format( 'yyyyMMdd' )
+              return datepre.numberAwareCompareTo(datenow)<0
+            }
+            return false
+          }
+        }
+        steps {
+          rocketSend channel: 'jenkinsohsome', message: "Hey, this is just your daily notice that Jenkins is still working for you on OSHDB-Branch ${env.BRANCH_NAME}! Happy and for free! Keep it up!" , rawMessage: true
+        }
+        post {
+          failure {
+            rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Reporting of oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
+          }
         }
       }
+
+      stage ('Report Status Change'){
+        when {
+          expression {
+            return ((currentBuild.number > 1) && (currentBuild.getPreviousBuild().result == 'FAILURE'))
+          }
+        }
+        steps {
+          rocketSend channel: 'jenkinsohsome', message: "We had some problems, but we are BACK TO NORMAL! Nice debugging: oshdb-build-nr. ${env.BUILD_NUMBER} *succeeded* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
+        }
+        post {
+          failure {
+            rocketSend channel: 'jenkinsohsome', message: "Reporting of oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
+          }
+        }
+
+      }
+
     }
-
-    stage ('Report Status Change'){
-      when {
-        expression {
-          return ((currentBuild.number > 1) && (currentBuild.getPreviousBuild().result == 'FAILURE'))
-        }
-      }
-      steps {
-        rocketSend channel: 'jenkinsohsome', message: "We had some problems, but we are BACK TO NORMAL! Nice debugging: oshdb-build-nr. ${env.BUILD_NUMBER} *succeeded* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
-      }
-      post {
-        failure {
-          rocketSend channel: 'jenkinsohsome', message: "Reporting of oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
-        }
-      }
-
-    }
-
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
       }
       steps {
         scipt{
-          dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "(\\?s)The following dependencies.*\'\n\'.* \'\n\'"').trim()
+          dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "\\(\\?s\\)The following dependencies.*\'\n\'.* \'\n\'"').trim()
         }
         rocketSend channel: 'jenkinsohsome', message: "!!!!! This is your monthly notice that the following dependencies need update: ${dependenciesU}" , rawMessage: true
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,6 @@ pipeline {
       }
       steps {
         scipt{
-          dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates').trim()
         }
       }
       post {
@@ -191,7 +190,6 @@ pipeline {
         }
       }
     }
-      
 
     stage ('Report Status Change'){
       when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
           updatenotify=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "(?s)The following dependencies.*\\n.* \\n"').trim()
           echo updatenotify
         }
-        rocketSend channel: 'jenkinsohsome', emoji: ':wave:' , message: "!!! This is your monthly notice! You might have updates in your dependecies. @admin check this: ${updatenotify}" , rawMessage: true
+        rocketSend channel: 'jenkinsohsome', emoji: ':wave:' , message: "You might have updates in your dependecies: ${updatenotify}" , rawMessage: true
       }
       post {
         failure {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -27,14 +27,14 @@ pipeline {
           buildInfo = rtMaven.run pom: 'pom.xml', goals: 'clean compile javadoc:jar source:jar install -P git -Dmaven.repo.local=.m2'
         }
       }
-      post{
+      post {
         failure {
           rocketSend channel: 'jenkinsohsome', emoji: ':sob:' , message: "oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}. Review the code!" , rawMessage: true
         }
       }
     }
 
-    stage ('Deploy'){
+    stage ('Deploy') {
       when {
         expression {
           return env.BRANCH_NAME ==~ /(^[0-9]+$)|(^(([0-9]+)(\.))+([0-9]+)?$)|(^master$)/
@@ -69,14 +69,14 @@ pipeline {
       }
     }
 
-    stage ('Publish Javadoc'){
+    stage ('Publish Javadoc') {
       when {
         expression {
           return env.BRANCH_NAME ==~ /(^[0-9]+$)|(^(([0-9]+)(\.))+([0-9]+)?$)|(^master$)/
         }
       }
       steps {
-        script{
+        script {
           //load dependencies to artifactory
           rtMaven.run pom: 'pom.xml', goals: 'org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version -Dmaven.repo.local=.m2'
           projver=sh(returnStdout: true, script: 'mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev "(^\\[|Download\\w+)"').trim()
@@ -84,15 +84,13 @@ pipeline {
           javadc_dir="/srv/javadoc/java/" + reponame + "/" + projver + "/"
           echo javadc_dir
 
-
           rtMaven.run pom: 'pom.xml', goals: 'clean javadoc:javadoc -Dadditionalparam=-Xdoclint:none -Dmaven.repo.local=.m2'
           sh "echo $javadc_dir"
           //make sure jenkins uses bash not dash!
           sh "mkdir -p $javadc_dir && rm -Rf $javadc_dir* && find . -path '*/target/site/apidocs' -exec cp -R --parents {} $javadc_dir \\; && find $javadc_dir -path '*/target/site/apidocs' | while read line; do echo \$line; neu=\${line/target\\/site\\/apidocs/} ;  mv \$line/* \$neu ; done && find $javadc_dir -type d -empty -delete"
         }
 
-        script{
-
+        script {
           javadc_dir=javadc_dir + "aggregated/"
           rtMaven.run pom: 'pom.xml', goals: 'clean javadoc:aggregate -Dadditionalparam=-Xdoclint:none -Dmaven.repo.local=.m2'
           sh "mkdir -p $javadc_dir && rm -Rf $javadc_dir* && find . -path './target/site/apidocs' -exec cp -R --parents {} $javadc_dir \\; && find $javadc_dir -path '*/target/site/apidocs' | while read line; do echo \$line; neu=\${line/target\\/site\\/apidocs/} ;  mv \$line/* \$neu ; done && find $javadc_dir -type d -empty -delete"
@@ -105,9 +103,9 @@ pipeline {
       }
     }
 
-    stage ('Reports and Statistics'){
+    stage ('Reports and Statistics') {
       steps {
-        script{
+        script {
           projver=sh(returnStdout: true, script: 'mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev "(^\\[|Download\\w+)"').trim()
 
           //jacoco
@@ -117,7 +115,7 @@ pipeline {
           sh "mkdir -p $report_dir && rm -Rf $report_dir* && find . -path '*/target/site/jacoco' -exec cp -R --parents {} $report_dir \\; && find $report_dir -path '*/target/site/jacoco' | while read line; do echo \$line; neu=\${line/target\\/site\\/jacoco/} ;  mv \$line/* \$neu ; done && find $report_dir -type d -empty -delete"
 
           //infer
-          if(env.BRANCH_NAME ==~ /(^master$)/){
+          if(env.BRANCH_NAME ==~ /(^master$)/) {
             report_dir="/srv/reports/" + reponame + "/" + projver + "_"  + env.BRANCH_NAME + "/" +  env.BUILD_NUMBER + "_" +gittiid+"/infer/"
             sh "mvn clean"
             sh "infer run -r -- mvn compile"
@@ -133,7 +131,6 @@ pipeline {
           recordIssues enabledForFailure: true, tool: spotBugs()
           recordIssues enabledForFailure: true, tool: cpd(pattern: '**/target/cpd.xml')
           recordIssues enabledForFailure: true, tool: pmd(pattern: '**/target/pmd.xml')
-
         }
       }
       post {
@@ -146,7 +143,7 @@ pipeline {
     stage ('Check Dependencies') {
       when {
         expression {
-          if(currentBuild.number > 1){
+          if(currentBuild.number > 1) {
             monthpre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
             echo monthpre.toString()
             monthnow=new Date(currentBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
@@ -157,7 +154,7 @@ pipeline {
         }
       }
       steps {
-        script{
+        script {
           updatenotify=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "(?s)The following dependencies.*\\n.* \\n"').trim()
           echo updatenotify
         }
@@ -174,7 +171,7 @@ pipeline {
     stage ('Encourage') {
       when {
         expression {
-          if(currentBuild.number > 1){
+          if(currentBuild.number > 1) {
             datepre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis()).clearTime()
             echo datepre.format( 'yyyyMMdd' )
             datenow=new Date(currentBuild.rawBuild.getStartTimeInMillis()).clearTime()
@@ -194,7 +191,7 @@ pipeline {
       }
     }
 
-    stage ('Report Status Change'){
+    stage ('Report Status Change') {
       when {
         expression {
           return ((currentBuild.number > 1) && (currentBuild.getPreviousBuild().result == 'FAILURE'))

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
       }
       steps {
         scipt{
-          dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "(?s)The following dependencies.*\n.* \n"').trim()
+          dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "(\\?s)The following dependencies.*\'\n\'.* \'\n\'"').trim()
         }
         rocketSend channel: 'jenkinsohsome', message: "!!!!! This is your monthly notice that the following dependencies need update: ${dependenciesU}" , rawMessage: true
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -157,7 +157,7 @@ pipeline {
         }
       }
       steps {
-        scipt{
+        script{
           updatenotify=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates').trim()
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -143,7 +143,7 @@ pipeline {
       }
     }
     
-    stage ('CheckDependencies') {
+    stage ('Check Dependencies') {
       when {
         expression {
           if(currentBuild.number > 1){
@@ -158,6 +158,7 @@ pipeline {
       }
       steps {
         scipt{
+          updatenotify=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates').trim()
         }
       }
       post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,18 +144,24 @@ pipeline {
     }
     
     stage ('Check Dependencies') {
+      when {
+        expression {
+          if(currentBuild.number > 1){
+            monthpre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
+            echo monthpre.toString()
+            monthnow=new Date(currentBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
+            echo monthnow.toString()
+            return monthpre!=monthnow
+          }
+          return false
+        }
+      }
       steps {
         script{
-          
-          monthpre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
-          echo monthpre+1.toString()
-          monthnow=new Date(currentBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
-          echo monthnow+1.toString()
-          
           updatenotify=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "(?s)The following dependencies.*\\n.* \\n"').trim()
           echo updatenotify
         }
-        rocketSend channel: 'jenkinsohsome', emoji: ':wave:' , message: "!!! This is your monthly notice! You might have updates in your dependecies. @rtroilo check this: ${updatenotify}" , rawMessage: true
+        rocketSend channel: 'jenkinsohsome', emoji: ':wave:' , message: "!!! This is your monthly notice! You might have updates in your dependecies. @admin check this: ${updatenotify}" , rawMessage: true
       }
       post {
         failure {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -144,27 +144,22 @@ pipeline {
     }
     
     stage ('Check Dependencies') {
-      when {
-        expression {
-          if(currentBuild.number > 1){
-            monthpre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
-            echo monthpre.toString()
-            monthnow=new Date(currentBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
-            echo monthnow.toString()
-            return monthpre!=monthnow
-          }
-          return false
-        }
-      }
       steps {
         script{
-          updatenotify=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates').trim()
+          
+          monthpre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
+          echo monthpre+1.toString()
+          monthnow=new Date(currentBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
+          echo monthnow+1.toString()
+          
+          updatenotify=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "(?s)The following dependencies.*\\n.* \\n"').trim()
           echo updatenotify
         }
+        rocketSend channel: 'jenkinsohsome', emoji: ':wave:' , message: "!!! This is your monthly notice! You might have updates in your dependecies. @rtroilo check this: ${updatenotify}" , rawMessage: true
       }
       post {
         failure {
-          rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Checking for updates in oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
+          rocketSend channel: 'jenkinsohsome', emoji: ':disappointed:' , message: "Checking for updates in oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,49 +166,47 @@ pipeline {
           }
         }
       }
+    }
 
 
-
-      stage ('Encourage') {
-        when {
-          expression {
-            if(currentBuild.number > 1){
-              datepre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis()).clearTime()
-              echo datepre.format( 'yyyyMMdd' )
-              datenow=new Date(currentBuild.rawBuild.getStartTimeInMillis()).clearTime()
-              echo datenow.format( 'yyyyMMdd' )
-              return datepre.numberAwareCompareTo(datenow)<0
-            }
-            return false
+    stage ('Encourage') {
+      when {
+        expression {
+          if(currentBuild.number > 1){
+            datepre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis()).clearTime()
+            echo datepre.format( 'yyyyMMdd' )
+            datenow=new Date(currentBuild.rawBuild.getStartTimeInMillis()).clearTime()
+            echo datenow.format( 'yyyyMMdd' )
+            return datepre.numberAwareCompareTo(datenow)<0
           }
-        }
-        steps {
-          rocketSend channel: 'jenkinsohsome', message: "Hey, this is just your daily notice that Jenkins is still working for you on OSHDB-Branch ${env.BRANCH_NAME}! Happy and for free! Keep it up!" , rawMessage: true
-        }
-        post {
-          failure {
-            rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Reporting of oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
-          }
+          return false
         }
       }
-
-      stage ('Report Status Change'){
-        when {
-          expression {
-            return ((currentBuild.number > 1) && (currentBuild.getPreviousBuild().result == 'FAILURE'))
-          }
-        }
-        steps {
-          rocketSend channel: 'jenkinsohsome', message: "We had some problems, but we are BACK TO NORMAL! Nice debugging: oshdb-build-nr. ${env.BUILD_NUMBER} *succeeded* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
-        }
-        post {
-          failure {
-            rocketSend channel: 'jenkinsohsome', message: "Reporting of oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
-          }
-        }
-
+      steps {
+        rocketSend channel: 'jenkinsohsome', message: "Hey, this is just your daily notice that Jenkins is still working for you on OSHDB-Branch ${env.BRANCH_NAME}! Happy and for free! Keep it up!" , rawMessage: true
       }
+      post {
+        failure {
+          rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Reporting of oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
+        }
+      }
+    }
+      
 
+    stage ('Report Status Change'){
+      when {
+        expression {
+          return ((currentBuild.number > 1) && (currentBuild.getPreviousBuild().result == 'FAILURE'))
+        }
+      }
+      steps {
+        rocketSend channel: 'jenkinsohsome', message: "We had some problems, but we are BACK TO NORMAL! Nice debugging: oshdb-build-nr. ${env.BUILD_NUMBER} *succeeded* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
+      }
+      post {
+        failure {
+          rocketSend channel: 'jenkinsohsome', message: "Reporting of oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
+        }
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -158,7 +158,7 @@ pipeline {
       }
       steps {
         scipt{
-          dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates | grep -Pzo "\\(\\?s\\)The following dependencies.*\'\n\'.* \'\n\'"').trim()
+          dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates').trim()
         }
         rocketSend channel: 'jenkinsohsome', message: "!!!!! This is your monthly notice that the following dependencies need update: ${dependenciesU}" , rawMessage: true
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -148,9 +148,9 @@ pipeline {
         expression {
           if(currentBuild.number > 1){
             monthpre=new Date(currentBuild.previousBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
-            echo monthpre
+            echo monthpre.toString()
             monthnow=new Date(currentBuild.rawBuild.getStartTimeInMillis())[Calendar.MONTH]
-            echo monthnow
+            echo monthnow.toString()
             return monthpre!=monthnow
           }
           return false
@@ -159,6 +159,7 @@ pipeline {
       steps {
         script{
           updatenotify=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates').trim()
+          echo updatenotify
         }
       }
       post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,10 +160,10 @@ pipeline {
         scipt{
           dependenciesU=sh(returnStdout: true, script: 'mvn versions:display-dependency-updates').trim()
         }
-        post {
-          failure {
-            rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Checking for updates in oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
-          }
+      }
+      post {
+        failure {
+          rocketSend channel: 'jenkinsohsome', emoji: ':wink:' , message: "Checking for updates in oshdb-build nr. ${env.BUILD_NUMBER} *failed* on Branch - ${env.BRANCH_NAME}  (<${env.BUILD_URL}|Open Build in Jenkins>). Latest commit from  ${author}." , rawMessage: true
         }
       }
     }


### PR DESCRIPTION
These changes to the Jenkinsfile send a rocket-chat message once a month to the Jenkinschannel addressed to @admin with a list of dependencies with updates.

Pease squash-commit, jenkins and groovy always need a lot more commits then necessary. 

addresses https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/111