### PR TITLE
Removing UNKNOWN from OSMType, throw Exception instead!

### DIFF
--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/OSMXmlReader.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/OSMXmlReader.java
@@ -206,7 +206,7 @@ public class OSMXmlReader {
           } else if ("relation".equalsIgnoreCase(type)) {
             t = OSMType.RELATION;
           } else {
-            t = OSMType.UNKNOWN;
+            t = null;
           }
 
           // members[idx++] = new OSMMemberRelation(memId, t, r.intValue());

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osm/OSMType.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/osm/OSMType.java
@@ -1,7 +1,6 @@
 package org.heigit.bigspatialdata.oshdb.osm;
 
 public enum OSMType {
-  UNKNOWN(-1),
   NODE(0),
   WAY(1),
   RELATION(2);
@@ -20,8 +19,10 @@ public enum OSMType {
         return WAY;
       case 2:
         return RELATION;
-      default:
-        return UNKNOWN;
+      default: {
+          final String msg = String.format("Unknown OSMType! Should be between 0 and 2, got [%d]", value);
+          throw new IllegalArgumentException(msg);
+      } 
     }
     
   }


### PR DESCRIPTION
apply change with next major release, since this is binary incompatible with older oshdb 0.5.* relases: the ordinal value of the OSMType enumeration is different.

see #198 and #235 for further information. originally by @rtroilo 