### PR TITLE
make preflight robust against null values in the stream

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -432,7 +432,8 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
           .filter(cellLongId -> {
             // test if cell exists and contains any relevant data
             GridOSHEntity cell = localCache.localPeek(cellLongId);
-            return cell != null && cellProcessor.apply(cell, cellIterator).findAny().isPresent();
+            return cell != null
+                && cellProcessor.apply(cell, cellIterator).anyMatch(ignored -> true);
           })
           .boxed()
           .collect(Collectors.toList());
@@ -483,9 +484,12 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
                   } else {
                     oshEntityCell = (GridOSHEntity) data;
                   }
-                  return cellProcessor.apply(oshEntityCell, this.cellIterator).findAny().map(
-                      ignored -> cacheEntry.getKey()
-                  );
+                  Stream<?> cellStream = cellProcessor.apply(oshEntityCell, this.cellIterator);
+                  if (cellStream.anyMatch(ignored -> true)) {
+                    return Optional.of(cacheEntry.getKey());
+                  } else {
+                    return Optional.empty();
+                  }
                 }
             )) {
               List<Long> acc = new LinkedList<>();

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
@@ -35,13 +35,13 @@ abstract class TestMapReduce {
     this.oshdb = oshdb;
   }
 
-  private MapReducer<OSMContribution> createMapReducerOSMContribution() throws Exception {
+  protected MapReducer<OSMContribution> createMapReducerOSMContribution() throws Exception {
     MapReducer<OSMContribution> mapRed = OSMContributionView.on(oshdb);
     if (this.keytables != null) mapRed = mapRed.keytables(this.keytables);
     return mapRed.osmType(OSMType.NODE).osmTag("highway").areaOfInterest(bbox);
   }
 
-  private MapReducer<OSMEntitySnapshot> createMapReducerOSMEntitySnapshot() throws Exception {
+  protected MapReducer<OSMEntitySnapshot> createMapReducerOSMEntitySnapshot() throws Exception {
     MapReducer<OSMEntitySnapshot> mapRed = OSMEntitySnapshotView.on(oshdb);
     if (this.keytables != null) mapRed = mapRed.keytables(this.keytables);
     return mapRed.osmType(OSMType.NODE).osmTag("highway").areaOfInterest(bbox);

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_Ignite_AffinityCall.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_Ignite_AffinityCall.java
@@ -1,9 +1,29 @@
 package org.heigit.bigspatialdata.oshdb.api.tests;
 
+import static org.junit.Assert.assertEquals;
+
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBIgnite;
+import org.heigit.bigspatialdata.oshdb.util.time.OSHDBTimestamps;
+import org.junit.Test;
 
 public class TestMapReduceOSHDB_Ignite_AffinityCall extends TestMapReduceOSHDB_Ignite {
   public TestMapReduceOSHDB_Ignite_AffinityCall() throws Exception {
     super(new OSHDBIgnite(ignite).computeMode(OSHDBIgnite.ComputeMode.AffinityCall));
+  }
+
+  @Test
+  public void testOSMEntitySnapshotViewStreamNullValues() throws Exception {
+    // simple stream query
+    Set<Integer> result = createMapReducerOSMEntitySnapshot()
+        .timestamps(new OSHDBTimestamps("2010-01-01", "2015-01-01", OSHDBTimestamps.Interval.YEARLY))
+        .osmEntityFilter(entity -> entity.getId() == 617308093)
+        .map(snapshot -> snapshot.getEntity().getUserId())
+        .map(x -> (Integer)null)
+        .stream()
+        .collect(Collectors.toSet());
+
+    assertEquals(1, result.size());
   }
 }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_Ignite_AffinityCall.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduceOSHDB_Ignite_AffinityCall.java
@@ -20,7 +20,7 @@ public class TestMapReduceOSHDB_Ignite_AffinityCall extends TestMapReduceOSHDB_I
         .timestamps(new OSHDBTimestamps("2010-01-01", "2015-01-01", OSHDBTimestamps.Interval.YEARLY))
         .osmEntityFilter(entity -> entity.getId() == 617308093)
         .map(snapshot -> snapshot.getEntity().getUserId())
-        .map(x -> (Integer)null)
+        .map(x -> (Integer) null)
         .stream()
         .collect(Collectors.toSet());
 


### PR DESCRIPTION
When the first entry of a stream is `null`, `Stream.findAny()` [throws](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#findAny--) a `NullPointerException`. In general, we can't guarantee that users never return null values in a map function, so there might be situations where this exception would be triggered.

This PR solves this by using `Stream.anyMatch()` instead of `Stream.findAny()`.

This is a relatively minor issue usually, since returning null values should be avoided by users anyway.

issue originally reported by @Zia- - thanks!