### PR TITLE
Improve data streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog
 ## 0.6.0 SNAPSHOT (current master)
 
 * bigspatialdata-parent version bump to 1.2, rename bigspatialdata-core-parent → oshdb-parent
+* improved performance of data [stream](https://docs.ohsome.org/java/oshdb/0.6.0-SNAPSHOT/oshdb-api/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#stream--)ing queries on ignite (using AffinityCall backend)
 
 ## 0.5.3
 

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -85,6 +85,12 @@
       <artifactId>t-digest</artifactId>
       <version>3.2</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.roaringbitmap</groupId>
+      <artifactId>RoaringBitmap</artifactId>
+      <version>${roaringbitmap.version}</version>
+    </dependency>
     
     <!-- TEST dependencies -->
     <dependency>

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -85,12 +85,6 @@
       <artifactId>t-digest</artifactId>
       <version>3.2</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.roaringbitmap</groupId>
-      <artifactId>RoaringBitmap</artifactId>
-      <version>${roaringbitmap.version}</version>
-    </dependency>
     
     <!-- TEST dependencies -->
     <dependency>

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/Kernels.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/Kernels.java
@@ -8,6 +8,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBiFunction;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableFunction;
@@ -188,14 +189,14 @@ class Kernels implements Serializable {
   // === stream processors ===
 
   @Nonnull
-  static <S> CellProcessor<Collection<S>> getOSMContributionCellStreamer(
+  static <S> CellProcessor<Stream<S>> getOSMContributionCellStreamer(
       SerializableFunction<OSMContribution, S> mapper
   ) {
     return getOSMContributionCellStreamer(mapper, NC);
   }
 
   @Nonnull
-  static <S> CellProcessor<Collection<S>> getOSMContributionCellStreamer(
+  static <S> CellProcessor<Stream<S>> getOSMContributionCellStreamer(
       SerializableFunction<OSMContribution, S> mapper,
       CancelableProcessStatus process
   ) {
@@ -204,20 +205,19 @@ class Kernels implements Serializable {
       return cellIterator.iterateByContribution(oshEntityCell)
           .filter(ignored -> process.isActive())
           .map(OSMContribution::new)
-          .map(mapper)
-          .collect(Collectors.toList());
+          .map(mapper);
     };
   }
 
   @Nonnull
-  static <S> CellProcessor<Collection<S>> getOSMContributionGroupingCellStreamer(
+  static <S> CellProcessor<Stream<S>> getOSMContributionGroupingCellStreamer(
       SerializableFunction<List<OSMContribution>, Iterable<S>> mapper
   ) {
     return getOSMContributionGroupingCellStreamer(mapper, NC);
   }
 
   @Nonnull
-  static <S> CellProcessor<Collection<S>> getOSMContributionGroupingCellStreamer(
+  static <S> CellProcessor<Stream<S>> getOSMContributionGroupingCellStreamer(
       SerializableFunction<List<OSMContribution>, Iterable<S>> mapper,
       CancelableProcessStatus process
   ) {
@@ -241,19 +241,19 @@ class Kernels implements Serializable {
       if (contributions.size() > 0) {
         Iterables.addAll(result, mapper.apply(contributions));
       }
-      return result;
+      return result.stream();
     };
   }
 
   @Nonnull
-  static <S> CellProcessor<Collection<S>> getOSMEntitySnapshotCellStreamer(
+  static <S> CellProcessor<Stream<S>> getOSMEntitySnapshotCellStreamer(
       SerializableFunction<OSMEntitySnapshot, S> mapper
   ) {
     return getOSMEntitySnapshotCellStreamer(mapper, NC);
   }
 
   @Nonnull
-  static <S> CellProcessor<Collection<S>> getOSMEntitySnapshotCellStreamer(
+  static <S> CellProcessor<Stream<S>> getOSMEntitySnapshotCellStreamer(
       SerializableFunction<OSMEntitySnapshot, S> mapper,
       CancelableProcessStatus process
   ) {
@@ -262,20 +262,19 @@ class Kernels implements Serializable {
       return cellIterator.iterateByTimestamps(oshEntityCell)
           .filter(ignored -> process.isActive())
           .map(OSMEntitySnapshot::new)
-          .map(mapper)
-          .collect(Collectors.toList());
+          .map(mapper);
     };
   }
 
   @Nonnull
-  static <S> CellProcessor<Collection<S>> getOSMEntitySnapshotGroupingCellStreamer(
+  static <S> CellProcessor<Stream<S>> getOSMEntitySnapshotGroupingCellStreamer(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<S>> mapper
   ) {
     return getOSMEntitySnapshotGroupingCellStreamer(mapper, NC);
   }
 
   @Nonnull
-  static <S> CellProcessor<Collection<S>> getOSMEntitySnapshotGroupingCellStreamer(
+  static <S> CellProcessor<Stream<S>> getOSMEntitySnapshotGroupingCellStreamer(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<S>> mapper,
       CancelableProcessStatus process
   ) {
@@ -299,7 +298,7 @@ class Kernels implements Serializable {
       if (snapshots.size() > 0) {
         Iterables.addAll(result, mapper.apply(snapshots));
       }
-      return result;
+      return result.stream();
     };
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -199,9 +199,9 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
       IgniteCache<Long, GridOSHEntity> cache = ignite.cache(cacheName);
 
       Function<CellIdRange, LongStream> cellIdRangeToCellIds = cellIdRangeToCellIds();
-      return compute.broadcast(
+      return compute.broadcastAsync(
               new GetMatchingKeysPreflight(ignite, cacheName, cellIdRangeToCellIds, cellIdRanges, processor, cellIterator)
-          )
+          ).get(this.timeout)
           .stream()
           .flatMap(Collection::stream).parallel()
           .filter(ignored -> this.isActive())

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -14,8 +15,10 @@ import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCompute;
 import org.apache.ignite.IgniteException;
+import org.apache.ignite.lang.IgniteCallable;
 import org.apache.ignite.lang.IgniteFuture;
 import org.apache.ignite.lang.IgniteRunnable;
+import org.apache.ignite.resources.IgniteInstanceResource;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
 import org.heigit.bigspatialdata.oshdb.api.generic.function.SerializableBiFunction;
@@ -93,7 +96,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
   }
 
   @Nonnull
-  private static Function<CellIdRange, LongStream> cellIdRangeToCellIds() {
+  private static SerializableFunction<CellIdRange, LongStream> cellIdRangeToCellIds() {
     return cellIdRange -> {
       int level = cellIdRange.getStart().getZoomLevel();
       long from = CellId.getLevelId(level, cellIdRange.getStart().getId());
@@ -173,7 +176,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
    * @throws OSHDBTimeoutException if a timeout was set and the computations took too long.
    */
   private Stream<X> stream(
-      CellProcessor<Collection<X>> processor
+      CellProcessor<Stream<X>> processor
   ) throws ParseException, SQLException, IOException {
     this.executionStartTimeMillis = System.currentTimeMillis();
 
@@ -190,31 +193,33 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
     IgniteCompute compute = ignite.compute();
     IgniteRunnable onClose = oshdb.onClose().orElse(() -> { });
 
-    return typeFilter.stream().map((SerializableFunction<OSMType, Stream<X>>) osmType -> {
+    return typeFilter.stream().flatMap((SerializableFunction<OSMType, Stream<X>>) osmType -> {
       assert TableNames.forOSMType(osmType).isPresent();
       String cacheName = TableNames.forOSMType(osmType).get().toString(this.oshdb.prefix());
       IgniteCache<Long, GridOSHEntity> cache = ignite.cache(cacheName);
 
-      return Streams.stream(cellIdRanges)
-          .flatMapToLong(cellIdRangeToCellIds())
-          .parallel()
+      Function<CellIdRange, LongStream> cellIdRangeToCellIds = cellIdRangeToCellIds();
+      return compute.broadcast(
+              new GetMatchingKeysPreflight(ignite, cacheName, cellIdRangeToCellIds, cellIdRanges, processor, cellIterator)
+          )
+          .stream()
+          .flatMap(Collection::stream).parallel()
           .filter(ignored -> this.isActive())
-          .mapToObj(cellLongId -> asyncGetHandleTimeouts(
-                compute.affinityCallAsync(cacheName, cellLongId, () -> {
-                  @SuppressWarnings("SerializableStoresNonSerializable")
-                  GridOSHEntity oshEntityCell = cache.localPeek(cellLongId);
-                  Collection<X> ret;
-                  if (oshEntityCell == null) {
-                    ret = Collections.<X>emptyList();
-                  } else {
-                    ret = processor.apply(oshEntityCell, cellIterator);
-                  }
-                  onClose.run();
-                  return ret;
-                })
+          .map(cellLongId -> asyncGetHandleTimeouts(
+              compute.affinityCallAsync(cacheName, cellLongId, () -> {
+                GridOSHEntity oshEntityCell = cache.localPeek(cellLongId);
+                Collection<X> ret;
+                if (oshEntityCell == null) {
+                  ret = Collections.<X>emptyList();
+                } else {
+                  ret = processor.apply(oshEntityCell, cellIterator).collect(Collectors.toList());
+                }
+                onClose.run();
+                return ret;
+              })
           ))
           .flatMap(Collection::stream);
-    }).flatMap(x -> x);
+    });
   }
 
   // === map-reduce operations ===
@@ -320,5 +325,48 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
   protected Stream<X> flatMapStreamCellsOSMEntitySnapshotGroupedById(
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> mapper) throws Exception {
     return stream(Kernels.getOSMEntitySnapshotGroupingCellStreamer(mapper, this));
+  }
+
+  private static class GetMatchingKeysPreflight implements IgniteCallable<Collection<Long>> {
+    @IgniteInstanceResource
+    private Ignite ignite;
+
+    //private final Ignite ignite;
+    private final String cacheName;
+    private final Function<CellIdRange, LongStream> cellIdRangeToCellIds;
+    private final Iterable<CellIdRange> cellIdRanges;
+    private final CellProcessor<? extends Stream<?>> cellProcessor;
+    private final CellIterator cellIterator;
+
+    public GetMatchingKeysPreflight(
+        Ignite ignite,
+        String cacheName,
+        Function<CellIdRange, LongStream> cellIdRangeToCellIds,
+        Iterable<CellIdRange> cellIdRanges,
+        CellProcessor<? extends Stream<?>> cellProcessor,
+        CellIterator cellIterator
+    ) {
+      //this.ignite = ignite;
+      this.cacheName = cacheName;
+      this.cellIdRangeToCellIds = cellIdRangeToCellIds;
+      this.cellIdRanges = cellIdRanges;
+      this.cellProcessor = cellProcessor;
+      this.cellIterator = cellIterator;
+    }
+
+    @Override
+    public Collection<Long> call() throws Exception {
+      IgniteCache<Long, GridOSHEntity> localCache = ignite.cache(cacheName);
+      return Streams.stream(cellIdRanges)
+          .flatMapToLong(cellIdRangeToCellIds)
+          .parallel()
+          .filter(cellLongId -> {
+            // test if cell exists and contains any relevant data
+            GridOSHEntity cell = localCache.localPeek(cellLongId);
+            return cell != null && cellProcessor.apply(cell, cellIterator).findAny().isPresent();
+          })
+          .boxed()
+          .collect(Collectors.toList());
+    }
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
@@ -3,7 +3,6 @@ package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
@@ -69,7 +68,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
   }
 
   private Stream<X> stream(
-      CellProcessor<Collection<X>> processor
+      CellProcessor<Stream<X>> processor
   ) throws ParseException, SQLException, IOException {
     this.executionStartTimeMillis = System.currentTimeMillis();
 
@@ -86,8 +85,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
         .filter(ignored -> this.isActive())
         .flatMap(this::getOshCellsStream)
         .filter(ignored -> this.isActive())
-        .map(oshCell -> processor.apply(oshCell, cellIterator))
-        .flatMap(Collection::stream);
+        .flatMap(oshCell -> processor.apply(oshCell, cellIterator));
   }
 
   // === map-reduce operations ===

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
@@ -4,7 +4,6 @@ import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Collection;
 import java.util.List;
 import java.util.stream.Stream;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
@@ -74,7 +73,7 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
   }
 
   private Stream<X> stream(
-      CellProcessor<Collection<X>> cellProcessor
+      CellProcessor<Stream<X>> cellProcessor
   ) throws ParseException, SQLException, IOException, ClassNotFoundException {
     this.executionStartTimeMillis = System.currentTimeMillis();
 
@@ -86,8 +85,7 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
 
     return Streams.stream(this.getCellIdRanges())
         .flatMap(this::getOshCellsStream)
-        .map(oshCellRawData -> cellProcessor.apply(oshCellRawData, cellIterator))
-        .flatMap(Collection::stream);
+        .flatMap(oshCellRawData -> cellProcessor.apply(oshCellRawData, cellIterator));
   }
 
   // === map-reduce operations ===

--- a/oshdb-tool/etl/pom.xml
+++ b/oshdb-tool/etl/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>org.roaringbitmap</groupId>
       <artifactId>RoaringBitmap</artifactId>
-      <version>0.6.59</version>
+      <version>${roaringbitmap.version}</version>
     </dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <mavenpmd.version>2.9</mavenpmd.version>
     <pmd.version>6.11.0</pmd.version>
     <mavenpmd.version>3.11.0</mavenpmd.version>
+    <roaringbitmap.version>0.6.59</roaringbitmap.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
# Changes proposed in this pull request:
## Type of change
- [x] performance enhancement

## Description

The _IgniteAffinityCall_ backend is currently the only one that properly implements the [`stream()`](https://docs.ohsome.org/java/oshdb/0.5.4/oshdb-api/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#stream--) method of the OSHDB API. Thus it is used for example by the ohsome API for [data extraction](https://api.ohsome.org/v0.9/swagger-ui.html?urls.primaryName=Data%20Extraction) requests.

The current implementation is inefficient due to the fact that it requests _all_ cell ids for the given request area, of which potentially the majority don't exist, are empty, or have no matching results. This causes requests with large areas of interest to not complete in a timely manner (or, in the ohsome-api case, to run into timeouts).

The new implementation runs a preflight request which returns the list of cell ids which actually contain any relevant data. Only these cells are then requested in the actual oshdb `stream()` query.

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
