### PR TITLE
more robust multipolygon geometry building with invalid outer rings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changelog
 
 * bigspatialdata-parent version bump to 1.1, rename bigspatialdata-core-parent → oshdb-parent
 
+## 0.5.2
+
+* prevent crashes while building certain invalid multipolygon relation geometries #179
+
 ## 0.5.1
 
 * oshdb-util: Fix a bug in `Geo.areaOf` when applied to polygons with holes. Before this fix, the method errorneously skipped the first inner ring when calculating the total area of a polygon. This affected geometries constructed from OSM multipolygon relations.

--- a/oshdb-util/pom.xml
+++ b/oshdb-util/pom.xml
@@ -43,10 +43,5 @@
       <version>${h2.version}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.wololo</groupId>
-      <artifactId>jts2geojson</artifactId>
-      <version>0.10.0</version>
-    </dependency>
   </dependencies>
 </project>

--- a/oshdb-util/pom.xml
+++ b/oshdb-util/pom.xml
@@ -43,5 +43,10 @@
       <version>${h2.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.wololo</groupId>
+      <artifactId>jts2geojson</artifactId>
+      <version>0.10.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -290,7 +290,7 @@ public class OSHDBGeometryBuilder {
         List<LinearRing> innerCandidates = inners.query(outer.getEnvelopeInternal());
     return geometryFactory.createPolygon(
         (LinearRing) outer.getExteriorRing(),
-        innerCandidates.stream().filter(outerPolygon::intersects).toArray(LinearRing[]::new)
+        innerCandidates.stream().filter(outerPolygon::contains).toArray(LinearRing[]::new)
     );
   }
 

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -273,7 +273,7 @@ public class OSHDBGeometryBuilder {
       result = geometryFactory.createMultiPolygon(polys);
     }
     if (touchingRings) {
-      // try to clean up gometry by calling buffer(0).
+      // try to clean up geometry by calling buffer(0).
       // see https://locationtech.github.io/jts/jts-faq.html#G1
       result = result.buffer(0);
     }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -290,7 +290,7 @@ public class OSHDBGeometryBuilder {
         List<LinearRing> innerCandidates = inners.query(outer.getEnvelopeInternal());
     return geometryFactory.createPolygon(
         (LinearRing) outer.getExteriorRing(),
-        innerCandidates.stream().filter(outerPolygon::contains).toArray(LinearRing[]::new)
+        innerCandidates.stream().filter(outerPolygon::intersects).toArray(LinearRing[]::new)
     );
   }
 

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -29,8 +29,10 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LinearRing;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.Polygonal;
+import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
 import org.locationtech.jts.geom.prep.PreparedPolygon;
+import org.locationtech.jts.index.strtree.STRtree;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -220,7 +222,6 @@ public class OSHDBGeometryBuilder {
         .collect(Collectors.toList());
 
     // check if there are any touching inner/outer rings
-
     Set<Integer> vertices = new HashSet<>();
     boolean touchingRings = false;
     List<LinearRing> allRings = new ArrayList<>(innerRings.size() + outerRings.size());
@@ -242,21 +243,34 @@ public class OSHDBGeometryBuilder {
     // construct multipolygon from rings
     // todo: handle nested outers with holes (e.g. inner-in-outer-in-inner-in-outer) - worth the
     // effort? see below for a possibly much easier implementation.
-    List<Polygon> polys = outerRings.stream().map(outer -> {
-      PreparedGeometry outerPolygon = new PreparedPolygon(geometryFactory.createPolygon(outer));
-      // todo: check for inners containing other inners -> inner-in-outer-in-inner-in-outer case
-      return geometryFactory.createPolygon(
-          outer,
-          innerRings.stream().filter(outerPolygon::contains).toArray(LinearRing[]::new)
-      );
-    }).collect(Collectors.toList());
-
-    // todo: what to do with unmatched inner rings??
     Geometry result;
-    if (polys.size() == 1) {
-      result = polys.get(0);
+    if (outerRings.size() == 1) {
+      result = geometryFactory.createPolygon(
+          outerRings.get(0),
+          innerRings.toArray(new LinearRing[0])
+      );
     } else {
-      result = geometryFactory.createMultiPolygon(polys.toArray(new Polygon[polys.size()]));
+      STRtree innersTree = new STRtree();
+      innerRings.forEach(inner -> innersTree.insert(inner.getEnvelopeInternal(), inner));
+      Polygon[] polys = outerRings.stream().map(outer -> {
+        // todo: check for inners containing other inners -> inner-in-outer-in-inner-in-outer case
+        try {
+          return constructMultipolygonPart(
+              geometryFactory,
+              innersTree,
+              geometryFactory.createPolygon(outer)
+          );
+        } catch (TopologyException e) {
+          // try again with buffer(0) on outer ring
+          return constructMultipolygonPart(
+              geometryFactory,
+              innersTree,
+              (Polygon) geometryFactory.createPolygon(outer).buffer(0)
+          );
+        }
+      }).toArray(Polygon[]::new);
+      // todo: what to do with unmatched inner rings??
+      result = geometryFactory.createMultiPolygon(polys);
     }
     if (touchingRings) {
       // try to clean up gometry by calling buffer(0).
@@ -264,6 +278,20 @@ public class OSHDBGeometryBuilder {
       result = result.buffer(0);
     }
     return result;
+  }
+
+  private static Polygon constructMultipolygonPart(
+      GeometryFactory geometryFactory,
+      STRtree inners,
+      Polygon outer
+  ) throws TopologyException {
+    PreparedGeometry outerPolygon = new PreparedPolygon(outer);
+    @SuppressWarnings("unchecked") // JTS returns raw types, but they are actually LinearRings
+        List<LinearRing> innerCandidates = inners.query(outer.getEnvelopeInternal());
+    return geometryFactory.createPolygon(
+        (LinearRing) outer.getExteriorRing(),
+        innerCandidates.stream().filter(outerPolygon::contains).toArray(LinearRing[]::new)
+    );
   }
 
   // helper that joins adjacent osm ways into linear rings

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
@@ -1,0 +1,40 @@
+package org.heigit.bigspatialdata.oshdb.util.geometry.relations;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
+import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
+import org.heigit.bigspatialdata.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.bigspatialdata.oshdb.util.geometry.helpers.TimestampParser;
+import org.heigit.bigspatialdata.oshdb.util.taginterpreter.TagInterpreter;
+import org.heigit.bigspatialdata.oshdb.util.xmlreader.OSMXmlReader;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+public class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
+
+  private final OSMXmlReader testData = new OSMXmlReader();
+  private final TagInterpreter tagInterpreter;
+  private final OSHDBTimestamp timestamp =
+      TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
+  private final double DELTA = 1E-6;
+
+  public OSHDBGeometryBuilderMultipolygonInvalidOutersTest() {
+    testData.add("./src/test/resources/relations/invalid-outer-ring.osm");
+    tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
+  }
+
+
+  @Test
+  public void test() {
+    // data has invlid (self-intersecting) outer ring
+    OSMEntity entity = testData.relations().get(1L).get(0);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    assertEquals(result.getClass(), MultiPolygon.class);
+    assertTrue(result instanceof MultiPolygon);
+    assertTrue(result.isValid());
+  }
+}

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
@@ -16,7 +16,7 @@ import org.locationtech.jts.io.WKTReader;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-public class OSHDBGeometryBuilderTestRelationOuterDirectionsTest {
+public class OSHDBGeometryBuilderRelationOuterDirectionsTest {
 
   private final OSMXmlReader testData = new OSMXmlReader();
   private final TagInterpreter tagInterpreter;
@@ -24,7 +24,7 @@ public class OSHDBGeometryBuilderTestRelationOuterDirectionsTest {
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderTestRelationOuterDirectionsTest() {
+  public OSHDBGeometryBuilderRelationOuterDirectionsTest() {
     testData.add("./src/test/resources/relations/outer-directions.osm");
     tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
   }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
@@ -16,14 +16,14 @@ import org.locationtech.jts.geom.Point;
 import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertTrue;
 
-public class OSHDBGeometryBuilderTestRelationTypeNotMultipolygonTest {
+public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   private final OSMXmlReader testData = new OSMXmlReader();
   private final TagInterpreter tagInterpreter;
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderTestRelationTypeNotMultipolygonTest() {
+  public OSHDBGeometryBuilderRelationTypeNotMultipolygonTest() {
     testData.add("./src/test/resources/relations/relationTypeNotMultipolygon.osm");
     tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
   }

--- a/oshdb-util/src/test/resources/relations/invalid-outer-ring.osm
+++ b/oshdb-util/src/test/resources/relations/invalid-outer-ring.osm
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6">
+
+  <relation id="1" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+    <member type="way" ref="1" role="outer"/>
+    <member type="way" ref="2" role="outer"/>
+    <member type="way" ref="3" role="inner"/>
+    <tag k="type" v="multipolygon"/>
+  </relation>
+  <way id="1" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="3098430676"/>
+    <nd ref="2384524509"/>
+    <nd ref="3098431359"/>
+    <nd ref="2613585560"/>
+    <nd ref="3098431358"/>
+    <nd ref="2384524503"/>
+    <nd ref="3098431358"/>
+    <nd ref="2613585539"/>
+    <nd ref="3098430676"/>
+  </way>
+  <way id="2" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="1"/>
+    <nd ref="2"/>
+    <nd ref="3"/>
+    <nd ref="1"/>
+  </way>
+  <way id="3" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="2613585539"/>
+    <nd ref="3098431358"/>
+    <nd ref="2613585560"/>
+    <nd ref="3098431359"/>
+    <nd ref="2613585539"/>
+  </way>
+  <node id="2384524503" lat="57.8438818" lon="16.1317602" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="2384524509" lat="57.8451501" lon="16.1328349" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="2613585539" lat="57.8441924" lon="16.1308403" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="2613585560" lat="57.8445134" lon="16.1327586" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="3098430676" lat="57.8444943" lon="16.1304822" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="3098431358" lat="57.8438106" lon="16.1312932" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="3098431359" lat="57.8448328" lon="16.1324731" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="1" lat="0" lon="0" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="2" lat="0" lon="1" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="3" lat="1" lon="1" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+
+</osm>

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osm/OSMWay.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osm/OSMWay.java
@@ -1,10 +1,10 @@
 package org.heigit.bigspatialdata.oshdb.osm;
 
 import java.io.Serializable;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.heigit.bigspatialdata.oshdb.osh.OSHEntities;
-import org.heigit.bigspatialdata.oshdb.osh.OSHNode;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 
 public class OSMWay extends OSMEntity implements Comparable<OSMWay>, Serializable {


### PR DESCRIPTION
fixes #179 and introduce an optimized code path for single-outer-multipolygons, and introduces a temporary r-tree to speed up building of actual multipolygons (with multiple outer rings).

# Changes proposed in this pull request:
## Type of change
Please delete if not relevant:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Performance optimization

## Corresponding issue
Closes #179

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have added sufficient unit tests
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
