### PR TITLE
check if VERSION could be correctly determined

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -38,7 +38,6 @@ pipeline {
           }
         }
         script {
-
           server = Artifactory.server 'HeiGIT Repo'
           rtMaven = Artifactory.newMavenBuild()
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,14 +7,14 @@ pipeline {
     SNAPSHOT_DEPLOY = false
 
     VERSION = sh(returnStdout: true, script: 'mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version | grep -Ev "(^\\[|Download\\w+)"').trim()
-    PACKAGING = sh(returnStdout: true, script: 'mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.packaging | grep -Ev "(^\\[|Download\\w+)"').trim()
-    GROUP_ID = sh(returnStdout: true, script: 'mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.groupId | grep -Ev "(^\\[|Download\\w+)"').trim()
-    ARTIFACT_ID = sh(returnStdout: true, script: 'mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.artifactId | grep -Ev "(^\\[|Download\\w+)"').trim()
   }
 
   stages {
     stage ('Build and Test') {
       steps {
+        script {
+          sh(script: 'mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version')
+        }
         script {
           env.MAVEN_HOME = '/usr/share/maven'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,9 @@ pipeline {
     stage ('Build and Test') {
       steps {
         script {
-          sh(script: 'mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate -Dexpression=project.version')
+          if(!(VERSION ==~ RELEASE_REGEX) || !(VERSION ==~ /.*-SNAPSHOT$/)) {
+            error("The version-variable is invalid. The Build neither creates a release nor a snapshot and would not have beed deployed!")
+          }
         }
         script {
           env.MAVEN_HOME = '/usr/share/maven'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,7 +14,7 @@ pipeline {
       steps {
         script {
           if(!(VERSION ==~ RELEASE_REGEX) || !(VERSION ==~ /.*-SNAPSHOT$/)) {
-            error("The version-variable is invalid. The Build neither creates a release nor a snapshot and would not have beed deployed!")
+            throw new Exception("The version-variable is invalid. The Build neither creates a release nor a snapshot and would not have beed deployed!")
           }
         }
         script {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,11 +13,6 @@ pipeline {
     stage ('Build and Test') {
       steps {
         script {
-          if(!(VERSION ==~ RELEASE_REGEX) || !(VERSION ==~ /.*-SNAPSHOT$/)) {
-            throw new Exception("The version-variable is invalid. The Build neither creates a release nor a snapshot and would not have beed deployed!")
-          }
-        }
-        script {
           env.MAVEN_HOME = '/usr/share/maven'
 
           author = sh(returnStdout: true, script: 'git show -s --pretty=%an')
@@ -35,6 +30,14 @@ pipeline {
           echo env.BRANCH_NAME
           echo env.BUILD_NUMBER
           echo env.TAG_NAME
+
+          if(!(VERSION ==~ RELEASE_REGEX || VERSION ==~ /.*-SNAPSHOT$/)) {
+            echo 'Version:'
+            echo VERSION
+            error 'The version declaration is invalid. It is neither a release nor a snapshot. Mabe some error while fetching it using maven.'
+          }
+        }
+        script {
 
           server = Artifactory.server 'HeiGIT Repo'
           rtMaven = Artifactory.newMavenBuild()


### PR DESCRIPTION
Under some error conditions `mvn org.apache.maven.plugins:maven-help-plugin:2.1.1:evaluate` can fail. This is for example the case when a module's parent module cannot be loaded from the specified repositories. Before this fix, this lead to the variable `VERSION` to be empty, resulting in any (snapshot) release deploys to be skipped silently. This changes the behaviour to instead fail early in the _build and test_ step, so one can see that the build didn't go as planned.

//edit: I also removed some unused variables. these can be added again later if they are going to be needed