### PR TITLE
Use jacoco coverage in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,9 +168,10 @@ pipeline {
 
           rtMaven.run pom: 'pom.xml', goals: 'clean verify -Pjacoco -Dmaven.repo.local=.m2 $MAVEN_TEST_OPTIONS'
           jacoco(
-              execPattern      : 'target/jacoco.exec',
-              classPattern     : 'target/classes',
-              sourcePattern    : 'src/main/java'
+              execPattern      : '**/target/jacoco.exec',
+              classPattern     : '**/target/classes',
+              sourcePattern    : '**/src/main/java',
+              inclusionPattern : '/org/heigit/**'
           )
           sh "mkdir -p $report_dir && rm -Rf $report_dir* && find . -path '*/target/site/jacoco' -exec cp -R --parents {} $report_dir \\; && find $report_dir -path '*/target/site/jacoco' | while read line; do echo \$line; neu=\${line/target\\/site\\/jacoco/} ;  mv \$line/* \$neu ; done && find $report_dir -type d -empty -delete"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,6 +167,11 @@ pipeline {
           report_dir="/srv/reports/" + reponame + "/" + VERSION + "_"  + env.BRANCH_NAME + "/" +  env.BUILD_NUMBER + "_" +gittiid+"/jacoco/"
 
           rtMaven.run pom: 'pom.xml', goals: 'clean verify -Pjacoco -Dmaven.repo.local=.m2 $MAVEN_TEST_OPTIONS'
+          jacoco(
+              execPattern      : 'target/jacoco.exec',
+              classPattern     : 'target/classes',
+              sourcePattern    : 'src/main/java'
+          )
           sh "mkdir -p $report_dir && rm -Rf $report_dir* && find . -path '*/target/site/jacoco' -exec cp -R --parents {} $report_dir \\; && find $report_dir -path '*/target/site/jacoco' | while read line; do echo \$line; neu=\${line/target\\/site\\/jacoco/} ;  mv \$line/* \$neu ; done && find $report_dir -type d -empty -delete"
 
           // infer


### PR DESCRIPTION
according to https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter/merge_requests/7
thanks to @tyrasd 

# Changes proposed in this pull request:
## Type of change
Please delete if not relevant:
- [x] New feature (non-breaking change which adds functionality)

## Description
- add jacoco coverage view to jenkins

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [ ] ~I have written javadoc (required for public methods)~
- [ ] ~I have added sufficient unit tests~
- [ ] ~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- [ ] ~I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)~
- [ ] ~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary~
