### PR TITLE
fix doclint error (in Java 11)

### DIFF
--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java
@@ -14,8 +14,9 @@ import org.slf4j.LoggerFactory;
 /**
  * XYGrid spans an equal degree grid over the world.
  * 
- * <p>How XYGrid sees the world. Example IDs for zoom = 2:
+ * <p>Example IDs for zoom = 2:
  * <table style="text-align:center; border-spacing: 4px">
+ * <caption>How XYGrid sees the world.</caption>
  * <tr>
  * <td></td><td></td><td colspan="3">+90 lat</td><td></td><td></td><td></td>
  * </tr>

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
  * <tr>
  * <td></td><td></td><td colspan="3">-90 lat</td><td></td><td></td><td></td>
  * </tr>
- * </table></p>
+ * </table>
  *
  * <p>Longitude +180 will be wrapped around to -180. Coordinates lying on
  * grid-borders will be assigned to the north-eastern cell.</p>

--- a/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java
+++ b/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java
@@ -13,10 +13,9 @@ import org.slf4j.LoggerFactory;
 
 /**
  * XYGrid spans an equal degree grid over the world.
- * <br>
- * <br>
- * IDs for zoom = 2:
- * <table summary="how XYGrid sees the world" style="text-align:center; border-spacing: 4px">
+ * 
+ * <p>How XYGrid sees the world. Example IDs for zoom = 2:
+ * <table style="text-align:center; border-spacing: 4px">
  * <tr>
  * <td></td><td></td><td colspan="3">+90 lat</td><td></td><td></td><td></td>
  * </tr>
@@ -32,12 +31,10 @@ import org.slf4j.LoggerFactory;
  * <tr>
  * <td></td><td></td><td colspan="3">-90 lat</td><td></td><td></td><td></td>
  * </tr>
- * </table>
- * <br>
- * Longitude +180 will be wrapped around to -180. Coordinates lying on
- * grid-borders will be assigned to the north-eastern cell.
+ * </table></p>
  *
- *
+ * <p>Longitude +180 will be wrapped around to -180. Coordinates lying on
+ * grid-borders will be assigned to the north-eastern cell.</p>
  */
 public class XYGrid implements Serializable {
 


### PR DESCRIPTION
fixes an error while building javadoc on openjdk-11:

```
MavenReportException: Error while generating Javadoc:
[main] ERROR org.apache.maven.cli.MavenCli - Exit code: 1 - /var/jenkins_home/workspace/oshdb_master-RVIDC2LPT4HCVWT5BKWAIEUOKFCZO7TEKEF7P2PHZSCDMPY344BA/oshdb/src/main/java/org/heigit/bigspatialdata/oshdb/index/XYGrid.java:19: error: attribute not supported in HTML5: summary
[main] ERROR org.apache.maven.cli.MavenCli - * <table summary="how XYGrid sees the world" style="text-align:center; border-spacing: 4px">
[main] ERROR org.apache.maven.cli.MavenCli - ^
```