### PR TITLE
Fix crash when building geometries of ways with broken node references

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -193,11 +193,14 @@ public class OSHDBGeometryBuilder {
     Stream<OSMWay> outerMembers =
         relation.getMemberEntities(timestamp, areaDecider::isMultipolygonOuterMember)
             .map(osm -> (OSMWay) osm)
+            .filter(Objects::nonNull)
             .filter(OSMEntity::isVisible);
 
     Stream<OSMWay> innerMembers =
         relation.getMemberEntities(timestamp, areaDecider::isMultipolygonInnerMember)
-            .map(osm -> (OSMWay) osm).filter(OSMEntity::isVisible);
+            .map(osm -> (OSMWay) osm)
+            .filter(Objects::nonNull)
+            .filter(OSMEntity::isVisible);
 
     OSMNode[][] outerLines =
         outerMembers

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -87,6 +87,7 @@ public class OSHDBGeometryBuilder {
       // todo: handle old-style multipolygons here???
       Coordinate[] coords =
           way.getRefEntities(timestamp)
+              .filter(Objects::nonNull)
               .filter(OSMEntity::isVisible)
               .map(nd -> new Coordinate(nd.getLongitude(), nd.getLatitude()))
               .toArray(Coordinate[]::new);
@@ -201,11 +202,13 @@ public class OSHDBGeometryBuilder {
     OSMNode[][] outerLines =
         outerMembers
             .map(way -> way.getRefEntities(timestamp)
+                .filter(Objects::nonNull)
                 .filter(OSMEntity::isVisible).toArray(OSMNode[]::new))
             .filter(line -> line.length > 0).toArray(OSMNode[][]::new);
     OSMNode[][] innerLines =
         innerMembers
             .map(way -> way.getRefEntities(timestamp)
+                .filter(Objects::nonNull)
                 .filter(OSMEntity::isVisible).toArray(OSMNode[]::new))
             .filter(line -> line.length > 0).toArray(OSMNode[][]::new);
 

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
@@ -1,6 +1,8 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.osmhistorytestdata;
 
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
+import org.heigit.bigspatialdata.oshdb.osm.OSMRelation;
+import org.heigit.bigspatialdata.oshdb.osm.OSMWay;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.bigspatialdata.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
@@ -493,5 +495,15 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection1 = result1.intersection(expectedPolygon1);
     assertEquals(expectedPolygon1.getArea(), intersection1.getArea(), DELTA);
+  }
+
+  @Test
+  public void testNullRefEntities() {
+    // broken rel references (=invalid OSM data) can occur after "partial" data redactions
+    OSMRelation rel = testData.relations().get(524L).get(0);
+    OSHDBTimestamp timestamp = rel.getTimestamp();
+    Geometry result = OSHDBGeometryBuilder.getGeometry(rel, timestamp, areaDecider);
+    // no exception should have been thrown at this point
+    assertTrue(result.getNumGeometries() < rel.getMembers().length);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.osmhistorytestdata;
 
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
+import org.heigit.bigspatialdata.oshdb.osm.OSMWay;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.bigspatialdata.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
@@ -274,5 +275,15 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     Geometry result4 = OSHDBGeometryBuilder.getGeometry(entity4, timestamp4, areaDecider);
     assertTrue(result4 instanceof LineString);
     assertEquals(4, result4.getNumPoints());
+  }
+
+  @Test
+  public void testNullRefEntities() {
+    // broken way references (=invalid OSM data) can occur after "partial" data redactions
+    OSMWay way = testData.ways().get(177974941L).get(0);
+    OSHDBTimestamp timestamp = way.getTimestamp();
+    Geometry result = OSHDBGeometryBuilder.getGeometry(way, timestamp, areaDecider);
+    // no exception should have been thrown at this point
+    assertTrue(result.getCoordinates().length < way.getRefs().length);
   }
 }

--- a/oshdb-util/src/test/resources/different-timestamps/polygon.osm
+++ b/oshdb-util/src/test/resources/different-timestamps/polygon.osm
@@ -694,5 +694,20 @@
     <relation id="523" visible="false" version="4" timestamp="2017-01-01T00:00:00Z" uid="1" user="test" changeset="344">
     </relation>
 
+    <!--relation with broken reference-->
+    <node id="115" visible="true" version="2" timestamp="2017-01-01T00:00:00Z" uid="1" user="A" changeset="8" lon="7.32" lat="1.04"/>
+    <way id="132" visible="true" version="2" timestamp="2016-01-01T00:00:00Z" uid="1" user="test" changeset="2">
+        <nd ref="13"/>
+        <nd ref="115"/>
+        <nd ref="14"/>
+        <nd ref="16"/>
+        <nd ref="13"/>
+    </way>
+    <relation id="524" visible="true" version="1" timestamp="2015-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+        <member type="way" ref="132" role="outer"/>
+        <member type="way" ref="132" role="inner"/>
+        <tag k="type" v="multipolygon"/>
+    </relation>
+
 
 </osm>

--- a/oshdb-util/src/test/resources/different-timestamps/way.osm
+++ b/oshdb-util/src/test/resources/different-timestamps/way.osm
@@ -365,4 +365,12 @@
   <!--way with nodes not existent-->
   <way id="113" visible="true" version="1" timestamp="2007-12-01T00:00:00Z" uid="1" user="test" changeset="68">
   </way>
+
+  <!-- broken node reference because of partial data redaction -->
+  <node id="3516928189" visible="true" version="2" changeset="31825893" timestamp="2015-06-08T18:50:54Z" user="tommystyle84" uid="438632" lat="50.0048563" lon="8.4080260"/>
+  <node id="3516928189" visible="false" version="3" changeset="46567125" timestamp="2017-03-04T09:14:47Z" user="SomeoneElse_Revert" uid="1778799"/>
+  <way id="177974941" visible="true" version="6" changeset="31179049" timestamp="2015-05-15T14:54:14Z" user="MichaH" uid="8464">
+    <nd ref="3516928189"/>
+    <nd ref="1"/>
+  </way>
 </osm>


### PR DESCRIPTION
# Description
Sometimes, after data redactions ([example](https://www.openstreetmap.org/redactions/6)), the OSM history data can be left in a state where some elements have broken references.

In such cases, the OSHDB's geometry building routines should not crash. This adds necessary checks to avoid a null pointer exception in [OSHDBGeometryBuilder.java#L89-L92](https://github.com/GIScience/oshdb/blob/a93168c/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java#L89-L92).

# Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist
- [ ] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [ ] I have commented my code
- [ ] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- [ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
