### PR TITLE
ohsome filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Changelog
 * improve accuracy of built-in geometry helper functions which calculate the geodesic lengths and areas of OSM geometries. #193
 * better handling of OSM multipolygons with touching inner rings. This improves performance considerably in some cases (especially large complex multipolygons). #249
 * (breaking) Timestamp parser class renamed to `IsoDateTimeParser` from `ISODateTimeParser` and adjust how input timestamps (e.g. in `MapReducer.timestamps()`) are handled: only the UTC time zone identifier `Z` is supported. #265
+* integrate [ohsome filter](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter) functionality. #253
 
 ## 0.5.10
 

--- a/documentation/manual/filters.md
+++ b/documentation/manual/filters.md
@@ -47,11 +47,11 @@ It is possible to [define custom filtering functions](https://docs.ohsome.org/ja
 _ohsome_ filter
 ---------------
 
-An easy way to provide complex [`filter`s](https://docs.ohsome.org/java/oshdb/0.6.0-SNAPSHOT/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#filter-org.heigit.bigspatialdata.oshdb.api.generic.function.String-) (available in the upcoming version 0.6 of the OSHDB) is through the functionality of [ohsome filters](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#readme), which allow one to define osm data filter in a human readable syntax. With these one can combine several tag, type and geoemtry filters with arbitrary boolean operators.
+An easy way to provide complex [`filter`s](https://docs.ohsome.org/java/oshdb/0.6.0-SNAPSHOT/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#filter-org.heigit.bigspatialdata.oshdb.api.generic.function.String-) (available in the upcoming version 0.6 of the OSHDB) is through the functionality of [ohsome filters](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#readme), which allow one to define osm data filter in a human readable syntax. With these one can combine several tag, type and geometry filters with arbitrary boolean operators.
 
 _lambda_ filter
 ---------------
 
-It is possible to define [`filter` functions](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#filter-org.heigit.bigspatialdata.oshdb.api.generic.function.SerializablePredicate-) that can sort out values after they already have been transformed in a [map](map.md#map) step.
+It is possible to define [`filter` functions](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#filter-org.heigit.bigspatialdata.oshdb.api.generic.function.SerializablePredicate-) that can sort out values after they already have been transformed in a [map](map-reduce.md#map) step.
 
-Note that it is ususally best to use the less flexible, but more performant OSM data filters described above wherever possible, as they can reduce the amount of data to be iterated over right from the start of the query. This is because while the basic filters are applied at the beginning of each query on the full OSM history data directly, the filter lambda functions are only executed after the data has already been computed and transformed.
+Note that it is usually best to use the less flexible, but more performant OSM data filters described above wherever possible, as they can reduce the amount of data to be iterated over right from the start of the query. This is because while the basic filters are applied at the beginning of each query on the full OSM history data directly, the filter lambda functions are only executed after the data has already been computed and transformed.

--- a/documentation/manual/filters.md
+++ b/documentation/manual/filters.md
@@ -43,3 +43,15 @@ osmEntityFilter
 ---------------
 
 It is possible to [define custom filtering functions](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#osmEntityFilter-org.heigit.bigspatialdata.oshdb.api.generic.function.SerializablePredicate-), that take an OSM entity object as input and decide wether each individual entity should be included in the result or not by returning a boolean value.
+
+_ohsome_ filter
+---------------
+
+An easy way to provide complex [`filter`s](https://docs.ohsome.org/java/oshdb/0.6.0-SNAPSHOT/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#filter-org.heigit.bigspatialdata.oshdb.api.generic.function.String-) (available in the upcoming version 0.6 of the OSHDB) is through the functionality of [ohsome filters](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#readme), which allow one to define osm data filter in a human readable syntax. With these one can combine several tag, type and geoemtry filters with arbitrary boolean operators.
+
+_lambda_ filter
+---------------
+
+It is possible to define [`filter` functions](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#filter-org.heigit.bigspatialdata.oshdb.api.generic.function.SerializablePredicate-) that can sort out values after they already have been transformed in a [map](map.md#map) step.
+
+Note that it is ususally best to use the less flexible, but more performant OSM data filters described above wherever possible, as they can reduce the amount of data to be iterated over right from the start of the query. This is because while the basic filters are applied at the beginning of each query on the full OSM history data directly, the filter lambda functions are only executed after the data has already been computed and transformed.

--- a/documentation/manual/map-reduce.md
+++ b/documentation/manual/map-reduce.md
@@ -22,9 +22,7 @@ A [`flatMap`](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/bi
 filter
 ------
 
-It is possible to define [`filter`s](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.html#filter-org.heigit.bigspatialdata.oshdb.api.generic.function.SerializablePredicate-) that can sort out values after they already have been transformed in a map step.
-
-Note that these filters are different from the OSM data filters described in the “[Filtering of OSM data](filters.md)” section of this manual, since those filters are always applied at the beginning of each query on the full OSM history data directly, while the filters described here are executed during the transformation of the data. Normally, it is best to use the less flexible, but more performant OSM data filters wherever possible, because they can reduce the amount of data to be iterated over right from the start of the query.
+Filters can even be applied in the map phase. Read more about this feature in the [filters](filters.md#lambda-filters) section of this manual.
 
 reduce
 ------

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -14,6 +14,11 @@
   <name>OSHDB API</name>
   <description>API to query the OpenStreetMap History Database. Includes MapReduce functionality to filter, analyze and aggregate data.</description>
 
+  <properties>
+    <ohsomefilter.version>1.4.0</ohsomefilter.version>
+    <tdigest.version>3.2</tdigest.version>
+  </properties>
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -83,13 +88,13 @@
     <dependency>
       <groupId>com.tdunning</groupId>
       <artifactId>t-digest</artifactId>
-      <version>3.2</version>
+      <version>${tdigest.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.heigit.ohsome</groupId>
       <artifactId>ohsome-filter</artifactId>
-      <version>1.4-SNAPSHOT</version>
+      <version>${ohsomefilter.version}</version>
     </dependency>
     
     <!-- TEST dependencies -->

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -85,6 +85,12 @@
       <artifactId>t-digest</artifactId>
       <version>3.2</version>
     </dependency>
+
+    <dependency>
+      <groupId>org.heigit.ohsome</groupId>
+      <artifactId>ohsome-filter</artifactId>
+      <version>1.3.0</version>
+    </dependency>
     
     <!-- TEST dependencies -->
     <dependency>
@@ -97,12 +103,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.heigit.ohsome</groupId>
-      <artifactId>ohsome-filter</artifactId>
-      <version>1.2.0</version>
     </dependency>
   </dependencies>
 

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -89,7 +89,7 @@
     <dependency>
       <groupId>org.heigit.ohsome</groupId>
       <artifactId>ohsome-filter</artifactId>
-      <version>1.3.0</version>
+      <version>1.4-SNAPSHOT</version>
     </dependency>
     
     <!-- TEST dependencies -->

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -98,7 +98,12 @@
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>
     </dependency>
-    
+
+    <dependency>
+      <groupId>org.heigit.ohsome</groupId>
+      <artifactId>ohsome-filter</artifactId>
+      <version>1.2-SNAPSHOT</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -102,7 +102,7 @@
     <dependency>
       <groupId>org.heigit.ohsome</groupId>
       <artifactId>ohsome-filter</artifactId>
-      <version>1.2-SNAPSHOT</version>
+      <version>1.2.0</version>
     </dependency>
   </dependencies>
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -826,6 +826,20 @@ public class MapAggregator<U extends Comparable<U> & Serializable, X> implements
     return this.copyTransform(this.mapReducer.filter(f));
   }
 
+  /**
+   * Apply a custom "ohsome" filter to this query.
+   *
+   * <p>See https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#syntax
+   * for a description of the ohsome filter syntax.</p>
+   *
+   * @param f the ohsome filter string to apply to the mapAggregator
+   * @return a modified copy of this object (can be used to chain multiple commands together)
+   */
+  @Contract(pure = true)
+  public MapAggregator<U, X> filter(String f) {
+    return this.copyTransform(this.mapReducer.filter(f));
+  }
+
   // -----------------------------------------------------------------------------------------------
   // Exposed generic reduce.
   // Can be used by experienced users of the api to implement complex queries.

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -41,6 +41,7 @@ import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.util.exceptions.OSHDBInvalidTimestampException;
 import org.heigit.bigspatialdata.oshdb.util.tagtranslator.OSMTagInterface;
+import org.heigit.ohsome.filter.FilterExpression;
 import org.jetbrains.annotations.Contract;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygonal;
@@ -808,6 +809,21 @@ public class MapAggregator<U extends Comparable<U> & Serializable, X> implements
     return this.copyTransform(this.mapReducer.filter(data ->
       f.test(data.getValue())
     ));
+  }
+
+  /**
+   * Apply a custom "ohsome" filter expression to this query.
+   *
+   * <p>See https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#readme
+   * and https://docs.ohsome.org/java/ohsome-filter/1.2-SNAPSHOT for further information about how
+   * to create such a filter expression object.</p>
+   *
+   * @param f the filter expression to apply to the mapAggregator
+   * @return a modified copy of this object (can be used to chain multiple commands together)
+   */
+  @Contract(pure = true)
+  public MapAggregator<U, X> filter(FilterExpression f) {
+    return this.copyTransform(this.mapReducer.filter(f));
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -719,8 +719,8 @@ public abstract class MapReducer<X> implements
   /**
    * Apply a custom "ohsome" filter expression to this query.
    *
-   * <p>See https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#readme
-   * and https://docs.ohsome.org/java/ohsome-filter/1.3.0 for further information about how
+   * <p>See https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#ohsome-filter
+   * and https://docs.ohsome.org/java/ohsome-filter for further information about how
    * to create such a filter expression object.</p>
    *
    * @param f the filter expression to apply to the mapReducer

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -723,7 +723,7 @@ public abstract class MapReducer<X> implements
    * and https://docs.ohsome.org/java/ohsome-filter/1.2-SNAPSHOT for further information about how
    * to create such a filter expression object.</p>
    *
-   * @param f the filter expression to apply to the mapreducer
+   * @param f the filter expression to apply to the mapReducer
    * @return a modified copy of this mapReducer (can be used to chain multiple commands together)
    */
   @Contract(pure = true)

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -67,6 +67,7 @@ import org.heigit.ohsome.filter.AndOperator;
 import org.heigit.ohsome.filter.BinaryOperator;
 import org.heigit.ohsome.filter.Filter;
 import org.heigit.ohsome.filter.FilterExpression;
+import org.heigit.ohsome.filter.FilterParser;
 import org.heigit.ohsome.filter.GeometryTypeFilter;
 import org.heigit.ohsome.filter.TagFilterEquals;
 import org.heigit.ohsome.filter.TagFilterEqualsAny;
@@ -749,6 +750,20 @@ public abstract class MapReducer<X> implements
       ret.mappers.addAll(mappers);
     }
     return optimizeFilters(ret, f);
+  }
+
+  /**
+   * Apply a custom "ohsome" filter to this query.
+   *
+   * <p>See https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#syntax
+   * for a description of the ohsome filter syntax.</p>
+   *
+   * @param f the ohsome filter string to apply to the mapReducer
+   * @return a modified copy of this mapReducer (can be used to chain multiple commands together)
+   */
+  @Contract(pure = true)
+  public MapReducer<X> filter(String f) {
+    return this.filter(new FilterParser(this.getTagTranslator()).parse(f));
   }
 
   // -----------------------------------------------------------------------------------------------

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -721,7 +721,7 @@ public abstract class MapReducer<X> implements
    * Apply a custom "ohsome" filter expression to this query.
    *
    * <p>See https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#readme
-   * and https://docs.ohsome.org/java/ohsome-filter/1.2-SNAPSHOT for further information about how
+   * and https://docs.ohsome.org/java/ohsome-filter/1.3.0 for further information about how
    * to create such a filter expression object.</p>
    *
    * @param f the filter expression to apply to the mapReducer

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -731,8 +731,8 @@ public abstract class MapReducer<X> implements
     MapReducer<X> ret = this.copy();
     ret.preFilters.add(f::applyOSH);
     ret.filters.add(f::applyOSM);
-    // apply geometry filter (only) if needed
-    List<MapFunction> mappers = List.copyOf(ret.mappers);
+    // apply geometry filter as first map function
+    final List<MapFunction> remainingMappers = List.copyOf(ret.mappers);
     ret.mappers.clear();
     if (ret.forClass.equals(OSMContribution.class)) {
       ret = ret.filter(x -> {
@@ -746,7 +746,7 @@ public abstract class MapReducer<X> implements
         return f.applyOSMGeometry(s.getEntity(), s::getGeometry);
       });
     }
-    ret.mappers.addAll(mappers);
+    ret.mappers.addAll(remainingMappers);
     return optimizeFilters(ret, f);
   }
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -734,7 +734,8 @@ public abstract class MapReducer<X> implements
     ret.filters.add(f::applyOSM);
     // apply geometry filter (only) if needed
     if (hasGeometryTypeFilter(f)) {
-      List<MapFunction> mappers = ret.mappers;
+      List<MapFunction> mappers = List.copyOf(ret.mappers);
+      ret.mappers.clear();
       if (ret.forClass.equals(OSMContribution.class)) {
         ret = ret.filter(x -> {
           OSMContribution c = (OSMContribution) x;

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -719,9 +719,9 @@ public abstract class MapReducer<X> implements
   /**
    * Apply a custom "ohsome" filter expression to this query.
    *
-   * <p>See https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#ohsome-filter
-   * and https://docs.ohsome.org/java/ohsome-filter for further information about how
-   * to create such a filter expression object.</p>
+   * <p>See <a href="https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#ohsome-filter">https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#ohsome-filter</a>
+   * and <a href="https://docs.ohsome.org/java/ohsome-filter">https://docs.ohsome.org/java/ohsome-filter</a>
+   * for further information about how to create such a filter expression object.</p>
    *
    * @param f the filter expression to apply to the mapReducer
    * @return a modified copy of this mapReducer (can be used to chain multiple commands together)
@@ -753,7 +753,7 @@ public abstract class MapReducer<X> implements
   /**
    * Apply a custom "ohsome" filter to this query.
    *
-   * <p>See https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#syntax
+   * <p>See <a href="https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#syntax">https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter#syntax</a>
    * for a description of the ohsome filter syntax.</p>
    *
    * @param f the ohsome filter string to apply to the mapReducer

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestLambdaFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestLambdaFilter.java
@@ -1,8 +1,3 @@
-/*
- * To change this license header, choose License Headers in Project Properties.
- * To change this template file, choose Tools | Templates
- * and open the template in the editor.
- */
 package org.heigit.bigspatialdata.oshdb.api.tests;
 
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
@@ -22,9 +17,9 @@ import java.util.SortedMap;
 import static org.junit.Assert.assertEquals;
 
 /**
- *
+ * Tests lambda functions as filters.
  */
-public class TestFilter {
+public class TestLambdaFilter {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
@@ -32,7 +27,7 @@ public class TestFilter {
 
   private final double DELTA = 1e-8;
 
-  public TestFilter() throws Exception {
+  public TestLambdaFilter() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOSMDataFilters.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOSMDataFilters.java
@@ -25,24 +25,16 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 /**
- *
+ * Tests osm data filters.
  */
 public class TestOSMDataFilters {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8.651133,49.387611,8.6561,49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2014-01-01");
-  private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2015-01-01");
-  private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01", OSHDBTimestamps.Interval.MONTHLY);
-
-  private final double DELTA = 1e-8;
 
   public TestOSMDataFilters() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
-  }
-
-  private MapReducer<OSMContribution> createMapReducerOSMContribution() throws Exception {
-    return OSMContributionView.on(oshdb);
   }
   private MapReducer<OSMEntitySnapshot> createMapReducerOSMEntitySnapshot() throws Exception {
     return OSMEntitySnapshotView.on(oshdb);

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOhsomeFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOhsomeFilter.java
@@ -47,9 +47,10 @@ public class TestOhsomeFilter {
 
   @Test
   public void testFilterString() throws Exception {
-    Integer result = createMapReducer()
-        .filter("type:way and building=*")
-        .count();
+    Number result = createMapReducer()
+        .map(x -> 1)
+        .filter("type:way and geometry:polygon and building=*")
+        .sum();
 
     assertEquals(42, result.intValue());
   }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOhsomeFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOhsomeFilter.java
@@ -1,0 +1,68 @@
+package org.heigit.bigspatialdata.oshdb.api.tests;
+
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;
+import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.MapReducer;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMContributionView;
+import org.heigit.bigspatialdata.oshdb.api.mapreducer.OSMEntitySnapshotView;
+import org.heigit.bigspatialdata.oshdb.api.object.OSMEntitySnapshot;
+import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
+import org.heigit.bigspatialdata.oshdb.osm.OSMMember;
+import org.heigit.bigspatialdata.oshdb.osm.OSMRelation;
+import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
+import org.heigit.bigspatialdata.oshdb.util.taginterpreter.TagInterpreter;
+import org.heigit.bigspatialdata.oshdb.util.time.OSHDBTimestamps;
+import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
+import org.heigit.bigspatialdata.oshdb.osm.OSMType;
+import org.heigit.bigspatialdata.oshdb.util.celliterator.ContributionType;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.SortedMap;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Tests integration of ohsome-filter library.
+ *
+ * <p>
+ *   Only basic "is it working at all" tests are done, since the library itself has its own set
+ *   of unit tests.
+ * </p>
+ */
+public class TestOhsomeFilter {
+  private final OSHDBDatabase oshdb;
+
+  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8.651133,49.387611,8.6561,49.390513);
+
+  public TestOhsomeFilter() throws Exception {
+    oshdb = new OSHDBH2("./src/test/resources/test-data");
+  }
+
+  private MapReducer<OSMEntitySnapshot> createMapReducer() throws Exception {
+    return OSMEntitySnapshotView.on(oshdb)
+        .areaOfInterest(bbox)
+        .timestamps("2014-01-01");
+  }
+
+  @Test
+  public void testFilterString() throws Exception {
+    Integer result = createMapReducer()
+        .filter("type:way and building=*")
+        .count();
+
+    assertEquals(42, result.intValue());
+  }
+
+  @Test
+  public void testAggregateFilter() throws Exception {
+    SortedMap<OSMType, Integer> result = createMapReducer()
+        .filter("(geometry:polygon or geometry:other) and building=*")
+        .aggregateBy(x -> x.getEntity().getType())
+        .count();
+
+    assertEquals(2, result.entrySet().size());
+    assertEquals(42, result.get(OSMType.WAY).intValue());
+    assertEquals(1, result.get(OSMType.RELATION).intValue());
+  }
+}

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOhsomeFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOhsomeFilter.java
@@ -11,10 +11,12 @@ import org.heigit.bigspatialdata.oshdb.osm.OSMMember;
 import org.heigit.bigspatialdata.oshdb.osm.OSMRelation;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.taginterpreter.TagInterpreter;
+import org.heigit.bigspatialdata.oshdb.util.tagtranslator.TagTranslator;
 import org.heigit.bigspatialdata.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.bigspatialdata.oshdb.api.object.OSMContribution;
 import org.heigit.bigspatialdata.oshdb.osm.OSMType;
 import org.heigit.bigspatialdata.oshdb.util.celliterator.ContributionType;
+import org.heigit.ohsome.filter.FilterParser;
 import org.junit.Test;
 
 import java.util.Set;
@@ -32,11 +34,14 @@ import static org.junit.Assert.assertEquals;
  */
 public class TestOhsomeFilter {
   private final OSHDBDatabase oshdb;
+  private final FilterParser filterParser;
 
   private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8.651133,49.387611,8.6561,49.390513);
 
   public TestOhsomeFilter() throws Exception {
-    oshdb = new OSHDBH2("./src/test/resources/test-data");
+    OSHDBH2 oshdb = new OSHDBH2("./src/test/resources/test-data");
+    filterParser = new FilterParser(new TagTranslator(oshdb.getConnection()));
+    this.oshdb = oshdb;
   }
 
   private MapReducer<OSMEntitySnapshot> createMapReducer() throws Exception {
@@ -56,6 +61,16 @@ public class TestOhsomeFilter {
   }
 
   @Test
+  public void testFilterObject() throws Exception {
+    MapReducer<OSMEntitySnapshot> mr = createMapReducer();
+    Number result = mr
+        .filter(filterParser.parse("type:way and geometry:polygon and building=*"))
+        .count();
+
+    assertEquals(42, result.intValue());
+  }
+
+  @Test
   public void testAggregateFilter() throws Exception {
     SortedMap<OSMType, Integer> result = createMapReducer()
         .aggregateBy(x -> x.getEntity().getType())
@@ -65,5 +80,16 @@ public class TestOhsomeFilter {
     assertEquals(2, result.entrySet().size());
     assertEquals(42, result.get(OSMType.WAY).intValue());
     assertEquals(1, result.get(OSMType.RELATION).intValue());
+  }
+
+  @Test
+  public void testAggregateFilterObject() throws Exception {
+    MapReducer<OSMEntitySnapshot> mr = createMapReducer();
+    SortedMap<OSMType, Integer> result = mr
+        .aggregateBy(x -> x.getEntity().getType())
+        .filter(filterParser.parse("(geometry:polygon or geometry:other) and building=*"))
+        .count();
+
+    assertEquals(42, result.get(OSMType.WAY).intValue());
   }
 }

--- a/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOhsomeFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/bigspatialdata/oshdb/api/tests/TestOhsomeFilter.java
@@ -57,8 +57,8 @@ public class TestOhsomeFilter {
   @Test
   public void testAggregateFilter() throws Exception {
     SortedMap<OSMType, Integer> result = createMapReducer()
-        .filter("(geometry:polygon or geometry:other) and building=*")
         .aggregateBy(x -> x.getEntity().getType())
+        .filter("(geometry:polygon or geometry:other) and building=*")
         .count();
 
     assertEquals(2, result.entrySet().size());


### PR DESCRIPTION
Allows to use an [ohsome filter](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter) directly in an oshdb query: `mapReducer.filter("amenity=bench and type:node or leisure=park and geometry:polygon");`. This includes the optimizations implemented in the [ohsome-api](https://github.com/GIScience/ohsome-api/blob/1.0.0/src/main/java/org/heigit/ohsome/ohsomeapi/inputprocessing/InputProcessor.java#L278-L329).

todo:
* [x] add to documentation
* [x] write unit tests
* [x] use stable release instead of snapshot of ohsome-filter
* [x] test serialization (for ignite)

# Changes proposed in this pull request:
## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## New or changed dependencies:
- ohsome-filter (version 1.4.0) 


# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary

# ~~🚧 wip 🚧~~
* [x] switch to non-snapshot of [ohsome-filter v1.4](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter/-/milestones/4)