### PR TITLE
Improve data streaming, part 3

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.api.mapreducer;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Streams;
 import com.tdunning.math.stats.TDigest;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -22,7 +23,6 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.heigit.bigspatialdata.oshdb.api.generic.NumberUtils;
 import org.heigit.bigspatialdata.oshdb.api.generic.OSHDBCombinedIndex;
 import org.heigit.bigspatialdata.oshdb.api.generic.WeightedValue;
@@ -618,7 +618,7 @@ public class MapAggregator<U extends Comparable<U> & Serializable, X> implements
   ) throws Exception {
     return transformSortedMap(
         this.estimatedQuantiles(mapper),
-        quantileFunction -> StreamSupport.stream(q.spliterator(), false)
+        quantileFunction -> Streams.stream(q)
             .mapToDouble(Double::doubleValue)
             .map(quantileFunction)
             .boxed()

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.api.mapreducer;
 
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Streams;
 import com.tdunning.math.stats.TDigest;
 import java.io.IOException;
 import java.io.Serializable;
@@ -23,7 +24,6 @@ import java.util.function.DoubleUnaryOperator;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.heigit.bigspatialdata.oshdb.OSHDB;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBJdbc;
@@ -1314,7 +1314,7 @@ public abstract class MapReducer<X> implements
       SerializableFunction<X, R> mapper,
       Iterable<Double> q
   ) throws Exception {
-    return StreamSupport.stream(q.spliterator(), false)
+    return Streams.stream(q)
         .mapToDouble(Double::doubleValue)
         .map(this.estimatedQuantiles(mapper))
         .boxed()

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -237,7 +237,7 @@ class IgniteLocalPeekHelper {
           .map(node::<Long, GridOSHEntity>cache)
           .collect(Collectors.toSet());
 
-      return Streams.stream(() -> new CellKeysIterator(cellIdRanges))
+      return Streams.stream(new CellKeysIterator(cellIdRanges))
           .filter(ignored -> this.isActive())
           .flatMap(cellKey ->
               // get local data from all requested caches

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -1,5 +1,6 @@
 package org.heigit.bigspatialdata.oshdb.api.mapreducer.backend;
 
+import com.google.common.collect.Streams;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -8,11 +9,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.Spliterators;
 import java.util.concurrent.ForkJoinPool;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import java.util.stream.StreamSupport;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;
 import org.apache.ignite.IgniteCompute;
@@ -191,10 +190,7 @@ class IgniteLocalPeekHelper {
       final int bufferSize = 102400 * ForkJoinPool.commonPool().getParallelism();
 
       CellKeysIterator(Iterable<CellIdRange> cellIdRanges) {
-        this.cellIds = StreamSupport.stream(
-            Spliterators.spliteratorUnknownSize(cellIdRanges.iterator(), 0),
-            true
-        )
+        this.cellIds = Streams.stream(cellIdRanges)
         .filter(ignored -> isActive())
         .flatMap(cellIdRange -> {
           int level = cellIdRange.getStart().getZoomLevel();
@@ -236,19 +232,12 @@ class IgniteLocalPeekHelper {
       }
     }
 
-    public abstract S execute(Ignite node);
-
     S execute(Ignite node, CellProcessor<S> cellProcessor) {
-      Iterator<Long> cellKeysIterator = new CellKeysIterator(cellIdRanges);
-
       Set<IgniteCache<Long, GridOSHEntity>> caches = this.cacheNames.stream()
           .map(node::<Long, GridOSHEntity>cache)
           .collect(Collectors.toSet());
 
-      return StreamSupport.stream(
-              Spliterators.spliteratorUnknownSize(cellKeysIterator, 0),
-              true
-          )
+      return Streams.stream(() -> new CellKeysIterator(cellIdRanges))
           .filter(ignored -> this.isActive())
           .flatMap(cellKey ->
               // get local data from all requested caches

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -578,7 +578,6 @@ class IgniteScanQueryHelperMapStream {
       CellIterator cellIterator,
       CellProcessor<Stream<X>> cellProcessor
   ) {
-    // run processing in parallel
     QueryCursor<List<X>> cursor = oshdb.getIgnite().cache(cacheName).withKeepBinary().query(
         new ScanQuery<Long, Object>((key, cell) ->
             /*isActive() &&*/ MapReducerIgniteScanQuery.cellKeyInRange(key, cellIdRangesByLevel)

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/CellIterator.java
@@ -13,7 +13,6 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import org.heigit.bigspatialdata.oshdb.grid.GridOSHEntity;
 import org.heigit.bigspatialdata.oshdb.index.XYGrid;
@@ -196,7 +195,7 @@ public class CellIterator implements Serializable {
     }
 
     Iterable<? extends OSHEntity> cellData = cell.getEntities();
-    return StreamSupport.stream(cellData.spliterator(), false).flatMap(oshEntity -> {
+    return Streams.stream(cellData).flatMap(oshEntity -> {
       if (!oshEntityPreFilter.test(oshEntity) ||
           !allFullyInside && (
               !oshEntity.getBoundingBox().intersects(boundingBox) ||
@@ -461,7 +460,7 @@ public class CellIterator implements Serializable {
     //noinspection unchecked
     Iterable<? extends OSHEntity> cellData = cell.getEntities();
 
-    return StreamSupport.stream(cellData.spliterator(), false).flatMap(oshEntity -> {
+    return Streams.stream(cellData).flatMap(oshEntity -> {
       if (!oshEntityPreFilter.test(oshEntity) ||
           !allFullyInside && (
               !oshEntity.getBoundingBox().intersects(boundingBox) ||


### PR DESCRIPTION
small addendum to #202: in scanquery backend: use an appropriate query page size, and make sure the cursor is closed when the returned stream is closed. (The issue that the scanquery backend doesn't yet implement timeouts remains a mayor downside.)