### PR TITLE
fix calculation of insertIds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 * bigspatialdata-parent version bump to 1.1, rename bigspatialdata-core-parent → oshdb-parent
 
+## 0.5.2
+
+* fix calculation of insertIds / entities stored in too high zoom levels, which resulted in partially missing data in some queries #183
+
 ## 0.5.1
 
 * oshdb-util: Fix a bug in `Geo.areaOf` when applied to polygons with holes. Before this fix, the method errorneously skipped the first inner ring when calculating the total area of a polygon. This affected geometries constructed from OSM multipolygon relations.

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java
@@ -211,7 +211,10 @@ public class XYGrid implements Serializable {
    */
   public long getEstimatedIdCount(final OSHDBBoundingBox data) {
     //number of Cells in x * number of cells in y
-    return ((long) Math.ceil(Math.max((data.getMaxLonLong() - data.getMinLonLong()) / cellWidth, (data.getMaxLatLong() - data.getMinLatLong()) / cellWidth)));
+    return Math.max(
+        (long) Math.ceil(data.getMaxLonLong() / cellWidth) - (long) Math.floor(data.getMinLonLong() / cellWidth),
+        (long) Math.ceil(data.getMaxLatLong() / cellWidth) - (long) Math.floor(data.getMinLatLong() / cellWidth)
+    );
   }
 
   /**

--- a/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/index/XYGridTest.java
+++ b/oshdb/src/test/java/org/heigit/bigspatialdata/oshdb/index/XYGridTest.java
@@ -248,6 +248,12 @@ public class XYGridTest {
     expResult = 16L;
     result = thirty.getEstimatedIdCount(data);
     assertEquals(expResult, result);
+
+    // "just" touching three cells, see https://github.com/GIScience/oshdb/pull/183
+    data = new OSHDBBoundingBox(-0.1, 0, 90.1, 89);
+    expResult = 3L;
+    result = two.getEstimatedIdCount(data);
+    assertEquals(expResult, result);
   }
 
   @Test


### PR DESCRIPTION
in some cases the `insertId` returned a too high zoom level. it's triggered when an entity bounding box is not larger than 2 `cellWidths`, but still touches three cells.

# Changes proposed in this pull request:
## Type of change
Please delete if not relevant:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have added sufficient unit tests
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
