### PR TITLE
make monthly time intervals more intuitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 * bigspatialdata-parent version bump to 1.2, rename bigspatialdata-core-parent → oshdb-parent
 * improved performance of data [stream](https://docs.ohsome.org/java/oshdb/0.6.0-SNAPSHOT/oshdb-api/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#stream--)ing queries on ignite (using AffinityCall backend)
+* make monthly time intervals more intuitive #201 
 
 ## 0.5.3
 

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/time/OSHDBTimestamps.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/time/OSHDBTimestamps.java
@@ -156,6 +156,8 @@ public class OSHDBTimestamps implements OSHDBTimestampList {
 
       Period period = (Period) steps.get("period");
       Duration duration = (Duration) steps.get("duration");
+      
+      int counter = 1;
 
       //validate start and end. start should be before end.
       if (start.isAfter(end)) {
@@ -171,7 +173,8 @@ public class OSHDBTimestamps implements OSHDBTimestampList {
 
         while (currentTimestamp.toEpochSecond() >= startTimestamp) {
           timestamps.add(currentTimestamp.toEpochSecond());
-          currentTimestamp = currentTimestamp.minus(period).minus(duration);
+          currentTimestamp = end.minus(period.multipliedBy(counter)).minus(duration.multipliedBy(counter));
+          counter++;
         }
       } else {
         ZonedDateTime currentTimestamp = ZonedDateTime.from(start);
@@ -179,7 +182,8 @@ public class OSHDBTimestamps implements OSHDBTimestampList {
 
         while (currentTimestamp.toEpochSecond() <= endTimestamp) {
           timestamps.add(currentTimestamp.toEpochSecond());
-          currentTimestamp = currentTimestamp.plus(period).plus(duration);
+          currentTimestamp = start.plus(period.multipliedBy(counter)).plus(duration.multipliedBy(counter));
+          counter++;
         }
       }
 

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/time/OSHDBTimestampsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/time/OSHDBTimestampsTest.java
@@ -28,12 +28,12 @@ public class OSHDBTimestampsTest {
     startList.add("2008-01-31T12:34:56");
     endList.add("2008-07-31T12:34:56");
     intervalList.add(Interval.QUARTERLY);
-    expectedResultList.add(Arrays.asList("2008-01-31T12:34:56", "2008-04-30T12:34:56", "2008-07-30T12:34:56"));
+    expectedResultList.add(Arrays.asList("2008-01-31T12:34:56", "2008-04-30T12:34:56", "2008-07-31T12:34:56"));
 
     startList.add("2008-01-31T12:34:56");
     endList.add("2008-03-31T12:34:56");
     intervalList.add(Interval.MONTHLY);
-    expectedResultList.add(Arrays.asList("2008-01-31T12:34:56", "2008-02-29T12:34:56", "2008-03-29T12:34:56"));
+    expectedResultList.add(Arrays.asList("2008-01-31T12:34:56", "2008-02-29T12:34:56", "2008-03-31T12:34:56"));
 
     startList.add("2008-01-31T12:34:56");
     endList.add("2008-02-14T12:34:56");


### PR DESCRIPTION
# Changes proposed in this pull request:
## Type of change
Please delete if not relevant:
- [x] Breaking change

## Description

Fixes https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/ohsome-api/issues/63: unexpected/unintuitive result when using a "monthly" time interval.

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have added sufficient unit tests
- [ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
