### PR TITLE
Use warnings for infer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -173,7 +173,7 @@ pipeline {
           if(env.BRANCH_NAME ==~ /(^master$)/) {
             report_dir="/srv/reports/" + reponame + "/" + VERSION + "_"  + env.BRANCH_NAME + "/" +  env.BUILD_NUMBER + "_" +gittiid+"/infer/"
             sh "mvn clean"
-            sh "infer run -r -- mvn compile"
+            sh "infer run --pmd-xml -r -- mvn compile"
             sh "mkdir -p $report_dir && rm -Rf $report_dir* && cp -R ./infer-out/* $report_dir"
           }
 
@@ -186,6 +186,7 @@ pipeline {
           recordIssues enabledForFailure: true, tool: spotBugs()
           recordIssues enabledForFailure: true, tool: cpd(pattern: '**/target/cpd.xml')
           recordIssues enabledForFailure: true, tool: pmdParser(pattern: '**/target/pmd.xml')
+          recordIssues enabledForFailure: true, tool: pmdParser(pattern: '**/infer-out/report.xml', id: 'infer')
         }
       }
       post {


### PR DESCRIPTION
according to https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter/merge_requests/6
thanks to @tyrasd 

# Changes proposed in this pull request:
## Type of change
Please delete if not relevant:
- [x] New feature (non-breaking change which adds functionality)

## Description
- Add infer warnings to Jenkins pipeline

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [ ] ~I have written javadoc (required for public methods)~
- [ ] ~I have added sufficient unit tests~
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- [ ] ~I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)~
- [ ] ~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary~
