### PR TITLE
fix (literal) edge cases in fast-polygon operations class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,13 @@ Changelog
 
 ## 0.6.0 SNAPSHOT (current master)
 
+* (minor) reorganize parent package: bigspatialdata-parent version bump to 1.2, rename bigspatialdata-core-parent to oshdb-parent
+* fix bug where polygonal areas of interest would throw an exception in some (rare) edge cases. #204
+
 ## 0.5.5
 
 * improved performance of data [stream](https://docs.ohsome.org/java/oshdb/0.5.4/oshdb-api/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#stream--)ing queries on ignite (using AffinityCall backend).
 * make monthly time intervals more intuitive to use. #201
-* (minor) reorganize parent package: bigspatialdata-parent version bump to 1.2, rename bigspatialdata-core-parent to oshdb-parent
 
 ## 0.5.4
 

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -6,6 +6,7 @@ import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.Polygonal;
 import java.io.Serializable;
@@ -52,12 +53,15 @@ public class FastPolygonOperations implements Serializable {
       // edges. These GeometryCollections would cause issues in the intersection method (e.g.
       // during the "union" operation). Here we need to clean these up.
       if (theGeom instanceof GeometryCollection) {
-        GeometryCollection gc = (GeometryCollection) theGeom;
-        List<Polygon> gcPolys = new ArrayList<>(gc.getNumGeometries());
-        for (int i = 0; i < gc.getNumGeometries(); i++) {
-          Geometry gcGeom = gc.getGeometryN(i);
+        List<Polygon> gcPolys = new ArrayList<>(theGeom.getNumGeometries());
+        for (int i = 0; i < theGeom.getNumGeometries(); i++) {
+          Geometry gcGeom = theGeom.getGeometryN(i);
           if (gcGeom instanceof Polygon) {
             gcPolys.add((Polygon) gcGeom);
+          } else if (gcGeom instanceof MultiPolygon) {
+            for (int j = 0; j < gcGeom.getNumGeometries(); j++) {
+              gcPolys.add((Polygon) gcGeom.getGeometryN(j));
+            }
           }
         }
         if (gcPolys.size() == 1) {

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -1,9 +1,12 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.fip;
 
 import java.util.Arrays;
+import java.util.List;
+import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.Polygonal;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -44,6 +47,24 @@ public class FastPolygonOperations implements Serializable {
       GeometryFactory gf,
       Geometry[] resultBuffer
   ) {
+    if (!(theGeom instanceof Polygonal)) {
+      // after clipping, the geometry might contain superfluous points or lines along the clipping
+      // edges. These GeometryCollections would cause issues in the intersection method (e.g.
+      // during the "union" operation). Here we need to clean these up.
+      if (theGeom instanceof GeometryCollection) {
+        GeometryCollection gc = (GeometryCollection) theGeom;
+        List<Polygon> gcPolys = new ArrayList<>(gc.getNumGeometries());
+        for (int i = 0; i < gc.getNumGeometries(); i++) {
+          Geometry gcGeom = gc.getGeometryN(i);
+          if (gcGeom instanceof Polygon) {
+            gcPolys.add((Polygon) gcGeom);
+          }
+        }
+        theGeom = gf.createMultiPolygon(gcPolys.toArray(new Polygon[0]));
+      } else {
+        theGeom = gf.createPolygon();
+      }
+    }
     if (level == 0) {
       int index = y + x * numBands;
       resultBuffer[index] = theGeom;

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -60,7 +60,11 @@ public class FastPolygonOperations implements Serializable {
             gcPolys.add((Polygon) gcGeom);
           }
         }
-        theGeom = gf.createMultiPolygon(gcPolys.toArray(new Polygon[0]));
+        if (gcPolys.size() == 1) {
+          theGeom = gcPolys.get(0);
+        } else {
+          theGeom = gf.createMultiPolygon(gcPolys.toArray(new Polygon[0]));
+        }
       } else {
         theGeom = gf.createPolygon();
       }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
@@ -1,11 +1,17 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.fip;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 import org.junit.Test;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
 
 public class FastPolygonOperationsTest {
 
@@ -17,8 +23,8 @@ public class FastPolygonOperationsTest {
     GeometryFactory gf = new GeometryFactory();
 
     assertEquals(
-        pop.intersection(gf.createPoint((Coordinate) null)),
-        gf.createPoint((Coordinate) null)
+        gf.createPoint((Coordinate) null),
+        pop.intersection(gf.createPoint((Coordinate) null))
     );
   }
 
@@ -27,11 +33,20 @@ public class FastPolygonOperationsTest {
     Polygon p = FastPointInPolygonTest.createPolygon();
     FastPolygonOperations pop = new FastPolygonOperations(p);
 
-    GeometryFactory gf = new GeometryFactory();
+    assertNull(pop.intersection((Polygon) null));
+  }
 
-    assertEquals(
-        pop.intersection((Polygon) null),
-        null
-    );
+  @Test
+  public void testBug206() throws ParseException {
+    // see https://github.com/GIScience/oshdb/pull/204
+    
+    String polyWkt = "POLYGON ((-0.0473915 51.5539955,-0.0473872 51.5540543,-0.0473811 51.554121,-0.0473792 51.5541494,-0.0473193 51.5541485,-0.047305 51.5540903,-0.0472924 51.5540904,-0.0472852 51.5540674,-0.0472735 51.5540681,-0.0472692 51.5540517,-0.0472852 51.5540499,-0.0472602 51.5539917,-0.0472317 51.553925,-0.0472157 51.5539254,-0.0472097 51.5539106,-0.0473992 51.5538913,-0.0474735 51.5538845,-0.0475498 51.5538774,-0.0476179 51.5538712,-0.0476923 51.5538643,-0.0476923 51.5538575,-0.0477741 51.5538544,-0.0478501 51.5538516,-0.0479217 51.553849,-0.0479986 51.5538462,-0.0480796 51.5538432,-0.0481503 51.5538406,-0.0482264 51.5538378,-0.0482708 51.5538377,-0.0483561 51.5538358,-0.0484275 51.5538343,-0.0485046 51.5538325,-0.0485294 51.553832,-0.0485255 51.5539171,-0.0485813 51.5539157,-0.0485787 51.5539268,-0.0485505 51.5540481,-0.048532 51.5540479,-0.0485309 51.5539901,-0.0484762 51.5539897,-0.0484784 51.5540545,-0.0484507 51.5540541,-0.0484187 51.5540536,-0.0484198 51.5539893,-0.0483923 51.5539892,-0.0483925 51.5539796,-0.0483729 51.5539795,-0.048362 51.5539794,-0.0483618 51.553989,-0.0483251 51.5539888,-0.0483241 51.5540522,-0.0482959 51.5540518,-0.0482676 51.5540514,-0.0482697 51.5539916,-0.0482366 51.5539911,-0.0482369 51.5539847,-0.0482236 51.5539846,-0.0482067 51.5539843,-0.0482064 51.5539907,-0.0481825 51.5539904,-0.0481803 51.5540561,-0.0481466 51.5540562,-0.0481136 51.5540562,-0.048115 51.5539953,-0.0480721 51.5539945,-0.048072 51.5540025,-0.0480546 51.5540021,-0.0480539 51.5540142,-0.0480194 51.5540138,-0.048018 51.5540561,-0.04799 51.5540558,-0.0479623 51.5540556,-0.047964 51.5540149,-0.0479185 51.5540142,-0.0478768 51.5540135,-0.047875 51.5540547,-0.0478614 51.5540546,-0.0478616 51.5540458,-0.0478423 51.5540457,-0.0478439 51.554006,-0.0477667 51.5540059,-0.0476868 51.5540057,-0.0476872 51.5539952,-0.047616 51.5539953,-0.0475449 51.5539954,-0.0474682 51.5539954,-0.0473915 51.5539955))";
+    Polygon poly = (Polygon) (new WKTReader()).read(polyWkt);
+    FastPolygonOperations pop = new FastPolygonOperations(poly);
+
+    String testWkt = "POLYGON ((-0.0478421 51.5540544,-0.0478399 51.5541248,-0.0478499 51.5541249,-0.0478549 51.5541307,-0.0478795 51.5541313,-0.0478858 51.5541252,-0.0479136 51.5541254,-0.0479185 51.5540142,-0.0478768 51.5540135,-0.047875 51.5540547,-0.0478614 51.5540546,-0.0478616 51.5540458,-0.0478423 51.5540457,-0.0478421 51.5540544))";
+    Polygon test = (Polygon) (new WKTReader()).read(testWkt);
+
+    assertNotNull(pop.intersection(test));
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 import org.junit.Test;
@@ -67,8 +68,8 @@ public class FastPolygonOperationsTest {
     // lines
     for (int i = 0; i < 30; i++) {
       Geometry testGeom = gf.createLineString(new Coordinate[] {
-          new Coordinate(0.4 * i, 0.35 * i),
-          new Coordinate(0.4 * i + 0.01, 0.35 * i)
+          new Coordinate(0.4 * i + 1.0, 0.35 * i),
+          new Coordinate(0.4 * i, 0.35 * i + 1.0)
       });
       assertEquals(
           poly.intersection(testGeom),

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
@@ -14,13 +14,12 @@ import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
 public class FastPolygonOperationsTest {
+  private GeometryFactory gf = new GeometryFactory();
 
   @Test
   public void testEmptyGeometryPolygon() {
     Polygon p = FastPointInPolygonTest.createPolygon();
     FastPolygonOperations pop = new FastPolygonOperations(p);
-
-    GeometryFactory gf = new GeometryFactory();
 
     assertEquals(
         gf.createPoint((Coordinate) null),
@@ -45,8 +44,45 @@ public class FastPolygonOperationsTest {
     FastPolygonOperations pop = new FastPolygonOperations(poly);
 
     String testWkt = "POLYGON ((-0.0478421 51.5540544,-0.0478399 51.5541248,-0.0478499 51.5541249,-0.0478549 51.5541307,-0.0478795 51.5541313,-0.0478858 51.5541252,-0.0479136 51.5541254,-0.0479185 51.5540142,-0.0478768 51.5540135,-0.047875 51.5540547,-0.0478614 51.5540546,-0.0478616 51.5540458,-0.0478423 51.5540457,-0.0478421 51.5540544))";
-    Polygon test = (Polygon) (new WKTReader()).read(testWkt);
+    Geometry test = (new WKTReader()).read(testWkt);
 
     assertNotNull(pop.intersection(test));
+  }
+
+  @Test
+  public void testGeometries() throws ParseException {
+    String polyWkt = "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 9, 9 9, 9 1, 1 1))";
+    Polygon poly = (Polygon) (new WKTReader()).read(polyWkt).buffer(0.1, 200);
+    FastPolygonOperations pop = new FastPolygonOperations(poly);
+
+    // points
+    for (int i = 0; i < 30; i++) {
+      Geometry testGeom = gf.createPoint(new Coordinate(0.4 * i, 0.35 * i));
+      assertEquals(
+          poly.intersection(testGeom),
+          pop.intersection(testGeom)
+      );
+    }
+
+    // lines
+    for (int i = 0; i < 30; i++) {
+      Geometry testGeom = gf.createLineString(new Coordinate[] {
+          new Coordinate(0.4 * i, 0.35 * i),
+          new Coordinate(0.4 * i + 0.01, 0.35 * i)
+      });
+      assertEquals(
+          poly.intersection(testGeom),
+          pop.intersection(testGeom)
+      );
+    }
+
+    // polygons
+    for (int i = 0; i < 30; i++) {
+      Geometry testGeom = gf.createPoint(new Coordinate(0.4 * i, 0.35 * i)).buffer(0.01);
+      assertEquals(
+          poly.intersection(testGeom),
+          pop.intersection(testGeom)
+      );
+    }
   }
 }


### PR DESCRIPTION
Literal edge case here :laughing: – Sometimes during the preprocessing step (responsible for optimizing the polygon operations) the intermediate results may contain superfluous points or lines along the clipping edge(s). These additional geometries cause problems further down the processing pipeline. Since these edge artifacts don't contribute anything to the final oshdb query result, they can just be filtered out.

Here is an example of a geometry which can cause such a situation: https://gist.github.com/tyrasd/19ec9399d42dcf76ed7ab16432052afe (found by @redfrexx ~ thanks!).
 
# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have added sufficient unit tests
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)