### PR TITLE
give timeout tests a better chance to actually fail

### DIFF
--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestMapReduce.java
@@ -186,15 +186,13 @@ abstract class TestMapReduce {
   @Test(expected = OSHDBTimeoutException.class)
   public void testTimeoutMapReduce() throws Exception {
     // set super short timeout -> all queries should fail
-    oshdb.timeoutInMilliseconds(1);
+    oshdb.timeoutInMilliseconds(0);
 
     // simple query
     //noinspection ResultOfMethodCallIgnored - we only test for thrown exceptions here
     createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps6)
-        .osmEntityFilter(entity -> entity.getId() == 617308093)
-        .map(snapshot -> snapshot.getEntity().getUserId())
-        .uniq();
+        .count();
 
     // reset timeout
     oshdb.timeoutInMilliseconds(Long.MAX_VALUE);
@@ -203,16 +201,15 @@ abstract class TestMapReduce {
   @Test(expected = OSHDBTimeoutException.class)
   public void testTimeoutStream() throws Exception {
     // set super short timeout -> all queries should fail
-    oshdb.timeoutInMilliseconds(1);
+    oshdb.timeoutInMilliseconds(0);
 
     // simple query
     //noinspection ResultOfMethodCallIgnored - we only test for thrown exceptions here
     createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps6)
-        .osmEntityFilter(entity -> entity.getId() == 617308093)
-        .map(snapshot -> snapshot.getEntity().getUserId())
+        .map(snapshot -> snapshot.getEntity().getId())
         .stream()
-        .collect(Collectors.toSet());
+        .count();
 
     // reset timeout
     oshdb.timeoutInMilliseconds(Long.MAX_VALUE);


### PR DESCRIPTION
Sometimes test runners are so quick that they sometimes do not reach the specified timeout during (some of) the queries in the timeout tests.

Example of a failed test run because of this: https://jenkins.ohsome.org/blue/organizations/jenkins/oshdb/detail/master/266/pipeline#step-92-log-477

This PR should prevent this by giving the queries a more realistic chance to actually time out by:

* setting the timeout to 0ms (from 1ms)
* letting the OSHDB query work through slightly more data (from just 1 entity filtered by id, to all in the test data set)
