### PR TITLE
fix rounding of values in bbox constructor from doubles

### DIFF
--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/util/OSHDBBoundingBox.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/util/OSHDBBoundingBox.java
@@ -68,10 +68,10 @@ public class OSHDBBoundingBox implements Serializable {
   }
   
   public OSHDBBoundingBox(double minLon, double minLat, double maxLon, double maxLat) {
-    this.minLon = (long) (minLon * OSHDB.GEOM_PRECISION_TO_LONG);
-    this.maxLon = (long) (maxLon * OSHDB.GEOM_PRECISION_TO_LONG);
-    this.minLat = (long) (minLat * OSHDB.GEOM_PRECISION_TO_LONG);
-    this.maxLat = (long) (maxLat * OSHDB.GEOM_PRECISION_TO_LONG);
+    this.minLon = Math.round(minLon * OSHDB.GEOM_PRECISION_TO_LONG);
+    this.maxLon = Math.round(maxLon * OSHDB.GEOM_PRECISION_TO_LONG);
+    this.minLat = Math.round(minLat * OSHDB.GEOM_PRECISION_TO_LONG);
+    this.maxLat = Math.round(maxLat * OSHDB.GEOM_PRECISION_TO_LONG);
   }
 
   public OSHDBBoundingBox(int minLon, int minLat, int maxLon, int maxLat) {


### PR DESCRIPTION
previously, values that are not directly representable as a double floating point value were truncated at the given precision value, resulting in a sometimes rounded down (i.e. off by one) value. When such a bounding box is later used to clip geometries, the results were off by about one centimeter (when calculating lengths). Rounding produces the expected result.