### PR TITLE
Releases are deployed to central

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,5 +207,30 @@
         </plugins>
       </build>
     </profile>
+
+    <profile>
+      <id>deploy-central</id>
+      <distributionManagement>
+        <snapshotRepository>
+          <id>ossrh</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>false</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
# Changes proposed in this pull request:
## Type of change
Please delete if not relevant:
- [x] CI Change
- [x] ~~This change requires a documentation update~~ (see #182)

## Description
- Release deployment to central via oss.sonatype.org

## New or changed dependencies:
- new _org.sonatype.plugins.nexus-staging-maven-plugin_

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~ (see #182)
- [x] ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary~~ (see #182)
- [x] Tested via [Test Release](https://jenkins.ohsome.org/blue/organizations/jenkins/oshdb/detail/0.0.0-RC1/3)

The automatically uploaded releases still have to be __released__ via the nexus webinterface of sonatype.
