### PR TITLE
Parent changes and improved pom descriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Changelog
 
 ## 0.6.0 SNAPSHOT (current master)
 
+* bigspatialdata-parent version bump to 1.1, rename bigspatialdata-core-parent → oshdb-parent
+
 ## 0.5.1
 
 * oshdb-util: Fix a bug in `Geo.areaOf` when applied to polygons with holes. Before this fix, the method errorneously skipped the first inner ring when calculating the total area of a polygon. This affected geometries constructed from OSM multipolygon relations.

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
-    <artifactId>bigspatialdata-core-parent</artifactId>
+    <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>

--- a/oshdb-tool/pom.xml
+++ b/oshdb-tool/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
-    <artifactId>bigspatialdata-core-parent</artifactId>
+    <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>

--- a/oshdb-util/pom.xml
+++ b/oshdb-util/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
-    <artifactId>bigspatialdata-core-parent</artifactId>
+    <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
   </parent>
   <artifactId>oshdb-util</artifactId>

--- a/oshdb/pom.xml
+++ b/oshdb/pom.xml
@@ -5,7 +5,7 @@
 
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
-    <artifactId>bigspatialdata-core-parent</artifactId>
+    <artifactId>oshdb-parent</artifactId>
     <version>0.6.0-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.heigit.bigspatialdata</groupId>
     <artifactId>bigspatialdata-parent</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
   </parent>
 
   <artifactId>bigspatialdata-core-parent</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <version>1.1</version>
   </parent>
 
-  <artifactId>bigspatialdata-core-parent</artifactId>
+  <artifactId>oshdb-parent</artifactId>
   <version>0.6.0-SNAPSHOT</version>
   <name>HeiGIT Big Spatial Data Core Parent POM</name>
   <description>The set of base functionality provided for all configurations of BigSpatialData</description>


### PR DESCRIPTION
# Changes proposed in this pull request:

## Description
- Change parent version and name

## New or changed dependencies:
- bigspatialdata-parent 1.1
- bigspatialdata-core-parent → oshdb-parent

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
