### PR TITLE
allow tag keys to be supplied in .osmTag(Collection) filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Changelog
 
 * (minor) reorganize parent package: bigspatialdata-parent version bump to 1.2, rename bigspatialdata-core-parent to oshdb-parent
 * fix bug where polygonal areas of interest would throw an exception in some (rare) edge cases. #204
+* allow osmTag filters more flexible: when used with a list of tags, it now accepts also `tagKey=*` statements (which can be mixed with `key=value` statements as before). #209
 
 ## 0.5.5
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -349,12 +349,12 @@ public class MapAggregator<U extends Comparable<U> & Serializable, X> implements
    * Adds an osm tag filter: The analysis will be restricted to osm entities that have at least one
    * of the supplied tags (key=value pairs).
    *
-   * @param keyValuePairs the tags (key/value pairs) to filter the osm entities for
+   * @param tags the tags (key/value pairs or key=*) to filter the osm entities for
    * @return a modified copy of this object (can be used to chain multiple commands together)
    */
   @Contract(pure = true)
-  public MapAggregator<U, X> osmTag(Collection<OSMTag> keyValuePairs) {
-    return this.copyTransform(this.mapReducer.osmTag(keyValuePairs));
+  public MapAggregator<U, X> osmTag(Collection<? extends OSMTagInterface> tags) {
+    return this.copyTransform(this.mapReducer.osmTag(tags));
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -347,7 +347,7 @@ public class MapAggregator<U extends Comparable<U> & Serializable, X> implements
 
   /**
    * Adds an osm tag filter: The analysis will be restricted to osm entities that have at least one
-   * of the supplied tags (key=value pairs).
+   * of the supplied tags (key=value pairs or key=*).
    *
    * @param tags the tags (key/value pairs or key=*) to filter the osm entities for
    * @return a modified copy of this object (can be used to chain multiple commands together)

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -483,7 +483,7 @@ public abstract class MapReducer<X> implements
    * Adds an osm tag filter: The analysis will be restricted to osm entities that have this tag key
    * and value.
    *
-   * @param tag the tag (key-value pair) to filter the osm entities for
+   * @param tag the tag (key-value pair or key=*) to filter the osm entities for
    * @return a modified copy of this mapReducer (can be used to chain multiple commands together)
    */
   @Contract(pure = true)

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -600,7 +600,9 @@ public abstract class MapReducer<X> implements
       ret.filters.add(ignored -> false);
       return ret;
     }
+    // for the "pre"-filter which removes all entitits wich don't have at least one of the given tag keys
     Set<Integer> preKeyIds = new HashSet<>();
+    // sets of tag keys and tags for the concrete entity filter: either one of these must match
     Set<Integer> keyIds = new HashSet<>();
     Set<OSHDBTag> keyValueIds = new HashSet<>();
     for (OSMTagInterface tag : tags) {

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerSettings.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerSettings.java
@@ -123,7 +123,7 @@ interface MapReducerSettings<M> {
    * @param keyValuePairs the tags (key/value pairs) to filter the osm entities for
    * @return `this` mapReducer (can be used to chain multiple commands together)
    */
-  M osmTag(Collection<OSMTag> keyValuePairs);
+  M osmTag(Collection<? extends OSMTagInterface> keyValuePairs);
 
   /** deprecated.
    * @deprecated replaced by {@link #osmType(OSMType, OSMType...)}

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerSettings.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerSettings.java
@@ -117,10 +117,10 @@ interface MapReducerSettings<M> {
   M osmTag(String key, Pattern valuePattern);
 
   /**
-   * Adds an osm tag filter: The analysis will be restricted to osm entities that have
-   * at least one of the supplied tags (key=value pairs).
+   * Adds an osm tag filter: The analysis will be restricted to osm entities that have at least one
+   * of the supplied tags (key=value pairs or key=*).
    *
-   * @param keyValuePairs the tags (key/value pairs) to filter the osm entities for
+   * @param keyValuePairs the tags (key/value pairs or key=*) to filter the osm entities for
    * @return `this` mapReducer (can be used to chain multiple commands together)
    */
   M osmTag(Collection<? extends OSMTagInterface> keyValuePairs);

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOSMDataFilters.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOSMDataFilters.java
@@ -142,7 +142,7 @@ public class TestOSMDataFilters {
         .timestamps(timestamps1)
         .count();
     assertEquals(5, result.intValue());
-    // only tags
+    // tags and keys mixed
     result = createMapReducerOSMEntitySnapshot()
         .osmTag(Arrays.asList(
             new OSMTag("highway", "residential"),
@@ -153,7 +153,7 @@ public class TestOSMDataFilters {
         .areaOfInterest(bbox)
         .timestamps(timestamps1)
         .count();
-    assertEquals(5+42, result.intValue());
+    assertEquals(5 + 42, result.intValue());
   }
 
   @Test

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOSMDataFilters.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOSMDataFilters.java
@@ -10,6 +10,8 @@ import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMEntitySnapshotView;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTag;
+import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTagInterface;
+import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTagKey;
 import org.heigit.bigspatialdata.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
@@ -129,6 +131,7 @@ public class TestOSMDataFilters {
 
   @Test
   public void tagList() throws Exception {
+    // only tags
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmTag(Arrays.asList(
             new OSMTag("highway", "residential"),
@@ -139,6 +142,18 @@ public class TestOSMDataFilters {
         .timestamps(timestamps1)
         .count();
     assertEquals(5, result.intValue());
+    // only tags
+    result = createMapReducerOSMEntitySnapshot()
+        .osmTag(Arrays.asList(
+            new OSMTag("highway", "residential"),
+            new OSMTag("highway", "unclassified"),
+            new OSMTagKey("building"))
+        )
+        .osmType(OSMType.WAY)
+        .areaOfInterest(bbox)
+        .timestamps(timestamps1)
+        .count();
+    assertEquals(5+42, result.intValue());
   }
 
   @Test


### PR DESCRIPTION
implements #209

# Changes proposed in this pull request:
## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
