### PR TITLE
catch all remote oshdb timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ Changelog
 ## 0.6.0 SNAPSHOT (current master)
 
 * reorganize maven packages: rename group parent to ohsome-parent (version bump to 2.3), rename local parent to oshdb-parent, and change groupId to org.heigit.ohsome
-* compatibility fix to allow building of javadoc under Java 11 
+* compatibility fix to allow building of javadoc under Java 11
+* fix bug where in some cases, instead of an OSHDBTimeoutException an IniteException was thrown. #258
 
 ## 0.5.9
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -136,11 +136,19 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
     } catch (IgniteFutureTimeoutException e) {
       throw new OSHDBTimeoutException();
     } catch (IgniteException e) {
-      if (e.getCause().getCause() instanceof OSHDBTimeoutException) {
-        throw (OSHDBTimeoutException) e.getCause().getCause();
-      } else {
-        throw e;
-      }
+      throw unwindIgniteExceptions(e);
+    }
+  }
+
+  private static RuntimeException unwindIgniteExceptions(IgniteException exception) {
+    if (exception.getCause() == exception) {
+      throw exception;
+    } else if (exception.getCause() instanceof OSHDBTimeoutException) {
+      return (OSHDBTimeoutException) exception.getCause();
+    } else if (exception.getCause() instanceof IgniteException) {
+      return unwindIgniteExceptions((IgniteException) exception.getCause());
+    } else {
+      throw exception;
     }
   }
 


### PR DESCRIPTION
When a timeout happens remotely (in the ignite cluster), the resulting exception which is thrown in the client might be nested in various levels of `IgniteException`s (depending on where in the code they are thrown precisely). This implementation recursively unwinds these nested exceptions, so that the original `OSHDBTimeout` exception is actually thrown in all cases.

# Changes proposed in this pull request:
## Type of change
Please delete if not relevant:
- [x] Bug fix (non-breaking change which fixes an issue)

## Corresponding issue
Fixes https://github.com/GIScience/ohsome-api/issues/10

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary~~
