### PR TITLE
Documentation pom descriptions

### DIFF
--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
-    <artifactId>bigspatialdata-core-parent</artifactId>
+    <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -11,7 +11,8 @@
   </parent>
 
   <artifactId>oshdb-api</artifactId>
-  <description>Functionallity of the Java-API.</description>
+  <name>OSHDB API</name>
+  <description>API to query the OpenStreetMap History Database. Includes MapReduce functionality to filter, analyze and aggregate data.</description>
 
   <dependencies>
     <dependency>

--- a/oshdb-tool/pom.xml
+++ b/oshdb-tool/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
-    <artifactId>bigspatialdata-core-parent</artifactId>
+    <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>

--- a/oshdb-tool/pom.xml
+++ b/oshdb-tool/pom.xml
@@ -11,7 +11,7 @@
   </parent>
 
   <artifactId>oshdb-tool</artifactId>
-  <name>oshdb-toolkit</name>
+  <name>OSHDB toolkit</name>
   <description>This is a toolkit that holds plug-in-like executable tools and their background. They are not directly a cornerstone of the core but hold some interesting tools you might want to check out!</description>
   <packaging>pom</packaging>
   

--- a/oshdb-util/pom.xml
+++ b/oshdb-util/pom.xml
@@ -6,8 +6,11 @@
     <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
   </parent>
+
   <artifactId>oshdb-util</artifactId>
-  <description>A collection of utilities that are helpers for an easy access to the raw-data or other computations.</description>
+  <name>OSHDB utilities</name>
+  <description>A collection of utilities for accessing to the OSHDB data and for performing computations on top of these.</description>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/oshdb-util/pom.xml
+++ b/oshdb-util/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
-    <artifactId>bigspatialdata-core-parent</artifactId>
+    <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>oshdb-util</artifactId>

--- a/oshdb/pom.xml
+++ b/oshdb/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
-    <artifactId>bigspatialdata-core-parent</artifactId>
+    <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>

--- a/oshdb/pom.xml
+++ b/oshdb/pom.xml
@@ -11,7 +11,8 @@
   </parent>
 
   <artifactId>oshdb</artifactId>
-  <description>The central database-concept for osh-objects.</description>
+  <name>OSHDB core</name>
+  <description>The central data model of the OpenStreetMap History Database.</description>
 
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -7,10 +7,10 @@
     <version>1.0</version>
   </parent>
 
-  <artifactId>bigspatialdata-core-parent</artifactId>
+  <artifactId>oshdb-parent</artifactId>
   <version>0.6.0-SNAPSHOT</version>
-  <name>HeiGIT Big Spatial Data Core Parent POM</name>
-  <description>The set of base functionality provided for all configurations of BigSpatialData</description>
+  <name>OSHDB parent module</name>
+  <description>Common dependencies, settings and profiles that are shared by all components of the OSHDB</description>
   <packaging>pom</packaging>
 
   <modules>


### PR DESCRIPTION
Renames the top-most pom module from `bigspatialdata-core-parent` to `oshdb-parent`, and adds better descriptions to the sub-modules.

@rtroilo @SlowMo24 @joker234: please have a look.