### PR TITLE
make uniq work with null or other non-comparable objects

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -1935,7 +1935,7 @@ public abstract class MapReducer<X> implements
 
   @Contract(pure = true)
   static <T> Set<T> uniqCombiner(Set<T> a, Set<T> b) {
-    HashSet<T> result = new HashSet<>(a.size() + b.size());
+    HashSet<T> result = new HashSet<>((int) Math.ceil(Math.max(a.size(), b.size()) / 0.75));
     result.addAll(a);
     result.addAll(b);
     return result;

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -9,7 +9,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -1923,7 +1924,7 @@ public abstract class MapReducer<X> implements
 
   @Contract(pure = true)
   static <T> Set<T> uniqIdentitySupplier() {
-    return new TreeSet<>();
+    return new HashSet<>();
   }
 
   @Contract(pure = false)

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestHelpersOSMContributionView.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestHelpersOSMContributionView.java
@@ -231,16 +231,4 @@ public class TestHelpersOSMContributionView {
     assertEquals(result5.size(), 1);
   }
 
-  @Test
-  public void testIssue107() throws Exception {
-    // single timestamp
-    List<OSMContribution> result = this.createMapReducer()
-        .timestamps(timestamps72)
-        .collect();
-
-    assertEquals(true, result.get(0).getContributionTypes().contains(ContributionType.CREATION));
-    assertEquals(null, result.get(0).getEntityBefore());
-    assertEquals(null, result.get(0).getGeometryBefore());
-  }
-
 }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestHelpersOSMContributionView.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestHelpersOSMContributionView.java
@@ -6,6 +6,7 @@
 package org.heigit.bigspatialdata.oshdb.api.tests;
 
 import java.util.List;
+import java.util.TreeSet;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
 import org.heigit.bigspatialdata.oshdb.api.generic.WeightedValue;
@@ -221,6 +222,13 @@ public class TestHelpersOSMContributionView {
 
     assertEquals(21, result4.get(true).size());
     assertEquals(21, result4.get(false).size());
+
+    // doesn't crash with null pointers
+    Set<Object> result5 = this.createMapReducer()
+        .timestamps(timestamps2)
+        .map(x -> null)
+        .uniq();
+    assertEquals(result5.size(), 1);
   }
 
   @Test

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestHelpersOSMContributionView.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestHelpersOSMContributionView.java
@@ -1,12 +1,5 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.heigit.bigspatialdata.oshdb.api.tests;
 
-import java.util.List;
-import java.util.TreeSet;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
 import org.heigit.bigspatialdata.oshdb.api.generic.WeightedValue;


### PR DESCRIPTION
Closes #159.

If I remember correctly, the idea for using a `TreeSet` in the accumulation step here was to improve performance, because a tree can grow linearly while a hashmap can't (and we don't know the size of the result at that point). We should probably check if this has any performance impact (I suspect it won't).