### PR TITLE
dedicated handling of touching inner rings in multipoygons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Changelog
 * compatibility fix to allow building of javadoc under Java 11
 * fix bug where in some cases, instead of an OSHDBTimeoutException an IniteException was thrown. #258
 * improve accuracy of built-in geometry helper functions which calculate the geodesic lengths and areas of OSM geometries. #193
+* better handling of OSM multipolygons with touching inner rings. This improves performance considerably in some cases (especially large complex multipolygons). #249
 
 ## 0.5.10
 

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -460,7 +460,13 @@ public class OSHDBGeometryBuilder {
     Geometry geom = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     return Geo.clip(geom, clipPoly);
   }
-  
+
+  /**
+   * Converts a JTS bounding box ("envelope") to an OSHDBBoundingBox object.
+   *
+   * @param envelope the bounding box object to convert
+   * @return the same bounding box as an OSHDBBoundingBox object
+   */
   public static OSHDBBoundingBox boundingBoxOf(Envelope envelope) {
     return new OSHDBBoundingBox(
         envelope.getMinX(),

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -449,14 +449,42 @@ public class OSHDBGeometryBuilder {
     return joined;
   }
 
-  public static <T extends OSMEntity> Geometry getGeometryClipped(
-      T entity, OSHDBTimestamp timestamp, TagInterpreter areaDecider, OSHDBBoundingBox clipBbox) {
+  /**
+   * Builds the geometry of an OSM entity at the given timestamp, clipped to the given bounding box.
+   *
+   * @param entity the osm entity to generate the geometry of
+   * @param timestamp  the timestamp for which to create the entity's geometry
+   * @param areaDecider a TagInterpreter object which decides whether to generate a linear or a
+   *                    polygonal geometry for the respective entity (based on its tags)
+   * @param clipBbox the bounding box to clip the resulting geometry to
+   * @return a JTS geometry object (simple features compatible, i.e. a Point, LineString, Polygon
+   *         or MultiPolygon)
+   */
+  public static Geometry getGeometryClipped(
+      OSMEntity entity,
+      OSHDBTimestamp timestamp,
+      TagInterpreter areaDecider,
+      OSHDBBoundingBox clipBbox
+  ) {
     Geometry geom = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     return Geo.clip(geom, clipBbox);
   }
 
-  public static <P extends Geometry & Polygonal, T extends OSMEntity> Geometry getGeometryClipped(
-      T entity, OSHDBTimestamp timestamp, TagInterpreter areaDecider, P clipPoly) {
+  /**
+   * Builds the geometry of an OSM entity at the given timestamp, clipped to the given polygon.
+   *
+   * @param entity the osm entity to generate the geometry of
+   * @param timestamp  the timestamp for which to create the entity's geometry
+   * @param areaDecider a TagInterpreter object which decides whether to generate a linear or a
+   *                    polygonal geometry for the respective entity (based on its tags)
+   * @param clipPoly a polygon to clip the resulting geometry to
+   * @param <P> either {@link Polygon} or {@link org.locationtech.jts.geom.MultiPolygon}
+   * @return a JTS geometry object (simple features compatible, i.e. a Point, LineString, Polygon
+   *         or MultiPolygon)
+   */
+  public static <P extends Geometry & Polygonal> Geometry getGeometryClipped(
+      OSMEntity entity, OSHDBTimestamp timestamp, TagInterpreter areaDecider, P clipPoly
+  ) {
     Geometry geom = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     return Geo.clip(geom, clipPoly);
   }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -1,5 +1,10 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.osmtestdata;
 
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
@@ -16,12 +21,6 @@ import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.geom.Polygonal;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
-import org.locationtech.jts.operation.valid.IsValidOp;
-
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   private final OSMXmlReader testData = new OSMXmlReader();
@@ -962,15 +961,21 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
 
   @Test
   public void test777() throws ParseException {
-    // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/137
+    /*
+    777 is not really a valid test case.
+
+    According to https://wiki.openstreetmap.org/wiki/Relation:multipolygon: “Generally, the
+    multipolygon relation can be used to build multipolygons in compliance with the OGC Simple
+    Feature standard. Anything that is not a valid multipolygon according to this standard
+    should also be considered an invalid multipolygon relation.”
+
+    Here, the inners form a ring around a portion of the interior.
+    */
+    // https://github.com/GIScience/oshdb/issues/123
     // Multipolygon with two outer rings and two inner rings touching in two nodes
     OSMEntity entity = testData.relations().get(777900L).get(0);
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
-    assertTrue(result instanceof MultiPolygon);
-    assertTrue(result.isValid());
-    assertEquals(2, result.getNumGeometries());
-    assertEquals(1, ((Polygon)result.getGeometryN(0)).getNumInteriorRing()
-        + ((Polygon)result.getGeometryN(1)).getNumInteriorRing());
+    assertTrue(result instanceof Polygonal);
 
     // compare if coordinates of created points equals the coordinates of polygon
     Geometry expectedPolygon = (new WKTReader()).read(
@@ -985,7 +990,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   @Test
   public void test778() throws ParseException {
     /*
-    I believe 778 is not really a valid test case.
+    778 is not really a valid test case.
 
     According to https://wiki.openstreetmap.org/wiki/Relation:multipolygon: “[inner ways make] up
     the optional inner ring(s) delimiting the excluded holes that must be fully inside the area
@@ -995,12 +1000,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     geometry building algorithm should use the even-odd rule, the non-zero-winding rule, a
     subtractive algorithm or something else.
     */
-    // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/137
+    // https://github.com/GIScience/oshdb/issues/123
     // Multipolygon with two outer rings and two inner rings touching in two nodes
     OSMEntity entity = testData.relations().get(778900L).get(0);
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof Polygonal);
-    assertTrue(result.isValid());
   }
 
   @Test
@@ -1089,7 +1093,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
 
   @Test
   public void test784() throws ParseException {
-    // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/131
+    // https://github.com/GIScience/oshdb/issues/129
     // Valid OSM multipolygon with multiple touching inner rings
     OSMEntity entity = testData.relations().get(784900L).get(0);
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
@@ -1109,17 +1113,20 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
 
   @Test
   public void test785() throws ParseException {
-    // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/131
+    /*
+    785 is not really a valid test case.
+
+    According to https://wiki.openstreetmap.org/wiki/Relation:multipolygon: “An implementation of
+    multipolygons should attempt to render [touching inner rings] as if the touching rings were
+    indeed one ring.”
+
+    Here, the inners form more than one ring: one inner ring and one additional outer ring.
+    */
+    // https://github.com/GIScience/oshdb/issues/129
     // Valid OSM multipolygon with two touching inner rings leaving an empty area.
     OSMEntity entity = testData.relations().get(785900L).get(0);
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
-    assertTrue(result instanceof MultiPolygon);
-    assertTrue(result.isValid());
-    assertEquals(2, result.getNumGeometries());
-    assertEquals(1,
-        ((Polygon)result.getGeometryN(0)).getNumInteriorRing()
-        + ((Polygon)result.getGeometryN(1)).getNumInteriorRing()
-    );
+    assertTrue(result instanceof Polygonal);
     // compare if coordinates of created points equals the coordinates of polygon
     Geometry expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.51 1.81,7.56 1.81,7.56 1.86,7.51 1.86,7.51 1.81),"

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -962,7 +962,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   @Test
   public void test777() throws ParseException {
     /*
-    777 is not really a valid test case.
+    777 is not a valid test case.
 
     According to https://wiki.openstreetmap.org/wiki/Relation:multipolygon: “Generally, the
     multipolygon relation can be used to build multipolygons in compliance with the OGC Simple
@@ -990,7 +990,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   @Test
   public void test778() throws ParseException {
     /*
-    778 is not really a valid test case.
+    778 is not a valid test case.
 
     According to https://wiki.openstreetmap.org/wiki/Relation:multipolygon: “[inner ways make] up
     the optional inner ring(s) delimiting the excluded holes that must be fully inside the area
@@ -1114,7 +1114,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   @Test
   public void test785() throws ParseException {
     /*
-    785 is not really a valid test case.
+    785 is not a valid test case.
 
     According to https://wiki.openstreetmap.org/wiki/Relation:multipolygon: “An implementation of
     multipolygons should attempt to render [touching inner rings] as if the touching rings were
@@ -1210,4 +1210,3 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     }
   }
 }
-

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
@@ -1,6 +1,5 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.relations;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
@@ -13,9 +12,8 @@ import org.heigit.bigspatialdata.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
-import org.locationtech.jts.geom.Polygon;
-public class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
 
+public class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
   private final OSMXmlReader testData = new OSMXmlReader();
   private final TagInterpreter tagInterpreter;
   private final OSHDBTimestamp timestamp =
@@ -27,14 +25,11 @@ public class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
     tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
   }
 
-
   @Test
   public void test() {
-    // data has invlid (self-intersecting) outer ring
+    // data has invalid (self-intersecting) outer ring
     OSMEntity entity = testData.relations().get(1L).get(0);
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
-    assertEquals(result.getClass(), MultiPolygon.class);
     assertTrue(result instanceof MultiPolygon);
-    assertTrue(result.isValid());
   }
 }


### PR DESCRIPTION
The previous workaround of using `buffer(0)` to let JTS join any touching inner rings can be very slow, up to the point of potentially bringing a query to an almost complete halt when it has to be called on very large multipolygons (e.g. `relation/1205151`).

This adds dedicated handling of touching inner rings, and merges them before the geometry object is created.

A few test cases were adjusted, because the new handling is following more strictly the multipolygon validity rules given in the osm wiki. (related: #123, #129)

Also includes some minor code cleanup (e.g. adding of a private construtor to the static geometry builder utility class to hide the implicit public constructor).


# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
