### PR TITLE
upgrade guava to latest release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <gitcommitplugin.version>2.2.6</gitcommitplugin.version>
     <glassfish.version>1.1</glassfish.version>
     <googlejson.version>1.1.1</googlejson.version>
-    <guava.version>23.6-jre</guava.version>
+    <guava.version>29.0-jre</guava.version>
     <h2.version>1.4.197</h2.version>
     <ignite.version>2.8.0</ignite.version>
     <jacoco.version>0.8.5</jacoco.version>


### PR DESCRIPTION
includes a fix for https://github.com/advisories/GHSA-mvr2-9pj6-7w5j which might possibly affect us


## New or changed dependencies:
- guava (upgrade from 23.6 to 29.0)
