### PR TITLE
Improve documentation of group by entity feature

### DIFF
--- a/documentation/manual/views.md
+++ b/documentation/manual/views.md
@@ -54,7 +54,7 @@ Note that there exist [cases](https://github.com/GIScience/oshdb/issues/87) wher
 GroupByEntity
 -------------
 
-The [`groupByEntity()`](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#groupByEntity--) method of a MapReducer slightly changes the way the MapReducers recieves and transforms values: Instead of iterating over each snapshot or contribution individually, in this mode all snapshots or all contributinos of an individual OSM entity are collected into a list of values first. This makes it possible to investigate the full edit history of individual OSM objects at once.
+The [`groupByEntity()`](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#groupByEntity--) method of a MapReducer slightly changes the way the MapReducers recieves and transforms values: Instead of iterating over each snapshot or contribution individually, in this mode all snapshots or all contributions of an individual OSM entity are collected into a (by timestamp sorted) list first. This makes it possible to investigate the full edit history of individual OSM objects at once, which is for example needed when one is looking for contributions that got reverted at a later point in time.
 
 It is recommended to call this method immediately after creating the MapReducer from a view:
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -715,7 +715,11 @@ public abstract class MapReducer<X> implements
    * Groups the input data (osm entity snapshot or contributions) by their respective entity's ids
    * before feeding them into further transformation functions. This can be used to do more complex
    * analysis on the osm data, that requires one to know about the full editing history of
-   * individual osm entities.
+   * individual osm entities, e.g., when looking for contributions which got reverted at a later
+   * point in time.
+   *
+   * <p>The values in the returned lists of snapshot or contribution objects are returned in their
+   * natural order: i.e. sorted ascending by timestamp.</p>
    *
    * <p>This needs to be called before any `map` or `flatMap` transformation functions have been
    * set. Otherwise a runtime exception will be thrown.</p>

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMContribution.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMContribution.java
@@ -267,6 +267,11 @@ public class OSMContribution implements OSHDBMapReducible, Comparable<OSMContrib
     return data.changeset;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * Note: this class has a natural ordering that is inconsistent with equals.
+   */
   @Override
   public int compareTo(@Nonnull OSMContribution other) {
     return ComparisonChain.start()

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMContribution.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMContribution.java
@@ -1,7 +1,9 @@
 package org.heigit.bigspatialdata.oshdb.api.object;
 
+import com.google.common.collect.ComparisonChain;
 import java.util.EnumSet;
 import java.util.Objects;
+import javax.annotation.Nonnull;
 import org.heigit.bigspatialdata.oshdb.osh.OSHEntity;
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
 import org.heigit.bigspatialdata.oshdb.osm.OSMRelation;
@@ -26,7 +28,7 @@ import org.locationtech.jts.geom.Geometry;
  *   modification of a geometry, altering of the tag list, etc.)</li>
  * </ul>
  */
-public class OSMContribution implements OSHDBMapReducible {
+public class OSMContribution implements OSHDBMapReducible, Comparable<OSMContribution> {
   private final IterateAllEntry data;
 
   public OSMContribution(IterateAllEntry data) {
@@ -263,5 +265,14 @@ public class OSMContribution implements OSHDBMapReducible {
    */
   public long getChangesetId() {
     return data.changeset;
+  }
+
+  @Override
+  public int compareTo(@Nonnull OSMContribution other) {
+    return ComparisonChain.start()
+        .compare(this.getOSHEntity().getType(), other.getOSHEntity().getType())
+        .compare(this.getOSHEntity().getId(), other.getOSHEntity().getId())
+        .compare(this.getTimestamp(), other.getTimestamp())
+        .result();
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMEntitySnapshot.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMEntitySnapshot.java
@@ -1,5 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.api.object;
 
+import com.google.common.collect.ComparisonChain;
+import javax.annotation.Nonnull;
 import org.heigit.bigspatialdata.oshdb.osh.OSHEntity;
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
@@ -12,7 +14,7 @@ import org.locationtech.jts.geom.Geometry;
  *
  * <p>Alongside the entity and the timestamp, also the entity's geometry is provided.</p>
  */
-public class OSMEntitySnapshot implements OSHDBMapReducible {
+public class OSMEntitySnapshot implements OSHDBMapReducible, Comparable<OSMEntitySnapshot> {
   private final IterateByTimestampEntry data;
   
   public OSMEntitySnapshot(IterateByTimestampEntry data) {
@@ -80,5 +82,14 @@ public class OSMEntitySnapshot implements OSHDBMapReducible {
    */
   public OSHEntity getOSHEntity() {
     return data.oshEntity;
+  }
+
+  @Override
+  public int compareTo(@Nonnull OSMEntitySnapshot other) {
+    return ComparisonChain.start()
+        .compare(this.getOSHEntity().getType(), other.getOSHEntity().getType())
+        .compare(this.getOSHEntity().getId(), other.getOSHEntity().getId())
+        .compare(this.getTimestamp(), other.getTimestamp())
+        .result();
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMEntitySnapshot.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMEntitySnapshot.java
@@ -84,6 +84,11 @@ public class OSMEntitySnapshot implements OSHDBMapReducible, Comparable<OSMEntit
     return data.oshEntity;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * Note: this class has a natural ordering that is inconsistent with equals.
+   */
   @Override
   public int compareTo(@Nonnull OSMEntitySnapshot other) {
     return ComparisonChain.start()

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/LazyEvaluatedObject.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/LazyEvaluatedObject.java
@@ -30,10 +30,15 @@ public class LazyEvaluatedObject<T> implements Supplier<T> {
   @Override
   public boolean equals(Object o) {
     if (o instanceof LazyEvaluatedObject) {
-      LazyEvaluatedObject lazyO = (LazyEvaluatedObject)o;
+      LazyEvaluatedObject<?> lazyO = (LazyEvaluatedObject<?>)o;
       return this.get().equals(lazyO.get());
     }
     return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return this.get().hashCode();
   }
 
   public boolean wasEvaluated() {

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/util/OSHDBTimestamp.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/util/OSHDBTimestamp.java
@@ -9,10 +9,10 @@ import java.util.Date;
 
 public class OSHDBTimestamp implements Comparable<OSHDBTimestamp>, Serializable {
   private static final long serialVersionUID = 1L;
-  private long _tstamp;
+  private long tstamp;
 
   public OSHDBTimestamp(long tstamp) {
-    this._tstamp = tstamp;
+    this.tstamp = tstamp;
   }
 
   public OSHDBTimestamp(Date tstamp) {
@@ -20,32 +20,37 @@ public class OSHDBTimestamp implements Comparable<OSHDBTimestamp>, Serializable 
   }
   
   public void setTimestamp(long tstamp){
-    this._tstamp = tstamp;
+    this.tstamp = tstamp;
   }
 
   @Override
   public int compareTo(OSHDBTimestamp other) {
-    return Long.compare(this._tstamp, other._tstamp);
+    return Long.compare(this.tstamp, other.tstamp);
   }
 
   @Override
   public boolean equals(Object other) {
     if (other instanceof OSHDBTimestamp)
-      return this._tstamp == ((OSHDBTimestamp)other)._tstamp;
+      return this.tstamp == ((OSHDBTimestamp)other).tstamp;
     else
       return super.equals(other);
   }
+
+  @Override
+  public int hashCode() {
+    return Long.hashCode(this.tstamp);
+  }
   
   public Date toDate() {
-    return new Date(this._tstamp * 1000);
+    return new Date(this.tstamp * 1000);
   }
 
   public long getRawUnixTimestamp() {
-    return this._tstamp;
+    return this.tstamp;
   }
 
   public String toString() {
-    ZonedDateTime zdt = ZonedDateTime.ofInstant(Instant.ofEpochSecond(_tstamp), ZoneOffset.UTC);
+    ZonedDateTime zdt = ZonedDateTime.ofInstant(Instant.ofEpochSecond(tstamp), ZoneOffset.UTC);
     return zdt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
   }
 }


### PR DESCRIPTION
additionally, this makes `OSMContribution` and `OSMEntitySnapshot` objects comparable to each other, defining a natural order: first by their respective entity _type_ and _id_, then by their _timestamp_.


# Checklist
- [ ] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [ ] I have commented my code
- [ ] I have written javadoc (required for public methods)
- [ ] I have added sufficient unit tests
- [ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
