### PR TITLE
Improve splitter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 * better handling of OSM multipolygons with touching inner rings. This improves performance considerably in some cases (especially large complex multipolygons). #249
 * (breaking) Timestamp parser class renamed to `IsoDateTimeParser` from `ISODateTimeParser` and adjust how input timestamps (e.g. in `MapReducer.timestamps()`) are handled: only the UTC time zone identifier `Z` is supported. #265
 * integrate [ohsome filter](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter) functionality. #253
+* improve performance of `aggregateByGeometry` queries. #272
 
 ## 0.5.10
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/GeometrySplitter.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/GeometrySplitter.java
@@ -192,8 +192,10 @@ class GeometrySplitter<U extends Comparable<U>> implements Serializable {
           FastPolygonOperations poop = poops.get(index);
           PreparedGeometry pg = pgs.get(index);
           try {
-            boolean intersectsBefore = pg.intersects(contributionGeometryBefore);
-            boolean intersectsAfter = pg.intersects(contributionGeometryAfter);
+            boolean intersectsBefore = contributionGeometryBefore != null
+                && pg.intersects(contributionGeometryBefore);
+            boolean intersectsAfter = contributionGeometryAfter != null
+                && pg.intersects(contributionGeometryAfter);
             if ((!intersectsBefore) && (!intersectsAfter)) {
               return Stream.empty(); // not actually intersecting -> skip
             } else {

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMContribution.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMContribution.java
@@ -36,20 +36,34 @@ public class OSMContribution implements OSHDBMapReducible, Comparable<OSMContrib
   }
 
   /**
-   * Creates a copy of the current entity snapshot with an updated geometry.
+   * Creates a copy of the given contribution object with an updated before/after geometry.
    */
   public OSMContribution(
       OSMContribution other,
       Geometry reclippedGeometryBefore,
       Geometry reclippedGeometryAfter
   ) {
+    this(other,
+        new LazyEvaluatedObject<>(reclippedGeometryBefore),
+        new LazyEvaluatedObject<>(reclippedGeometryAfter)
+    );
+  }
+
+  /**
+   * Creates a copy of the given contribution object with an updated before/after geometry.
+   */
+  public OSMContribution(
+      OSMContribution other,
+      LazyEvaluatedObject<Geometry> reclippedGeometryBefore,
+      LazyEvaluatedObject<Geometry> reclippedGeometryAfter
+  ) {
     this.data = new IterateAllEntry(
         other.data.timestamp,
         other.data.osmEntity,
         other.data.previousOsmEntity,
         other.data.oshEntity,
-        new LazyEvaluatedObject<>(reclippedGeometryAfter),
-        new LazyEvaluatedObject<>(reclippedGeometryBefore),
+        reclippedGeometryAfter,
+        reclippedGeometryBefore,
         other.data.unclippedGeometry,
         other.data.unclippedPreviousGeometry,
         other.data.activities,

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMEntitySnapshot.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/object/OSMEntitySnapshot.java
@@ -22,14 +22,24 @@ public class OSMEntitySnapshot implements OSHDBMapReducible, Comparable<OSMEntit
   }
 
   /**
-   * Creates a copy of the current entity snapshot with an updated geometry.
+   * Creates a copy of the given entity snapshot object with an updated geometry.
    */
   public OSMEntitySnapshot(OSMEntitySnapshot other, Geometry reclippedGeometry) {
+    this(other, new LazyEvaluatedObject<>(reclippedGeometry));
+  }
+
+  /**
+   * Creates a copy of the given entity snapshot object with an updated geometry.
+   */
+  public OSMEntitySnapshot(
+      OSMEntitySnapshot other,
+      LazyEvaluatedObject<Geometry> reclippedGeometry
+  ) {
     this.data = new IterateByTimestampEntry(
         other.data.timestamp,
         other.data.osmEntity,
         other.data.oshEntity,
-        new LazyEvaluatedObject<>(reclippedGeometry),
+        reclippedGeometry,
         other.data.unclippedGeometry
     );
   }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -149,26 +149,7 @@ public class FastPolygonOperations implements Serializable {
     if (other == null || other.isEmpty()) {
       return other;
     }
-    Geometry intersector = getIntersector(other.getEnvelopeInternal());
-    return other.intersection(intersector);
-  }
-
-  /**
-   * Returns the intersection of this polygon with the given other geometry.
-   *
-   * @param other an arbitrary geometry
-   * @return the intersection of this polygon with the other geometry
-   */
-  public boolean intersects(Geometry other) {
-    // todo: benchmark this against `PreparedGeometry.intersects()`
-    if (other == null || other.isEmpty()) {
-      return false;
-    }
-    Geometry intersector = getIntersector(other.getEnvelopeInternal());
-    return other.intersects(intersector);
-  }
-
-  private Geometry getIntersector(Envelope otherEnv) {
+    Envelope otherEnv = other.getEnvelopeInternal();
     int minBandX = Math.max(0, Math.min(numBands - 1,
         (int) Math.floor((otherEnv.getMinX() - env.getMinX()) / envWidth * numBands)));
     int maxBandX = Math.max(0, Math.min(numBands - 1,
@@ -192,6 +173,44 @@ public class FastPolygonOperations implements Serializable {
     }
 
     assert intersector != null;
-    return intersector;
+    if (other instanceof GeometryCollection) {
+      return other.intersection(intersector);
+    } else {
+      return intersector.intersection(other);
+    }
   }
+
+  /**
+   * Returns the intersection of this polygon with the given other geometry.
+   *
+   * @param other an arbitrary geometry
+   * @return the intersection of this polygon with the other geometry
+   */
+  public boolean intersects(Geometry other) {
+    // todo: benchmark this against `PreparedGeometry.intersects()`
+    if (other == null || other.isEmpty()) {
+      return false;
+    }
+    Envelope otherEnv = other.getEnvelopeInternal();
+    int minBandX = Math.max(0, Math.min(numBands - 1,
+        (int) Math.floor((otherEnv.getMinX() - env.getMinX()) / envWidth * numBands)));
+    int maxBandX = Math.max(0, Math.min(numBands - 1,
+        (int) Math.floor((otherEnv.getMaxX() - env.getMinX()) / envWidth * numBands)));
+    int minBandY = Math.max(0, Math.min(numBands - 1,
+        (int) Math.floor((otherEnv.getMinY() - env.getMinY()) / envHeight * numBands)));
+    int maxBandY = Math.max(0, Math.min(numBands - 1,
+        (int) Math.floor((otherEnv.getMaxY() - env.getMinY()) / envHeight * numBands)));
+
+    for (int x = minBandX; x <= maxBandX; x++) {
+      for (int y = minBandY; y <= maxBandY; y++) {
+        Geometry block = blocks.get(y + x * numBands);
+        if (other.intersects(block)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
 }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -179,38 +179,4 @@ public class FastPolygonOperations implements Serializable {
       return intersector.intersection(other);
     }
   }
-
-  /**
-   * Returns the intersection of this polygon with the given other geometry.
-   *
-   * @param other an arbitrary geometry
-   * @return the intersection of this polygon with the other geometry
-   */
-  public boolean intersects(Geometry other) {
-    // todo: benchmark this against `PreparedGeometry.intersects()`
-    if (other == null || other.isEmpty()) {
-      return false;
-    }
-    Envelope otherEnv = other.getEnvelopeInternal();
-    int minBandX = Math.max(0, Math.min(numBands - 1,
-        (int) Math.floor((otherEnv.getMinX() - env.getMinX()) / envWidth * numBands)));
-    int maxBandX = Math.max(0, Math.min(numBands - 1,
-        (int) Math.floor((otherEnv.getMaxX() - env.getMinX()) / envWidth * numBands)));
-    int minBandY = Math.max(0, Math.min(numBands - 1,
-        (int) Math.floor((otherEnv.getMinY() - env.getMinY()) / envHeight * numBands)));
-    int maxBandY = Math.max(0, Math.min(numBands - 1,
-        (int) Math.floor((otherEnv.getMaxY() - env.getMinY()) / envHeight * numBands)));
-
-    for (int x = minBandX; x <= maxBandX; x++) {
-      for (int y = minBandY; y <= maxBandY; y++) {
-        Geometry block = blocks.get(y + x * numBands);
-        if (other.intersects(block)) {
-          return true;
-        }
-      }
-    }
-
-    return false;
-  }
-
 }


### PR DESCRIPTION
Makes use of `LazyEvaluatedObject`s and `PreparedGeometry`s to improve performance of geometry splitter (used in `aggreateByGeometry` queries):

* use `PreparedGeometry.intersects` to reduce expensive `intersection` calls
  * todo: can this optimization be applied in the "regular" cell-iterator also?
* use `LazyEvaluatedObject` to avoid expensive calculations of intersections when they might not get used after all.

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
