### PR TITLE
fix checkstyle issues and other in oshdb-util

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/CellIterator.java
@@ -321,9 +321,9 @@ public class CellIterator implements Serializable {
           // skip because this entity is deleted at this timestamp
           continue;
         }
-        if (osmEntity instanceof OSMWay && ((OSMWay)osmEntity).getRefs().length == 0
+        if (osmEntity instanceof OSMWay && ((OSMWay) osmEntity).getRefs().length == 0
             || osmEntity instanceof OSMRelation
-                && ((OSMRelation)osmEntity).getMembers().length == 0) {
+                && ((OSMRelation) osmEntity).getMembers().length == 0) {
           // skip way/relation with zero nodes/members
           continue;
         }
@@ -626,8 +626,8 @@ public class CellIterator implements Serializable {
           if (prev != null && !prev.activities.contains(ContributionType.DELETION)) {
             prev = new IterateAllEntry(timestamp,
                 osmEntity, prev.osmEntity, oshEntity,
-                new LazyEvaluatedObject<>((Geometry)null), prev.geometry,
-                new LazyEvaluatedObject<>((Geometry)null), prev.unclippedGeometry,
+                new LazyEvaluatedObject<>((Geometry) null), prev.geometry,
+                new LazyEvaluatedObject<>((Geometry) null), prev.unclippedGeometry,
                 new LazyEvaluatedContributionTypes(EnumSet.of(ContributionType.DELETION)),
                 osmEntity.getChangesetId()
             );
@@ -672,8 +672,8 @@ public class CellIterator implements Serializable {
             if (prev != null && !prev.activities.contains(ContributionType.DELETION)) {
               prev = new IterateAllEntry(timestamp,
                   osmEntity, prev.osmEntity, oshEntity,
-                  new LazyEvaluatedObject<>((Geometry)null), prev.geometry,
-                  new LazyEvaluatedObject<>((Geometry)null), prev.unclippedGeometry,
+                  new LazyEvaluatedObject<>((Geometry) null), prev.geometry,
+                  new LazyEvaluatedObject<>((Geometry) null), prev.unclippedGeometry,
                   new LazyEvaluatedContributionTypes(EnumSet.of(ContributionType.DELETION)),
                   changesetTs.get(timestamp)
               );
@@ -718,8 +718,8 @@ public class CellIterator implements Serializable {
             if (prev != null && !prev.activities.contains(ContributionType.DELETION)) {
               prev = new IterateAllEntry(timestamp,
                   osmEntity, prev.osmEntity, oshEntity,
-                  new LazyEvaluatedObject<>((Geometry)null), prev.geometry,
-                  new LazyEvaluatedObject<>((Geometry)null), prev.unclippedGeometry,
+                  new LazyEvaluatedObject<>((Geometry) null), prev.geometry,
+                  new LazyEvaluatedObject<>((Geometry) null), prev.unclippedGeometry,
                   new LazyEvaluatedContributionTypes(EnumSet.of(ContributionType.DELETION)),
                   changesetTs.get(timestamp)
               );
@@ -775,8 +775,8 @@ public class CellIterator implements Serializable {
           } else {
             result = new IterateAllEntry(timestamp,
                 osmEntity, null, oshEntity,
-                geom, new LazyEvaluatedObject<>((Geometry)null),
-                unclippedGeom, new LazyEvaluatedObject<>((Geometry)null),
+                geom, new LazyEvaluatedObject<>((Geometry) null),
+                unclippedGeom, new LazyEvaluatedObject<>((Geometry) null),
                 activity,
                 changesetTs.get(timestamp)
             );

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/LazyEvaluatedObject.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/celliterator/LazyEvaluatedObject.java
@@ -54,7 +54,7 @@ public class LazyEvaluatedObject<T> implements Supplier<T> {
   @Override
   public boolean equals(Object o) {
     if (o instanceof LazyEvaluatedObject) {
-      LazyEvaluatedObject<?> lazyO = (LazyEvaluatedObject<?>)o;
+      LazyEvaluatedObject<?> lazyO = (LazyEvaluatedObject<?>) o;
       return this.get().equals(lazyO.get());
     }
     return false;

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxInPolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxInPolygon.java
@@ -35,9 +35,9 @@ public class FastBboxInPolygon extends FastInPolygon implements Predicate<OSHDBB
 
     List<Polygon> polys = new LinkedList<>();
     if (geom instanceof Polygon) {
-      polys.add((Polygon)geom);
+      polys.add((Polygon) geom);
     } else if (geom instanceof MultiPolygon) {
-      MultiPolygon mp = (MultiPolygon)geom;
+      MultiPolygon mp = (MultiPolygon) geom;
       for (int i = 0; i < mp.getNumGeometries(); i++) {
         polys.add((Polygon) mp.getGeometryN(i));
       }
@@ -68,11 +68,11 @@ public class FastBboxInPolygon extends FastInPolygon implements Predicate<OSHDBB
         || crossingNumber(p4, false) != crossingNumber(p1, false)) {
       return false; // at least one of the bbox'es edges crosses the polygon
     }
-    for (Envelope innerBBox : innerBboxes) {
-      if (boundingBox.getMinLat() <= innerBBox.getMinY()
-          && boundingBox.getMaxLat() >= innerBBox.getMaxY()
-          && boundingBox.getMinLon() <= innerBBox.getMinX()
-          && boundingBox.getMaxLon() >= innerBBox.getMaxX()) {
+    for (Envelope innerBbox : innerBboxes) {
+      if (boundingBox.getMinLat() <= innerBbox.getMinY()
+          && boundingBox.getMaxLat() >= innerBbox.getMaxY()
+          && boundingBox.getMinLon() <= innerBbox.getMinX()
+          && boundingBox.getMaxLon() >= innerBbox.getMaxX()) {
         // the bounding box fully covers at least one of the (multi)polygon's inner rings
         return false;
       }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxOutsidePolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxOutsidePolygon.java
@@ -36,9 +36,9 @@ public class FastBboxOutsidePolygon extends FastInPolygon implements Predicate<O
 
     List<Polygon> polys = new LinkedList<>();
     if (geom instanceof Polygon) {
-      polys.add((Polygon)geom);
+      polys.add((Polygon) geom);
     } else if (geom instanceof MultiPolygon) {
-      MultiPolygon mp = (MultiPolygon)geom;
+      MultiPolygon mp = (MultiPolygon) geom;
       for (int i = 0; i < mp.getNumGeometries(); i++) {
         polys.add((Polygon) mp.getGeometryN(i));
       }
@@ -67,11 +67,11 @@ public class FastBboxOutsidePolygon extends FastInPolygon implements Predicate<O
         || crossingNumber(p4, false) != crossingNumber(p1, false)) {
       return false; // at least one of the bbox'es edges crosses the polygon
     }
-    for (Envelope innerBBox : outerBboxes) {
-      if (boundingBox.getMinLat() <= innerBBox.getMinY()
-          && boundingBox.getMaxLat() >= innerBBox.getMaxY()
-          && boundingBox.getMinLon() <= innerBBox.getMinX()
-          && boundingBox.getMaxLon() >= innerBBox.getMaxX()) {
+    for (Envelope innerBbox : outerBboxes) {
+      if (boundingBox.getMinLat() <= innerBbox.getMinY()
+          && boundingBox.getMaxLat() >= innerBbox.getMaxY()
+          && boundingBox.getMinLon() <= innerBbox.getMinX()
+          && boundingBox.getMaxLon() >= innerBbox.getMaxX()) {
         // the bounding box fully covers at least one of the (multi)polygon's outer rings
         return false;
       }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -42,7 +42,7 @@ public class FastPolygonOperations implements Serializable {
     GeometryFactory gf = new GeometryFactory();
 
     Geometry[] result = new Geometry[numBands * numBands];
-    traverseQuads(bandIterations, 0,0, env, geom, gf, result);
+    traverseQuads(bandIterations, 0, 0, env, geom, gf, result);
 
     blocks = new ArrayList<>(Arrays.asList(result));
   }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/taginterpreter/BaseTagInterpreter.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/taginterpreter/BaseTagInterpreter.java
@@ -81,9 +81,9 @@ class BaseTagInterpreter implements TagInterpreter {
       if (nds.length < 4 || nds[0].getId() != nds[nds.length - 1].getId()) {
         return false;
       }
-      return this.evaluateWayForArea((OSMWay)entity);
+      return this.evaluateWayForArea((OSMWay) entity);
     } else /*if (entity instanceof OSMRelation)*/ {
-      return this.evaluateRelationForArea((OSMRelation)entity);
+      return this.evaluateRelationForArea((OSMRelation) entity);
     }
   }
 

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/taginterpreter/DefaultTagInterpreter.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/taginterpreter/DefaultTagInterpreter.java
@@ -66,12 +66,12 @@ public class DefaultTagInterpreter extends BaseTagInterpreter {
       TagTranslator tagTranslator,
       String areaTagsDefinitionFile, String uninterestingTagsDefinitionFile
   ) throws IOException, ParseException {
-    super(-1,-1, null, null, null, -1, -1, -1); // initialize with dummy parameters for now
+    super(-1, -1, null, null, null, -1, -1, -1); // initialize with dummy parameters for now
     // construct list of area tags for ways
     Map<Integer, Set<Integer>> wayAreaTags = new HashMap<>();
 
     JSONParser parser = new JSONParser();
-    JSONArray tagList = (JSONArray)parser.parse(new InputStreamReader(
+    JSONArray tagList = (JSONArray) parser.parse(new InputStreamReader(
         Thread.currentThread().getContextClassLoader().getResourceAsStream(areaTagsDefinitionFile)
     ));
     // todo: check json schema for validity
@@ -79,8 +79,8 @@ public class DefaultTagInterpreter extends BaseTagInterpreter {
     @SuppressWarnings("unchecked") // we expect only JSON objects here in a valid definition file
     Iterable<JSONObject> iterableTagList = tagList;
     for (JSONObject tag : iterableTagList) {
-      String key = (String)tag.get("key");
-      switch ((String)tag.get("polygon")) {
+      String key = (String) tag.get("key");
+      switch ((String) tag.get("polygon")) {
         case "all":
           Set<Integer> valueIds = new InvertedHashSet<>();
           int keyId = tagTranslator.getOSHDBTagKeyOf(key).toInt();
@@ -132,7 +132,7 @@ public class DefaultTagInterpreter extends BaseTagInterpreter {
 
     // list of uninteresting tags
     Set<Integer> uninterestingTagKeys = new HashSet<>();
-    JSONArray uninterestingTagsList = (JSONArray)parser.parse(new InputStreamReader(
+    JSONArray uninterestingTagsList = (JSONArray) parser.parse(new InputStreamReader(
         Thread.currentThread().getContextClassLoader().getResourceAsStream(
             uninterestingTagsDefinitionFile)));
     // todo: check json schema for validity
@@ -158,7 +158,7 @@ public class DefaultTagInterpreter extends BaseTagInterpreter {
   @Override
   public boolean isArea(OSMEntity entity) {
     if (entity instanceof OSMRelation) {
-      return evaluateRelationForArea((OSMRelation)entity);
+      return evaluateRelationForArea((OSMRelation) entity);
     } else {
       return super.isArea(entity);
     }
@@ -167,7 +167,7 @@ public class DefaultTagInterpreter extends BaseTagInterpreter {
   @Override
   public boolean isLine(OSMEntity entity) {
     if (entity instanceof OSMRelation) {
-      return evaluateRelationForLine((OSMRelation)entity);
+      return evaluateRelationForLine((OSMRelation) entity);
     } else {
       return super.isLine(entity);
     }

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/tagtranslator/OSMRole.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/tagtranslator/OSMRole.java
@@ -14,7 +14,7 @@ public class OSMRole {
 
   @Override
   public boolean equals(Object o) {
-    return o instanceof OSMRole && ((OSMRole)o).role.equals(this.role);
+    return o instanceof OSMRole && ((OSMRole) o).role.equals(this.role);
   }
 
   @Override

--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/tagtranslator/OSMTagKey.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/tagtranslator/OSMTagKey.java
@@ -14,7 +14,7 @@ public class OSMTagKey implements OSMTagInterface {
 
   @Override
   public boolean equals(Object o) {
-    return o instanceof OSMTagKey && ((OSMTagKey)o).key.equals(this.key);
+    return o instanceof OSMTagKey && ((OSMTagKey) o).key.equals(this.key);
   }
 
   @Override

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateAllTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateAllTest.java
@@ -51,6 +51,7 @@ public class IterateAllTest {
   public IterateAllTest() {
   }
 
+  @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
   @Test
   public void testIssue108() throws SQLException, IOException, ClassNotFoundException,
       ParseException, OSHDBKeytablesNotFoundException {
@@ -93,8 +94,8 @@ public class IterateAllTest {
       }
     }
 
-    assertEquals(countTotal, 4);
-    assertEquals(countCreated, 0);
-    assertEquals(countOther, 4);
+    assertEquals(4, countTotal);
+    assertEquals(0, countCreated);
+    assertEquals(4, countOther);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -2,6 +2,7 @@ package org.heigit.bigspatialdata.oshdb.util.celliterator;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -25,7 +26,7 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 
 public class IterateByContributionNodesTest {
-  private GridOSHNodes oshdbDataGridCell;
+  private final GridOSHNodes oshdbDataGridCell;
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
 
@@ -71,7 +72,7 @@ public class IterateByContributionNodesTest {
         result.get(2).activities.get()
     );
     assertEquals(1, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
+    assertNull(result.get(0).previousGeometry.get());
     Geometry geom = result.get(0).geometry.get();
     assertTrue(geom instanceof Point);
     assertEquals(result.get(0).geometry.get(), result.get(1).previousGeometry.get());
@@ -468,7 +469,7 @@ public class IterateByContributionNodesTest {
     )).iterateByContribution(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    // result size =2 becuase if tag filtered for disappears it's a deletion
+    // result size =2 because if tag filtered for disappears it's a deletion
     assertEquals(2, result.size()); // one version with tag shop
   }
 
@@ -497,7 +498,7 @@ public class IterateByContributionNodesTest {
             .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)).collect(Collectors.toList());
 
     assertEquals(2, result.size());
-    assertTrue(result.get(0).osmEntity.getId() == 13);
-    assertTrue(result.get(1).osmEntity.getId() == 14);
+    assertEquals(13, result.get(0).osmEntity.getId());
+    assertEquals(14, result.get(1).osmEntity.getId());
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -48,7 +48,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -88,7 +88,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 2,
         osmEntity -> true,
@@ -124,7 +124,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 3,
         osmEntity -> true,
@@ -171,7 +171,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 4,
         osmEntity -> true,
@@ -186,7 +186,7 @@ public class IterateByContributionNodesTest {
         result.get(0).activities.get()
     );
     assertEquals(
-        EnumSet.of(ContributionType.TAG_CHANGE,ContributionType.GEOMETRY_CHANGE),
+        EnumSet.of(ContributionType.TAG_CHANGE, ContributionType.GEOMETRY_CHANGE),
         result.get(1).activities.get()
     );
     assertEquals(
@@ -301,7 +301,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -337,7 +337,7 @@ public class IterateByContributionNodesTest {
             "2007-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 7,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("disused:shop")),
@@ -369,7 +369,7 @@ public class IterateByContributionNodesTest {
             "2007-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(0,0, 180, 90),
+        new OSHDBBoundingBox(0, 0, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 8,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -402,7 +402,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),
@@ -418,11 +418,11 @@ public class IterateByContributionNodesTest {
     // lon lat changes, so that node in v2 is outside bbox
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -438,7 +438,7 @@ public class IterateByContributionNodesTest {
     )).iterateByContribution(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(2,result.size());
+    assertEquals(2, result.size());
   }
 
   @Test
@@ -447,11 +447,11 @@ public class IterateByContributionNodesTest {
     final GeometryFactory geometryFactory = new GeometryFactory();
     // create clipping polygon for area of interest
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -459,7 +459,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        polygonFromCoordinates,// clipping polygon
+        polygonFromCoordinates, // clipping polygon
         areaDecider,
         oshEntity -> oshEntity.getId() == 6,
         // filter entity for tag = shop
@@ -469,7 +469,7 @@ public class IterateByContributionNodesTest {
         oshdbDataGridCell
     ).collect(Collectors.toList());
     // result size =2 becuase if tag filtered for disappears it's a deletion
-    assertEquals(2,result.size()); // one version with tag shop
+    assertEquals(2, result.size()); // one version with tag shop
   }
 
   @Test
@@ -477,10 +477,10 @@ public class IterateByContributionNodesTest {
     // different cases of relative position between node coordinate(s) and cell bbox / query polygon
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[4];
-    coords[0] = new Coordinate(0.0,0.0);
-    coords[1] = new Coordinate(1.5,0.0);
-    coords[2] = new Coordinate(0.0,1.5);
-    coords[3] = new Coordinate(0.0,0.0);
+    coords[0] = new Coordinate(0.0, 0.0);
+    coords[1] = new Coordinate(1.5, 0.0);
+    coords[2] = new Coordinate(0.0, 1.5);
+    coords[3] = new Coordinate(0.0, 0.0);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -494,7 +494,7 @@ public class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(GridOSHFactory.getGridOSHNodes(osmXmlTestData, 6, (new XYGrid(6))
-            .getId(1.0, 1.0)/* approx. 0,0,5.6,5.6*/)).collect(Collectors.toList());
+            .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)).collect(Collectors.toList());
 
     assertEquals(2, result.size());
     assertTrue(result.get(0).osmEntity.getId() == 13);

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
@@ -1,5 +1,6 @@
 package org.heigit.bigspatialdata.oshdb.util.celliterator;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
@@ -7,7 +8,6 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.heigit.bigspatialdata.oshdb.grid.GridOSHNodes;
 import org.heigit.bigspatialdata.oshdb.grid.GridOSHRelations;
 import org.heigit.bigspatialdata.oshdb.osh.OSHRelation;
 import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator.IterateAllEntry;
@@ -23,16 +23,15 @@ import org.locationtech.jts.geom.Polygon;
 
 public class IterateByContributionNotOsmTypeSpecificTest {
 
-  private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
   private final List<OSHRelation> oshRelations;
-  private static final double DELTA = 1E-6;
 
   /**
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * a list of {@link OSHRelation OSHRelations}.
    */
   public IterateByContributionNotOsmTypeSpecificTest() throws IOException {
+    OSMXmlReader osmXmlTestData = new OSMXmlReader();
     osmXmlTestData.add("./src/test/resources/different-timestamps/polygon.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     GridOSHRelations oshdbDataGridCell = GridOSHFactory.getGridOSHRelations(osmXmlTestData);
@@ -127,7 +126,7 @@ public class IterateByContributionNotOsmTypeSpecificTest {
     )).iterateByContribution(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertTrue(!resultPoly.isEmpty());
+    assertFalse(resultPoly.isEmpty());
   }
 
 

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
@@ -46,11 +46,11 @@ public class IterateByContributionNotOsmTypeSpecificTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,12.7);
-    coords[2] = new Coordinate(12.7,12.7);
-    coords[3] = new Coordinate(12.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 12.7);
+    coords[2] = new Coordinate(12.7, 12.7);
+    coords[3] = new Coordinate(12.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> resultPoly = (new CellIterator(
@@ -77,10 +77,10 @@ public class IterateByContributionNotOsmTypeSpecificTest {
     final GeometryFactory geometryFactory = new GeometryFactory();
 
     Coordinate[] coords = new Coordinate[4];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(12.7,12.7);
-    coords[2] = new Coordinate(12.7,10.3);
-    coords[3] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(12.7, 12.7);
+    coords[2] = new Coordinate(12.7, 10.3);
+    coords[3] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> resultPoly = (new CellIterator(
@@ -107,11 +107,11 @@ public class IterateByContributionNotOsmTypeSpecificTest {
     final GeometryFactory geometryFactory = new GeometryFactory();
 
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(-180,-90);
-    coords[1] = new Coordinate(180,-90);
-    coords[2] = new Coordinate(180,90);
-    coords[3] = new Coordinate(-180,90);
-    coords[4] = new Coordinate(-180,-90);
+    coords[0] = new Coordinate(-180, -90);
+    coords[1] = new Coordinate(180, -90);
+    coords[2] = new Coordinate(180, 90);
+    coords[3] = new Coordinate(-180, 90);
+    coords[4] = new Coordinate(-180, -90);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> resultPoly = (new CellIterator(

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -37,10 +37,13 @@ public class IterateByContributionRelationsTest {
    * {@link GridOSHRelations}.
    */
   public IterateByContributionRelationsTest() throws IOException {
-    osmXmlTestData.add("./src/test/resources/different-timestamps/polygon.osm");// read osm xml data
-    areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);// Used to provided information
+    // read osm xml data
+    osmXmlTestData.add("./src/test/resources/different-timestamps/polygon.osm");
+    // Used to provided information
+    areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     // needed to create actual geometries from OSM data
-    oshdbDataGridCell = GridOSHFactory.getGridOSHRelations(osmXmlTestData);// get GridOSH's
+    // get GridOSH's
+    oshdbDataGridCell = GridOSHFactory.getGridOSHRelations(osmXmlTestData);
     // (Holds the basic information, every OSM-Object has at a specific level) out of osm-xml file
   }
 
@@ -55,12 +58,12 @@ public class IterateByContributionRelationsTest {
             "2020-01-01T00:00:00Z"
         ).get(),
         // look at dat in this bbox
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         // needed to create actual geometries from OSM data
         areaDecider,
         // oshEntityPreFilter: get data of relation with id 500
         oshEntity -> oshEntity.getId() == 500,
-        osmEntity -> true,// osmEntityFilter: true -> get all
+        osmEntity -> true, // osmEntityFilter: true -> get all
         false
     )).iterateByContribution(
         oshdbDataGridCell
@@ -100,7 +103,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -134,7 +137,7 @@ public class IterateByContributionRelationsTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          new OSHDBBoundingBox(-180,-90, 180, 90),
+          new OSHDBBoundingBox(-180, -90, 180, 90),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -156,7 +159,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -190,7 +193,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -230,7 +233,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -269,7 +272,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -308,7 +311,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -342,7 +345,7 @@ public class IterateByContributionRelationsTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          new OSHDBBoundingBox(-180,-90, 180, 90),
+          new OSHDBBoundingBox(-180, -90, 180, 90),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -364,7 +367,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -421,7 +424,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -448,7 +451,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -485,7 +488,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -519,7 +522,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -549,7 +552,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -584,7 +587,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -622,11 +625,11 @@ public class IterateByContributionRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -642,7 +645,7 @@ public class IterateByContributionRelationsTest {
     )).iterateByContribution(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(3,result.size());
+    assertEquals(3, result.size());
   }
 
   @Test
@@ -650,11 +653,11 @@ public class IterateByContributionRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.7,10.4);
-    coords[1] = new Coordinate(10.94,10.4);
-    coords[2] = new Coordinate(10.94,10.9);
-    coords[3] = new Coordinate(10.7,10.9);
-    coords[4] = new Coordinate(10.7,10.4);
+    coords[0] = new Coordinate(10.7, 10.4);
+    coords[1] = new Coordinate(10.94, 10.4);
+    coords[2] = new Coordinate(10.94, 10.9);
+    coords[3] = new Coordinate(10.7, 10.9);
+    coords[4] = new Coordinate(10.7, 10.4);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -678,11 +681,11 @@ public class IterateByContributionRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,52.7);
-    coords[2] = new Coordinate(52.7,52.7);
-    coords[3] = new Coordinate(52.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 52.7);
+    coords[2] = new Coordinate(52.7, 52.7);
+    coords[3] = new Coordinate(52.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -698,7 +701,7 @@ public class IterateByContributionRelationsTest {
     )).iterateByContribution(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(3,result.size());
+    assertEquals(3, result.size());
   }
 
   @Test
@@ -706,11 +709,11 @@ public class IterateByContributionRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(48,49);
-    coords[1] = new Coordinate(48,50);
-    coords[2] = new Coordinate(49,50);
-    coords[3] = new Coordinate(49,49);
-    coords[4] = new Coordinate(48,49);
+    coords[0] = new Coordinate(48, 49);
+    coords[1] = new Coordinate(48, 50);
+    coords[2] = new Coordinate(49, 50);
+    coords[3] = new Coordinate(49, 49);
+    coords[4] = new Coordinate(48, 49);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -739,7 +742,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 22.7, 22.7),
+        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -764,11 +767,11 @@ public class IterateByContributionRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,52.7);
-    coords[2] = new Coordinate(52.7,52.7);
-    coords[3] = new Coordinate(52.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 52.7);
+    coords[2] = new Coordinate(52.7, 52.7);
+    coords[3] = new Coordinate(52.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -795,7 +798,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 52.7, 52.7),
+        new OSHDBBoundingBox(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -816,7 +819,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(50,50, 52, 52),
+        new OSHDBBoundingBox(50, 50, 52, 52),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -839,7 +842,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 22.7, 22.7),
+        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -850,7 +853,7 @@ public class IterateByContributionRelationsTest {
 
     // full geom of same timestamp with unclippedPreviousGeometry and unclippedGeometry
     assertEquals(result.get(1).unclippedPreviousGeometry.get().getArea(),
-        result.get(0).unclippedGeometry.get().getArea(),DELTA);
+        result.get(0).unclippedGeometry.get().getArea(), DELTA);
     // geom of requested area vs full geom after modification
     assertNotEquals(result.get(0).geometry.get().getArea(),
         result.get(0).unclippedGeometry.get().getArea());
@@ -869,11 +872,11 @@ public class IterateByContributionRelationsTest {
     // happy if it works without crashing
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(7.31,1.0);
-    coords[1] = new Coordinate(7.335,1.0);
-    coords[2] = new Coordinate(7.335,2.0);
-    coords[3] = new Coordinate(7.31,2.0);
-    coords[4] = new Coordinate(7.31,1.0);
+    coords[0] = new Coordinate(7.31, 1.0);
+    coords[1] = new Coordinate(7.335, 1.0);
+    coords[2] = new Coordinate(7.335, 2.0);
+    coords[3] = new Coordinate(7.31, 2.0);
+    coords[4] = new Coordinate(7.31, 1.0);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -901,7 +904,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -926,7 +929,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,
@@ -950,7 +953,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 523,
         osmEntity -> true,
@@ -974,7 +977,7 @@ public class IterateByContributionRelationsTest {
             "2012-01-01T00:00:00Z",
             "2014-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> !(osmEntity.getVersion() == 2),
@@ -997,11 +1000,11 @@ public class IterateByContributionRelationsTest {
     // is deleted
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -1035,11 +1038,11 @@ public class IterateByContributionRelationsTest {
     // relation in second version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -1069,11 +1072,11 @@ public class IterateByContributionRelationsTest {
     // relation in first and third version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -1102,11 +1105,11 @@ public class IterateByContributionRelationsTest {
     // relation in second version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(7.31,1.0);
-    coords[1] = new Coordinate(7.335,1.0);
-    coords[2] = new Coordinate(7.335,2.0);
-    coords[3] = new Coordinate(7.31,2.0);
-    coords[4] = new Coordinate(7.31,1.0);
+    coords[0] = new Coordinate(7.31, 1.0);
+    coords[1] = new Coordinate(7.335, 1.0);
+    coords[2] = new Coordinate(7.335, 2.0);
+    coords[3] = new Coordinate(7.31, 2.0);
+    coords[4] = new Coordinate(7.31, 1.0);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -1136,11 +1139,11 @@ public class IterateByContributionRelationsTest {
     // relation with two way members(nodes of ways have changes in 2009 and 2011)
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(-180,-90);
-    coords[1] = new Coordinate(180,-90);
-    coords[2] = new Coordinate(180,90);
-    coords[3] = new Coordinate(-180,90);
-    coords[4] = new Coordinate(-180,-90);
+    coords[0] = new Coordinate(-180, -90);
+    coords[1] = new Coordinate(180, -90);
+    coords[2] = new Coordinate(180, 90);
+    coords[3] = new Coordinate(-180, 90);
+    coords[4] = new Coordinate(-180, -90);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -39,12 +39,11 @@ public class IterateByContributionRelationsTest {
   public IterateByContributionRelationsTest() throws IOException {
     // read osm xml data
     osmXmlTestData.add("./src/test/resources/different-timestamps/polygon.osm");
-    // Used to provided information
+    // used to provide information needed to create actual geometries from OSM data
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
-    // needed to create actual geometries from OSM data
-    // get GridOSH's
+    // gets GridOSHs (holds the basic information, every OSM-Object has at a specific level) out of
+    // osm-xml file
     oshdbDataGridCell = GridOSHFactory.getGridOSHRelations(osmXmlTestData);
-    // (Holds the basic information, every OSM-Object has at a specific level) out of osm-xml file
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
@@ -48,7 +48,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> true,
@@ -88,7 +88,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -122,7 +122,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          new OSHDBBoundingBox(-180,-90, 180, 90),
+          new OSHDBBoundingBox(-180, -90, 180, 90),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -144,7 +144,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -178,7 +178,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -218,7 +218,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -258,7 +258,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -297,7 +297,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -331,7 +331,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          new OSHDBBoundingBox(-180,-90, 180, 90),
+          new OSHDBBoundingBox(-180, -90, 180, 90),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -353,7 +353,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -410,7 +410,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -437,7 +437,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -465,7 +465,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -499,7 +499,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -529,7 +529,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -564,7 +564,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -602,11 +602,11 @@ public class IterateByContributionTypeNotMultipolygonTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -622,7 +622,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
     )).iterateByContribution(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(3,result.size());
+    assertEquals(3, result.size());
   }
 
   @Test
@@ -630,11 +630,11 @@ public class IterateByContributionTypeNotMultipolygonTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,52.7);
-    coords[2] = new Coordinate(52.7,52.7);
-    coords[3] = new Coordinate(52.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 52.7);
+    coords[2] = new Coordinate(52.7, 52.7);
+    coords[3] = new Coordinate(52.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -650,7 +650,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
     )).iterateByContribution(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(3,result.size());
+    assertEquals(3, result.size());
   }
 
   @Test
@@ -658,11 +658,11 @@ public class IterateByContributionTypeNotMultipolygonTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(48,49);
-    coords[1] = new Coordinate(48,50);
-    coords[2] = new Coordinate(49,50);
-    coords[3] = new Coordinate(49,49);
-    coords[4] = new Coordinate(48,49);
+    coords[0] = new Coordinate(48, 49);
+    coords[1] = new Coordinate(48, 50);
+    coords[2] = new Coordinate(49, 50);
+    coords[3] = new Coordinate(49, 49);
+    coords[4] = new Coordinate(48, 49);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -691,7 +691,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 22.7, 22.7),
+        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -717,11 +717,11 @@ public class IterateByContributionTypeNotMultipolygonTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,52.7);
-    coords[2] = new Coordinate(52.7,52.7);
-    coords[3] = new Coordinate(52.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 52.7);
+    coords[2] = new Coordinate(52.7, 52.7);
+    coords[3] = new Coordinate(52.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -748,7 +748,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2016-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 52.7, 52.7),
+        new OSHDBBoundingBox(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -769,7 +769,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(50,50, 52, 52),
+        new OSHDBBoundingBox(50, 50, 52, 52),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -785,11 +785,11 @@ public class IterateByContributionTypeNotMultipolygonTest {
     // Polygon with self crossing way
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(7.31,1.0);
-    coords[1] = new Coordinate(7.335,1.0);
-    coords[2] = new Coordinate(7.335,2.0);
-    coords[3] = new Coordinate(7.31,2.0);
-    coords[4] = new Coordinate(7.31,1.0);
+    coords[0] = new Coordinate(7.31, 1.0);
+    coords[1] = new Coordinate(7.335, 1.0);
+    coords[2] = new Coordinate(7.335, 2.0);
+    coords[3] = new Coordinate(7.31, 2.0);
+    coords[4] = new Coordinate(7.31, 1.0);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -807,7 +807,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
     ).collect(Collectors.toList());
     Geometry geom1 = result.get(0).geometry.get();
     assertTrue(geom1 instanceof GeometryCollection);
-    assertEquals(1,result.size());
+    assertEquals(1, result.size());
   }
 
   @Test
@@ -819,7 +819,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 22.7, 22.7),
+        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -844,7 +844,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2012-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 22.7, 22.7),
+        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,
@@ -860,11 +860,11 @@ public class IterateByContributionTypeNotMultipolygonTest {
     // relation in first and third version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateAllEntry> result = (new CellIterator(

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByContributionWaysTest.java
@@ -46,7 +46,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 100,
         osmEntity -> true,
@@ -95,7 +95,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 101,
         osmEntity -> true,
@@ -146,7 +146,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 102,
         osmEntity -> true,
@@ -179,7 +179,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 103,
         osmEntity -> true,
@@ -194,7 +194,7 @@ public class IterateByContributionWaysTest {
         result.get(0).activities.get()
     );
     assertEquals(
-        EnumSet.of(ContributionType.TAG_CHANGE,ContributionType.GEOMETRY_CHANGE),
+        EnumSet.of(ContributionType.TAG_CHANGE, ContributionType.GEOMETRY_CHANGE),
         result.get(1).activities.get()
     );
     assertEquals(
@@ -230,7 +230,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 104,
         osmEntity -> true,
@@ -274,7 +274,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 105,
         osmEntity -> true,
@@ -288,7 +288,7 @@ public class IterateByContributionWaysTest {
         result.get(0).activities.get()
     );
     assertEquals(
-        EnumSet.of(ContributionType.TAG_CHANGE,ContributionType.GEOMETRY_CHANGE),
+        EnumSet.of(ContributionType.TAG_CHANGE, ContributionType.GEOMETRY_CHANGE),
         result.get(1).activities.get()
     );
     assertEquals(
@@ -321,7 +321,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 106,
         osmEntity -> true,
@@ -335,7 +335,7 @@ public class IterateByContributionWaysTest {
         result.get(0).activities.get()
     );
     assertEquals(
-        EnumSet.of(ContributionType.TAG_CHANGE,ContributionType.GEOMETRY_CHANGE),
+        EnumSet.of(ContributionType.TAG_CHANGE, ContributionType.GEOMETRY_CHANGE),
         result.get(1).activities.get()
     );
 
@@ -361,7 +361,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 107,
         osmEntity -> true,
@@ -402,7 +402,7 @@ public class IterateByContributionWaysTest {
             "2009-02-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 108,
         osmEntity -> true,
@@ -424,7 +424,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 109,
         osmEntity -> true,
@@ -455,7 +455,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2009-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(1.8,1.3, 2.7, 2.7),
+        new OSHDBBoundingBox(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -483,7 +483,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2012-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(1.8,1.3, 2.7, 2.7),
+        new OSHDBBoundingBox(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
@@ -83,11 +83,11 @@ public class IterateByTimestampNotOsmTypeSpecificTest {
         oshRelations);
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,12.7);
-    coords[2] = new Coordinate(12.7,12.7);
-    coords[3] = new Coordinate(12.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 12.7);
+    coords[2] = new Coordinate(12.7, 12.7);
+    coords[3] = new Coordinate(12.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -114,10 +114,10 @@ public class IterateByTimestampNotOsmTypeSpecificTest {
         oshRelations);
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[4];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(12.7,12.7);
-    coords[2] = new Coordinate(12.7,10.3);
-    coords[3] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(12.7, 12.7);
+    coords[2] = new Coordinate(12.7, 10.3);
+    coords[3] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -144,11 +144,11 @@ public class IterateByTimestampNotOsmTypeSpecificTest {
         oshRelations);
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(-180,-90);
-    coords[1] = new Coordinate(180,-90);
-    coords[2] = new Coordinate(180,90);
-    coords[3] = new Coordinate(-180,90);
-    coords[4] = new Coordinate(-180,-90);
+    coords[0] = new Coordinate(-180, -90);
+    coords[1] = new Coordinate(180, -90);
+    coords[2] = new Coordinate(180, 90);
+    coords[3] = new Coordinate(-180, 90);
+    coords[4] = new Coordinate(-180, -90);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.heigit.bigspatialdata.oshdb.grid.GridOSHNodes;
-import org.heigit.bigspatialdata.oshdb.grid.GridOSHRelations;
 import org.heigit.bigspatialdata.oshdb.index.XYGrid;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator.IterateByTimestampEntry;
@@ -24,7 +23,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 
 public class IterateByTimestampsNodesTest {
-  private GridOSHNodes oshdbDataGridCell;
+  private final GridOSHNodes oshdbDataGridCell;
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
 
@@ -264,8 +263,8 @@ public class IterateByTimestampsNodesTest {
     ).collect(Collectors.toList());
 
     assertEquals(3, result.size());
-    assertTrue(result.get(0).osmEntity.getId() == 13);
-    assertTrue(result.get(1).osmEntity.getId() == 13);
-    assertTrue(result.get(2).osmEntity.getId() == 14);
+    assertEquals(13, result.get(0).osmEntity.getId());
+    assertEquals(13, result.get(1).osmEntity.getId());
+    assertEquals(14, result.get(2).osmEntity.getId());
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -49,7 +49,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -75,7 +75,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 2,
         osmEntity -> true,
@@ -107,7 +107,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 3,
         osmEntity -> true,
@@ -133,7 +133,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 4,
         osmEntity -> true,
@@ -176,7 +176,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -196,7 +196,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),
@@ -212,11 +212,11 @@ public class IterateByTimestampsNodesTest {
     // lon lat changes, so that node in v2 is outside bbox
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -233,7 +233,7 @@ public class IterateByTimestampsNodesTest {
     )).iterateByTimestamps(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(1,result.size());
+    assertEquals(1, result.size());
   }
 
   @Test
@@ -241,10 +241,10 @@ public class IterateByTimestampsNodesTest {
     //different cases of relative position between node coordinate(s) and cell bbox / query polygon
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[4];
-    coords[0] = new Coordinate(0.0,0.0);
-    coords[1] = new Coordinate(1.5,0.0);
-    coords[2] = new Coordinate(0.0,1.5);
-    coords[3] = new Coordinate(0.0,0.0);
+    coords[0] = new Coordinate(0.0, 0.0);
+    coords[1] = new Coordinate(1.5, 0.0);
+    coords[2] = new Coordinate(0.0, 1.5);
+    coords[3] = new Coordinate(0.0, 0.0);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -260,7 +260,7 @@ public class IterateByTimestampsNodesTest {
         false
     )).iterateByTimestamps(
         GridOSHFactory.getGridOSHNodes(osmXmlTestData, 6, (new XYGrid(6))
-            .getId(1.0, 1.0)/* approx. 0,0,5.6,5.6*/)
+            .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)
     ).collect(Collectors.toList());
 
     assertEquals(3, result.size());

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -25,8 +25,7 @@ import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
 
 public class IterateByTimestampsRelationsTest {
-  private GridOSHRelations oshdbDataGridCell;
-  private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
+  private final GridOSHRelations oshdbDataGridCell;
   TagInterpreter areaDecider;
 
   /**
@@ -34,6 +33,7 @@ public class IterateByTimestampsRelationsTest {
    * {@link GridOSHRelations}.
    */
   public IterateByTimestampsRelationsTest() throws IOException {
+    OSMXmlReader osmXmlTestData = new OSMXmlReader();
     osmXmlTestData.add("./src/test/resources/different-timestamps/polygon.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     oshdbDataGridCell = GridOSHFactory.getGridOSHRelations(osmXmlTestData);
@@ -92,6 +92,7 @@ public class IterateByTimestampsRelationsTest {
     assertEquals(303, result.get(0).osmEntity.getChangesetId());
   }
 
+  @SuppressWarnings("unused")
   @Test
   public void testWaysNotExistent() {
     // relation with two ways, both missing
@@ -254,6 +255,7 @@ public class IterateByTimestampsRelationsTest {
     assertTrue(geom2 instanceof GeometryCollection);
   }
 
+  @SuppressWarnings("unused")
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
@@ -767,7 +769,7 @@ public class IterateByTimestampsRelationsTest {
 
   @Test
   public void testTimeIntervalAfterDeletionInVersion2() {
-    // relation in second version visible = false, timeinterval includes version 3
+    // relation in second version visible = false, time interval includes version 3
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
             "2016-01-01T00:00:00Z",
@@ -788,7 +790,7 @@ public class IterateByTimestampsRelationsTest {
 
   @Test
   public void testTimeIntervalAfterDeletionInCurrentVersion() {
-    // relation in first and third version visible = false, timeinterval includes version 3
+    // relation in first and third version visible = false, time interval includes version 3
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
             "2016-01-01T00:00:00Z",
@@ -839,7 +841,7 @@ public class IterateByTimestampsRelationsTest {
 
   @Test
   public void testTimeIntervalAfterDeletionInVersion2Clipped() {
-    // relation in second version visible = false, timeinterval includes version 3
+    // relation in second version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
     coords[0] = new Coordinate(10.8, 10.3);
@@ -869,7 +871,7 @@ public class IterateByTimestampsRelationsTest {
 
   @Test
   public void testTimeIntervalAfterDeletionInCurrentVersionClipped() {
-    // relation in first and third version visible = false, timeinterval includes version 3
+    // relation in first and third version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
     coords[0] = new Coordinate(10.8, 10.3);
@@ -899,7 +901,7 @@ public class IterateByTimestampsRelationsTest {
 
   @Test
   public void testExcludingVersion2Clipped() {
-    // relation in second version visible = false, timeinterval includes version 3
+    // relation in second version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
     coords[0] = new Coordinate(7.31, 1.0);

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -49,7 +49,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> true,
@@ -79,7 +79,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -102,7 +102,7 @@ public class IterateByTimestampsRelationsTest {
               "2020-01-01T00:00:00Z",
               "P1Y"
           ).get(),
-          new OSHDBBoundingBox(-180,-90, 180, 90),
+          new OSHDBBoundingBox(-180, -90, 180, 90),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -125,7 +125,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -148,7 +148,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -180,7 +180,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -211,7 +211,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -236,7 +236,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -264,7 +264,7 @@ public class IterateByTimestampsRelationsTest {
               "2020-01-01T00:00:00Z",
               "P1Y"
           ).get(),
-          new OSHDBBoundingBox(-180,-90, 180, 90),
+          new OSHDBBoundingBox(-180, -90, 180, 90),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -287,7 +287,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -323,7 +323,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -345,7 +345,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -370,7 +370,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -396,7 +396,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -422,7 +422,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -449,7 +449,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -474,11 +474,11 @@ public class IterateByTimestampsRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -487,7 +487,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 22.7, 22.7),
+        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -496,7 +496,7 @@ public class IterateByTimestampsRelationsTest {
     )).iterateByTimestamps(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(10,result.size());
+    assertEquals(10, result.size());
   }
 
   @Test
@@ -504,11 +504,11 @@ public class IterateByTimestampsRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.7,10.4);
-    coords[1] = new Coordinate(10.94,10.4);
-    coords[2] = new Coordinate(10.94,10.9);
-    coords[3] = new Coordinate(10.7,10.9);
-    coords[4] = new Coordinate(10.7,10.4);
+    coords[0] = new Coordinate(10.7, 10.4);
+    coords[1] = new Coordinate(10.94, 10.4);
+    coords[2] = new Coordinate(10.94, 10.9);
+    coords[3] = new Coordinate(10.7, 10.9);
+    coords[4] = new Coordinate(10.7, 10.4);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -525,7 +525,7 @@ public class IterateByTimestampsRelationsTest {
     )).iterateByTimestamps(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(0,result.size());
+    assertEquals(0, result.size());
   }
 
   @Test
@@ -533,11 +533,11 @@ public class IterateByTimestampsRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,52.7);
-    coords[2] = new Coordinate(52.7,52.7);
-    coords[3] = new Coordinate(52.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 52.7);
+    coords[2] = new Coordinate(52.7, 52.7);
+    coords[3] = new Coordinate(52.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -546,7 +546,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 52.7, 52.7),
+        new OSHDBBoundingBox(10.8, 10.3, 52.7, 52.7),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -555,7 +555,7 @@ public class IterateByTimestampsRelationsTest {
     )).iterateByTimestamps(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(10,result.size());
+    assertEquals(10, result.size());
   }
 
   @Test
@@ -563,11 +563,11 @@ public class IterateByTimestampsRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(48,49);
-    coords[1] = new Coordinate(48,50);
-    coords[2] = new Coordinate(49,50);
-    coords[3] = new Coordinate(49,49);
-    coords[4] = new Coordinate(48,49);
+    coords[0] = new Coordinate(48, 49);
+    coords[1] = new Coordinate(48, 50);
+    coords[2] = new Coordinate(49, 50);
+    coords[3] = new Coordinate(49, 49);
+    coords[4] = new Coordinate(48, 49);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> resultPoly = (new CellIterator(
@@ -576,7 +576,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(50,51, 51, 52),
+        new OSHDBBoundingBox(50, 51, 51, 52),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -599,7 +599,7 @@ public class IterateByTimestampsRelationsTest {
             "2019-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 22.7, 22.7),
+        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -616,11 +616,11 @@ public class IterateByTimestampsRelationsTest {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,52.7);
-    coords[2] = new Coordinate(52.7,52.7);
-    coords[3] = new Coordinate(52.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 52.7);
+    coords[2] = new Coordinate(52.7, 52.7);
+    coords[3] = new Coordinate(52.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -638,7 +638,7 @@ public class IterateByTimestampsRelationsTest {
         oshdbDataGridCell
     ).collect(Collectors.toList());
 
-    assertEquals(3,result.size());
+    assertEquals(3, result.size());
   }
 
   @Test
@@ -650,7 +650,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 52.7, 52.7),
+        new OSHDBBoundingBox(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -658,7 +658,7 @@ public class IterateByTimestampsRelationsTest {
     )).iterateByTimestamps(
         oshdbDataGridCell
     ).collect(Collectors.toList());
-    assertEquals(3,result.size());
+    assertEquals(3, result.size());
   }
 
   @Test
@@ -670,7 +670,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(50,50, 52, 52),
+        new OSHDBBoundingBox(50, 50, 52, 52),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -693,7 +693,7 @@ public class IterateByTimestampsRelationsTest {
             "2019-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8,10.3, 22.7, 22.7),
+        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -719,11 +719,11 @@ public class IterateByTimestampsRelationsTest {
     // happy if it works without crashing
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(7.31,1.0);
-    coords[1] = new Coordinate(7.335,1.0);
-    coords[2] = new Coordinate(7.335,2.0);
-    coords[3] = new Coordinate(7.31,2.0);
-    coords[4] = new Coordinate(7.31,1.0);
+    coords[0] = new Coordinate(7.31, 1.0);
+    coords[1] = new Coordinate(7.335, 1.0);
+    coords[2] = new Coordinate(7.335, 2.0);
+    coords[3] = new Coordinate(7.31, 2.0);
+    coords[4] = new Coordinate(7.31, 1.0);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -753,7 +753,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -774,7 +774,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,
@@ -795,7 +795,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 523,
         osmEntity -> true,
@@ -812,11 +812,11 @@ public class IterateByTimestampsRelationsTest {
     // is deleted
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -842,11 +842,11 @@ public class IterateByTimestampsRelationsTest {
     // relation in second version visible = false, timeinterval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -872,11 +872,11 @@ public class IterateByTimestampsRelationsTest {
     // relation in first and third version visible = false, timeinterval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(10.8,10.3);
-    coords[1] = new Coordinate(10.8,22.7);
-    coords[2] = new Coordinate(22.7,22.7);
-    coords[3] = new Coordinate(22.7,10.3);
-    coords[4] = new Coordinate(10.8,10.3);
+    coords[0] = new Coordinate(10.8, 10.3);
+    coords[1] = new Coordinate(10.8, 22.7);
+    coords[2] = new Coordinate(22.7, 22.7);
+    coords[3] = new Coordinate(22.7, 10.3);
+    coords[4] = new Coordinate(10.8, 10.3);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -902,11 +902,11 @@ public class IterateByTimestampsRelationsTest {
     // relation in second version visible = false, timeinterval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(7.31,1.0);
-    coords[1] = new Coordinate(7.335,1.0);
-    coords[2] = new Coordinate(7.335,2.0);
-    coords[3] = new Coordinate(7.31,2.0);
-    coords[4] = new Coordinate(7.31,1.0);
+    coords[0] = new Coordinate(7.31, 1.0);
+    coords[1] = new Coordinate(7.335, 1.0);
+    coords[2] = new Coordinate(7.335, 2.0);
+    coords[3] = new Coordinate(7.31, 2.0);
+    coords[4] = new Coordinate(7.31, 1.0);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -932,11 +932,11 @@ public class IterateByTimestampsRelationsTest {
     // relation with two way members(nodes of ways have changes in 2009 and 2011)
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
-    coords[0] = new Coordinate(-180,-90);
-    coords[1] = new Coordinate(180,-90);
-    coords[2] = new Coordinate(180,90);
-    coords[3] = new Coordinate(-180,90);
-    coords[4] = new Coordinate(-180,-90);
+    coords[0] = new Coordinate(-180, -90);
+    coords[1] = new Coordinate(180, -90);
+    coords[2] = new Coordinate(180, 90);
+    coords[3] = new Coordinate(-180, 90);
+    coords[4] = new Coordinate(-180, -90);
     Polygon polygonFromCoordinates = geometryFactory.createPolygon(coords);
 
     List<IterateByTimestampEntry> result = (new CellIterator(

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -92,12 +92,12 @@ public class IterateByTimestampsRelationsTest {
     assertEquals(303, result.get(0).osmEntity.getChangesetId());
   }
 
-  @SuppressWarnings("unused")
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   public void testWaysNotExistent() {
     // relation with two ways, both missing
     try {
-      List<IterateByTimestampEntry> result = (new CellIterator(
+      (new CellIterator(
           new OSHDBTimestamps(
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z",
@@ -255,12 +255,12 @@ public class IterateByTimestampsRelationsTest {
     assertTrue(geom2 instanceof GeometryCollection);
   }
 
-  @SuppressWarnings("unused")
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
     try {
-      List<IterateByTimestampEntry> result = (new CellIterator(
+      (new CellIterator(
           new OSHDBTimestamps(
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z",

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -7,8 +7,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.heigit.bigspatialdata.oshdb.grid.GridOSHNodes;
-import org.heigit.bigspatialdata.oshdb.grid.GridOSHRelations;
 import org.heigit.bigspatialdata.oshdb.grid.GridOSHWays;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.celliterator.CellIterator.IterateByTimestampEntry;
@@ -24,9 +22,7 @@ import org.locationtech.jts.geom.Polygon;
 
 public class IterateByTimestampsWaysTest {
 
-  private GridOSHWays oshdbDataGridCell;
-  private GridOSHNodes oshdbDataGridCellNodes;
-  private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
+  private final GridOSHWays oshdbDataGridCell;
   TagInterpreter areaDecider;
 
   /**
@@ -34,6 +30,7 @@ public class IterateByTimestampsWaysTest {
    * {@link GridOSHWays}.
    */
   public IterateByTimestampsWaysTest() throws IOException {
+    OSMXmlReader osmXmlTestData = new OSMXmlReader();
     osmXmlTestData.add("./src/test/resources/different-timestamps/way.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     oshdbDataGridCell = GridOSHFactory.getGridOSHWays(osmXmlTestData);

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -85,7 +85,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 101,
         osmEntity -> true,
@@ -116,7 +116,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 102,
         osmEntity -> true,
@@ -140,7 +140,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 103,
         osmEntity -> true,
@@ -178,7 +178,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 104,
         osmEntity -> true,
@@ -206,7 +206,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 105,
         osmEntity -> true,
@@ -232,7 +232,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 106,
         osmEntity -> true,
@@ -262,7 +262,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 107,
         osmEntity -> true,
@@ -292,7 +292,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180,-90, 180, 90),
+        new OSHDBBoundingBox(-180, -90, 180, 90),
         areaDecider,
         oshEntity -> oshEntity.getId() == 108,
         osmEntity -> true,
@@ -313,7 +313,7 @@ public class IterateByTimestampsWaysTest {
             "2010-02-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(1.8,1.3, 2.7, 2.7),
+        new OSHDBBoundingBox(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -338,7 +338,7 @@ public class IterateByTimestampsWaysTest {
             "2012-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(1.8,1.3, 2.7, 2.7),
+        new OSHDBBoundingBox(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -347,7 +347,7 @@ public class IterateByTimestampsWaysTest {
         oshdbDataGridCell
     ).collect(Collectors.toList());
 
-    assertNotEquals(result.get(0).geometry.get(),result.get(3).geometry.get());
+    assertNotEquals(result.get(0).geometry.get(), result.get(3).geometry.get());
     assertEquals(4, result.size());
     assertEquals(3, result.get(1).geometry.get().getNumPoints());
     assertEquals(4, result.get(0).unclippedGeometry.get().getNumPoints());

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/helpers/GridOSHFactory.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/helpers/GridOSHFactory.java
@@ -91,7 +91,7 @@ public class GridOSHFactory {
           ).collect(Collectors.toSet())
       ));
     }
-    oshdbDataGridCellWays = GridOSHWays.compact(-1, -1, 0, 0, 0, 0, oshWays);
+    oshdbDataGridCellWays = GridOSHWays.compact(cellId, cellZoom, 0, 0, 0, 0, oshWays);
     return oshdbDataGridCellWays;
   }
 
@@ -133,7 +133,8 @@ public class GridOSHFactory {
           ).filter(Objects::nonNull).collect(Collectors.toSet())
       ));
     }
-    oshdbDataGridCellRelations = GridOSHRelations.compact(0, 0, 0, 0, 0, 0, oshRelations);
+    oshdbDataGridCellRelations =
+        GridOSHRelations.compact(cellId, cellZoom, 0, 0, 0, 0, oshRelations);
     return oshdbDataGridCellRelations;
   }
 

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -206,24 +206,4 @@ public class OSHDBGeometryBuilderTest {
       new Coordinate(0, 0)};
     Assert.assertArrayEquals(test, geometry.getCoordinates());
   }
-
-  abstract class FakeTagInterpreter implements TagInterpreter {
-
-    @Override
-    public boolean isArea(OSMEntity entity) {
-      return false;
-    }
-
-    @Override
-    public boolean isLine(OSMEntity entity) {
-      return false;
-    }
-
-    @Override
-    public boolean hasInterestingTagKey(OSMEntity osm) {
-      return false;
-    }
-
-  }
-
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
@@ -11,7 +12,6 @@ import org.heigit.bigspatialdata.oshdb.util.geometry.helpers.FakeTagInterpreterA
 import org.heigit.bigspatialdata.oshdb.util.geometry.helpers.FakeTagInterpreterAreaNever;
 import org.heigit.bigspatialdata.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.bigspatialdata.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.bigspatialdata.oshdb.util.time.IsoDateTimeParser;
 import org.heigit.bigspatialdata.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.Assert;
 import org.junit.Test;
@@ -32,17 +32,6 @@ public class OSHDBGeometryBuilderTest {
     testData.add("./src/test/resources/geometryBuilder.osh");
   }
 
-  private OSHDBTimestamp toOSHDBTimestamp(String timeString) {
-    try {
-      return new OSHDBTimestamp(
-          IsoDateTimeParser.parseIsoDateTime(timeString).toEpochSecond()
-      );
-    } catch (Exception e) {
-      e.printStackTrace();
-      return null;
-    }
-  }
-
   @Test
   public void testPointGetGeometry() {
     OSMEntity entity = testData.nodes().get(1L).get(1);
@@ -60,17 +49,17 @@ public class OSHDBGeometryBuilderTest {
     // by bbox
     OSHDBBoundingBox clipBbox = new OSHDBBoundingBox(-180.0, -90.0, 180.0, 90.0);
     Geometry result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipBbox);
-    assertEquals(false, result.isEmpty());
+    assertFalse(result.isEmpty());
     clipBbox = new OSHDBBoundingBox(-180.0, -90.0, 0.0, 0.0);
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipBbox);
-    assertEquals(true, result.isEmpty());
+    assertTrue(result.isEmpty());
     // by poly
     Polygon clipPoly = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-180, -90, 180, 90));
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipPoly);
-    assertEquals(false, result.isEmpty());
+    assertFalse(result.isEmpty());
     clipPoly = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-1, -1, 1, 1));
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipPoly);
-    assertEquals(true, result.isEmpty());
+    assertTrue(result.isEmpty());
   }
 
   @Test
@@ -118,12 +107,12 @@ public class OSHDBGeometryBuilderTest {
     entity = testData.ways().get(4L).get(0);
     result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertEquals("Point", result.getGeometryType());
-    assertEquals(false, result.isEmpty());
+    assertFalse(result.isEmpty());
 
     // zero noded way
     entity = testData.ways().get(5L).get(0);
     result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-    assertEquals(true, result.isEmpty());
+    assertTrue(result.isEmpty());
   }
 
   @Test
@@ -177,9 +166,9 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testBoundingBoxOf() throws ParseException {
+  public void testBoundingBoxOf() {
     OSHDBBoundingBox bbox = OSHDBGeometryBuilder.boundingBoxOf(new Envelope(-180, 180, -90, 90));
-    assertEquals(new String("(-180.0000000,-90.0000000,180.0000000,90.0000000)"), bbox.toString());
+    assertEquals("(-180.0000000,-90.0000000,180.0000000,90.0000000)", bbox.toString());
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
@@ -16,10 +16,10 @@ public class FastBboxInPolygonTest {
    */
   public static MultiPolygon createSquareSquareMultiPolygon() {
     GeometryFactory gf = new GeometryFactory();
-    Polygon poly1 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-1.5,-1.5,-0.5,-0.5));
-    Polygon poly2 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0.5,-1.5,1.5,-0.5));
-    Polygon poly3 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-1.5,0.5,-0.5,1.5));
-    Polygon poly4 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0.5,0.5,1.5,1.5));
+    Polygon poly1 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-1.5, -1.5, -0.5, -0.5));
+    Polygon poly2 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0.5, -1.5, 1.5, -0.5));
+    Polygon poly3 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-1.5, 0.5, -0.5, 1.5));
+    Polygon poly4 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0.5, 0.5, 1.5, 1.5));
     return new MultiPolygon(new Polygon[] { poly1, poly2, poly3, poly4 }, gf);
   }
 
@@ -29,22 +29,22 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6,-0.1,-0.4,0.1)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)), true);
     // partially inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-1.5,-0.1,-0.4,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6,-0.1,1.4,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6,-1.1,-0.4,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6,-0.1,-0.4,1.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)), false);
     // in concave part
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4,-0.1,0.6,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4,-0.9,0.6,-0.8)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4,0.8,0.6,0.9)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)), true);
     // in concave part, coordinates all inside
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4,-0.9,0.6,0.9)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)), false);
     // outside poly's bbox
-    assertEquals(bip.test(new OSHDBBoundingBox(1.4,-0.1,1.6,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)), false);
     // bbox covering
-    assertEquals(bip.test(new OSHDBBoundingBox(-11,-10,10,10)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-11, -10, 10, 10)), false);
   }
 
   @Test
@@ -53,31 +53,31 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // inside
-    assertEquals(bip.test(new OSHDBBoundingBox(2.1,-0.1,2.2,0.1)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,-0.9,3.2,-0.8)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,0.8,3.2,0.9)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.8,-0.1,3.9,0.1)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.8, -0.1, 3.9,  .1)), true);
     // partially inside
-    assertEquals(bip.test(new OSHDBBoundingBox(1.8,-0.1,2.2,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,-1.1,3.2,-0.8)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,0.8,3.2,1.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.8,-0.1,4.1,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)), false);
     // in hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.9,-0.1,3.1,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)), false);
     // partially in hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.4,-0.1,2.6,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,-0.6,3.2,-0.4)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,0.4,3.2,0.6)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.4,-0.1,3.6,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)), false);
     // intersecting hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.1,-0.1,3.9,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)), false);
     // outside poly's bbox
-    assertEquals(bip.test(new OSHDBBoundingBox(4.1,-0.1,4.2,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(1.8,-0.1,1.9,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,-1.2,3.2,-1.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,1.1,3.2,1.2)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1,  1.1, 3.2, 1.2)), false);
     // covering hole, but all vertices inside polygon
-    assertEquals(bip.test(new OSHDBBoundingBox(2.2,-0.8,3.8,0.8)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)), false);
   }
 
   @Test
@@ -87,50 +87,50 @@ public class FastBboxInPolygonTest {
 
     // left polygon
     // inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6,-0.1,-0.4,0.1)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)), true);
     // partially inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-1.5,-0.1,-0.4,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6,-0.1,1.4,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6,-1.1,-0.4,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6,-0.1,-0.4,1.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)), false);
     // in concave part
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4,-0.1,0.6,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4,-0.9,0.6,-0.8)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4,0.8,0.6,0.9)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)), true);
     // in concave part, coordinates all inside
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4,-0.9,0.6,0.9)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)), false);
     // outside poly's bbox
-    assertEquals(bip.test(new OSHDBBoundingBox(1.4,-0.1,1.6,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)), false);
     // bbox covering
-    assertEquals(bip.test(new OSHDBBoundingBox(-11,-10,10,10)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-11, -10, 10, 10)), false);
 
     // right polygon
     // inside
-    assertEquals(bip.test(new OSHDBBoundingBox(2.1,-0.1,2.2,0.1)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,-0.9,3.2,-0.8)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,0.8,3.2,0.9)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.8,-0.1,3.9,0.1)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)), true);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)), true);
     // partially inside
-    assertEquals(bip.test(new OSHDBBoundingBox(1.8,-0.1,2.2,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,-1.1,3.2,-0.8)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,0.8,3.2,1.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.8,-0.1,4.1,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)), false);
     // in hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.9,-0.1,3.1,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)), false);
     // partially in hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.4,-0.1,2.6,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,-0.6,3.2,-0.4)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,0.4,3.2,0.6)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.4,-0.1,3.6,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)), false);
     // intersecting hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.1,-0.1,3.9,0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)), false);
     // outside poly's bbox
-    assertEquals(bip.test(new OSHDBBoundingBox(4.1,-0.1,4.2,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(1.8,-0.1,1.9,0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,-1.2,3.2,-1.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,1.1,3.2,1.2)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)), false);
     // covering hole, but all vertices inside polygon
-    assertEquals(bip.test(new OSHDBBoundingBox(2.2,-0.8,3.8,0.8)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)), false);
   }
 
   @Test
@@ -139,6 +139,6 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // not inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-1,-1,1,1)), false);
+    assertEquals(bip.test(new OSHDBBoundingBox(-1, -1, 1, 1)), false);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
@@ -49,6 +49,7 @@ public class FastBboxInPolygonTest {
   }
 
   @Test
+  @SuppressWarnings("java:S5961" /* has to test all cases how bbox and polygon can be aligned */)
   public void testBboxInPolygonWithHole() {
     Polygon p = FastPointInPolygonTest.createPolygonWithHole();
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
@@ -82,6 +83,7 @@ public class FastBboxInPolygonTest {
   }
 
   @Test
+  @SuppressWarnings("java:S5961" /* has to test all cases how bbox and polygon can be aligned */)
   public void testBboxInMultiPolygon() {
     MultiPolygon p = FastPointInPolygonTest.createMultiPolygon();
     FastBboxInPolygon bip = new FastBboxInPolygon(p);

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.fip;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
@@ -29,22 +30,22 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)), true);
+    assertTrue(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)), true);
+    assertFalse(bip.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)));
+    assertTrue(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)));
+    assertTrue(bip.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertEquals(bip.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertEquals(bip.test(new OSHDBBoundingBox(-11, -10, 10, 10)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(-11, -10, 10, 10)));
   }
 
   @Test
@@ -53,31 +54,31 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // inside
-    assertEquals(bip.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.8, -0.1, 3.9,  .1)), true);
+    assertTrue(bip.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)));
+    assertTrue(bip.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)));
+    assertTrue(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)));
+    assertTrue(bip.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, .1)));
     // partially inside
-    assertEquals(bip.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertEquals(bip.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1,  1.1, 3.2, 1.2)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertEquals(bip.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -87,50 +88,50 @@ public class FastBboxInPolygonTest {
 
     // left polygon
     // inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)), true);
+    assertTrue(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)), true);
+    assertFalse(bip.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)));
+    assertTrue(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)));
+    assertTrue(bip.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertEquals(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertEquals(bip.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertEquals(bip.test(new OSHDBBoundingBox(-11, -10, 10, 10)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(-11, -10, 10, 10)));
 
     // right polygon
     // inside
-    assertEquals(bip.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)), true);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)), true);
+    assertTrue(bip.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)));
+    assertTrue(bip.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)));
+    assertTrue(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)));
+    assertTrue(bip.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertEquals(bip.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertEquals(bip.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertEquals(bip.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)), false);
-    assertEquals(bip.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)));
+    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertEquals(bip.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -139,6 +140,6 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // not inside
-    assertEquals(bip.test(new OSHDBBoundingBox(-1, -1, 1, 1)), false);
+    assertFalse(bip.test(new OSHDBBoundingBox(-1, -1, 1, 1)));
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
@@ -15,22 +15,22 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6,-0.1,-0.4,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)), false);
     // partially inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-1.5,-0.1,-0.4,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6,-0.1,1.4,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6,-1.1,-0.4,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6,-0.1,-0.4,1.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)), false);
     // in concave part
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4,-0.1,0.6,0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4,-0.9,0.6,-0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4,0.8,0.6,0.9)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)), false);
     // in concave part, coordinates all inside
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4,-0.9,0.6,0.9)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)), false);
     // outside poly's bbox
-    assertEquals(bop.test(new OSHDBBoundingBox(1.4,-0.1,1.6,0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)), true);
     // bbox covering
-    assertEquals(bop.test(new OSHDBBoundingBox(-11,-10,10,10)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-11, -10, 10, 10)), false);
   }
 
   @Test
@@ -39,31 +39,31 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // inside
-    assertEquals(bop.test(new OSHDBBoundingBox(2.1,-0.1,2.2,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,-0.9,3.2,-0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,0.8,3.2,0.9)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.8,-0.1,3.9,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)), false);
     // partially inside
-    assertEquals(bop.test(new OSHDBBoundingBox(1.8,-0.1,2.2,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,-1.1,3.2,-0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,0.8,3.2,1.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.8,-0.1,4.1,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)), false);
     // in hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.9,-0.1,3.1,0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)), true);
     // partially in hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.4,-0.1,2.6,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,-0.6,3.2,-0.4)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,0.4,3.2,0.6)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.4,-0.1,3.6,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)), false);
     // intersecting hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.1,-0.1,3.9,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)), false);
     // outside poly's bbox
-    assertEquals(bop.test(new OSHDBBoundingBox(4.1,-0.1,4.2,0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(1.8,-0.1,1.9,0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,-1.2,3.2,-1.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,1.1,3.2,1.2)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)), true);
     // covering hole, but all vertices inside polygon
-    assertEquals(bop.test(new OSHDBBoundingBox(2.2,-0.8,3.8,0.8)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)), false);
   }
 
   @Test
@@ -73,50 +73,50 @@ public class FastBboxOutsidePolygonTest {
 
     // left polygon
     // inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6,-0.1,-0.4,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)), false);
     // partially inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-1.5,-0.1,-0.4,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6,-0.1,1.4,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6,-1.1,-0.4,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6,-0.1,-0.4,1.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)), false);
     // in concave part
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4,-0.1,0.6,0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4,-0.9,0.6,-0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4,0.8,0.6,0.9)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)), false);
     // in concave part, coordinates all inside
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4,-0.9,0.6,0.9)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)), false);
     // outside poly's bbox
-    assertEquals(bop.test(new OSHDBBoundingBox(1.4,-0.1,1.6,0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)), true);
     // bbox covering
-    assertEquals(bop.test(new OSHDBBoundingBox(-11,-10,10,10)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-11, -10, 10, 10)), false);
 
     // right polygon
     // inside
-    assertEquals(bop.test(new OSHDBBoundingBox(2.1,-0.1,2.2,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,-0.9,3.2,-0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,0.8,3.2,0.9)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.8,-0.1,3.9,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)), false);
     // partially inside
-    assertEquals(bop.test(new OSHDBBoundingBox(1.8,-0.1,2.2,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,-1.1,3.2,-0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,0.8,3.2,1.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.8,-0.1,4.1,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)), false);
     // in hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.9,-0.1,3.1,0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)), true);
     // partially in hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.4,-0.1,2.6,0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,-0.6,3.2,-0.4)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,0.4,3.2,0.6)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.4,-0.1,3.6,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)), false);
     // intersecting hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.1,-0.1,3.9,0.1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)), false);
     // outside poly's bbox
-    assertEquals(bop.test(new OSHDBBoundingBox(4.1,-0.1,4.2,0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(1.8,-0.1,1.9,0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,-1.2,3.2,-1.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1,1.1,3.2,1.2)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)), true);
+    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)), true);
     // covering hole, but all vertices inside polygon
-    assertEquals(bop.test(new OSHDBBoundingBox(2.2,-0.8,3.8,0.8)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)), false);
   }
 
   @Test
@@ -125,6 +125,6 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // not inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-1,-1,1,1)), false);
+    assertEquals(bop.test(new OSHDBBoundingBox(-1, -1, 1, 1)), false);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
@@ -35,6 +35,7 @@ public class FastBboxOutsidePolygonTest {
   }
 
   @Test
+  @SuppressWarnings("java:S5961" /* has to test all cases how bbox and polygon can be aligned */)
   public void testBboxInPolygonWithHole() {
     Polygon p = FastPointInPolygonTest.createPolygonWithHole();
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
@@ -68,6 +69,7 @@ public class FastBboxOutsidePolygonTest {
   }
 
   @Test
+  @SuppressWarnings("java:S5961" /* has to test all cases how bbox and polygon can be aligned */)
   public void testBboxInMultiPolygon() {
     MultiPolygon p = FastPointInPolygonTest.createMultiPolygon();
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.fip;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.heigit.bigspatialdata.oshdb.util.OSHDBBoundingBox;
 import org.junit.Test;
@@ -15,22 +16,22 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)), false);
+    assertTrue(bop.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)));
+    assertFalse(bop.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertEquals(bop.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)), true);
+    assertTrue(bop.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertEquals(bop.test(new OSHDBBoundingBox(-11, -10, 10, 10)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(-11, -10, 10, 10)));
   }
 
   @Test
@@ -39,31 +40,31 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // inside
-    assertEquals(bop.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertEquals(bop.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)), true);
+    assertTrue(bop.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertEquals(bop.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)), true);
+    assertTrue(bop.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)));
+    assertTrue(bop.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)));
+    assertTrue(bop.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)));
+    assertTrue(bop.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertEquals(bop.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -73,50 +74,50 @@ public class FastBboxOutsidePolygonTest {
 
     // left polygon
     // inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)), false);
+    assertTrue(bop.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)));
+    assertFalse(bop.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertEquals(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertEquals(bop.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)), true);
+    assertTrue(bop.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertEquals(bop.test(new OSHDBBoundingBox(-11, -10, 10, 10)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(-11, -10, 10, 10)));
 
     // right polygon
     // inside
-    assertEquals(bop.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertEquals(bop.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)), true);
+    assertTrue(bop.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)), false);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bop.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertEquals(bop.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertEquals(bop.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)), true);
-    assertEquals(bop.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)), true);
+    assertTrue(bop.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)));
+    assertTrue(bop.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)));
+    assertTrue(bop.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)));
+    assertTrue(bop.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertEquals(bop.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -125,6 +126,6 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // not inside
-    assertEquals(bop.test(new OSHDBBoundingBox(-1, -1, 1, 1)), false);
+    assertFalse(bop.test(new OSHDBBoundingBox(-1, -1, 1, 1)));
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPointInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPointInPolygonTest.java
@@ -17,15 +17,15 @@ public class FastPointInPolygonTest {
   public static Polygon createPolygon() {
     final GeometryFactory gf = new GeometryFactory();
     Coordinate[] coordinates = new Coordinate[100];
-    coordinates[0] = new Coordinate(0,0);
-    coordinates[1] = new Coordinate(1,1);
-    coordinates[2] = new Coordinate(-1,1);
+    coordinates[0] = new Coordinate(0, 0);
+    coordinates[1] = new Coordinate(1, 1);
+    coordinates[2] = new Coordinate(-1, 1);
     for (int i = 3; i <= 96; i++) {
       coordinates[i] = new Coordinate(-1.0, 1.0 - 2.0 * (i - 2) / 95);
     }
-    coordinates[97] = new Coordinate(-1,-1);
-    coordinates[98] = new Coordinate(1,-1);
-    coordinates[99] = new Coordinate(0,0);
+    coordinates[97] = new Coordinate(-1, -1);
+    coordinates[98] = new Coordinate(1, -1);
+    coordinates[99] = new Coordinate(0, 0);
     LinearRing linear = gf.createLinearRing(coordinates);
     return new Polygon(linear, null, gf);
   }
@@ -36,18 +36,18 @@ public class FastPointInPolygonTest {
   public static Polygon createPolygonWithHole() {
     final GeometryFactory gf = new GeometryFactory();
     Coordinate[] coordinates1 = new Coordinate[5];
-    coordinates1[0] = new Coordinate(4,-1);
-    coordinates1[1] = new Coordinate(4,1);
-    coordinates1[2] = new Coordinate(2,1);
-    coordinates1[3] = new Coordinate(2,-1);
-    coordinates1[4] = new Coordinate(4,-1);
+    coordinates1[0] = new Coordinate(4, -1);
+    coordinates1[1] = new Coordinate(4, 1);
+    coordinates1[2] = new Coordinate(2, 1);
+    coordinates1[3] = new Coordinate(2, -1);
+    coordinates1[4] = new Coordinate(4, -1);
     final LinearRing linear1 = gf.createLinearRing(coordinates1);
     Coordinate[] coordinates2 = new Coordinate[5];
-    coordinates2[0] = new Coordinate(3.5,-0.5);
-    coordinates2[1] = new Coordinate(3.5,0.5);
-    coordinates2[2] = new Coordinate(2.5,0.5);
-    coordinates2[3] = new Coordinate(2.5,-0.5);
-    coordinates2[4] = new Coordinate(3.5,-0.5);
+    coordinates2[0] = new Coordinate(3.5, -0.5);
+    coordinates2[1] = new Coordinate(3.5, 0.5);
+    coordinates2[2] = new Coordinate(2.5, 0.5);
+    coordinates2[3] = new Coordinate(2.5, -0.5);
+    coordinates2[4] = new Coordinate(3.5, -0.5);
     final LinearRing linear2 = gf.createLinearRing(coordinates2);
     return new Polygon(linear1, new LinearRing[] { linear2 }, gf);
   }
@@ -70,11 +70,11 @@ public class FastPointInPolygonTest {
     GeometryFactory gf = new GeometryFactory();
 
     // inside
-    assertEquals(pip.test(gf.createPoint(new Coordinate(-0.5,0))), true);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(-0.5, 0))), true);
     // in concave part
-    assertEquals(pip.test(gf.createPoint(new Coordinate(0.5,0))), false);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(0.5, 0))), false);
     // outside poly's bbox
-    assertEquals(pip.test(gf.createPoint(new Coordinate(1.5,0))), false);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(1.5, 0))), false);
   }
 
   @Test
@@ -85,11 +85,11 @@ public class FastPointInPolygonTest {
     GeometryFactory gf = new GeometryFactory();
 
     // inside
-    assertEquals(pip.test(gf.createPoint(new Coordinate(2.25,0))), true);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(2.25, 0))), true);
     // in hole
-    assertEquals(pip.test(gf.createPoint(new Coordinate(3,0))), false);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(3, 0))), false);
     // outside poly's bbox
-    assertEquals(pip.test(gf.createPoint(new Coordinate(4.5,0))), false);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(4.5, 0))), false);
   }
 
   @Test
@@ -100,16 +100,16 @@ public class FastPointInPolygonTest {
     GeometryFactory gf = new GeometryFactory();
 
     // inside left polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(-0.5,0))), true);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(-0.5, 0))), true);
     // in concave part of left polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(0.5,0))), false);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(0.5, 0))), false);
     // outside left polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(1.5,0))), false);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(1.5, 0))), false);
     // inside right polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(2.25,0))), true);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(2.25, 0))), true);
     // in hole of right polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(3,0))), false);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(3, 0))), false);
     // outside right polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(4.5,0))), false);
+    assertEquals(pip.test(gf.createPoint(new Coordinate(4.5, 0))), false);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPointInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPointInPolygonTest.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.fip;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -70,11 +71,11 @@ public class FastPointInPolygonTest {
     GeometryFactory gf = new GeometryFactory();
 
     // inside
-    assertEquals(pip.test(gf.createPoint(new Coordinate(-0.5, 0))), true);
+    assertTrue(pip.test(gf.createPoint(new Coordinate(-0.5, 0))));
     // in concave part
-    assertEquals(pip.test(gf.createPoint(new Coordinate(0.5, 0))), false);
+    assertFalse(pip.test(gf.createPoint(new Coordinate(0.5, 0))));
     // outside poly's bbox
-    assertEquals(pip.test(gf.createPoint(new Coordinate(1.5, 0))), false);
+    assertFalse(pip.test(gf.createPoint(new Coordinate(1.5, 0))));
   }
 
   @Test
@@ -85,11 +86,11 @@ public class FastPointInPolygonTest {
     GeometryFactory gf = new GeometryFactory();
 
     // inside
-    assertEquals(pip.test(gf.createPoint(new Coordinate(2.25, 0))), true);
+    assertTrue(pip.test(gf.createPoint(new Coordinate(2.25, 0))));
     // in hole
-    assertEquals(pip.test(gf.createPoint(new Coordinate(3, 0))), false);
+    assertFalse(pip.test(gf.createPoint(new Coordinate(3, 0))));
     // outside poly's bbox
-    assertEquals(pip.test(gf.createPoint(new Coordinate(4.5, 0))), false);
+    assertFalse(pip.test(gf.createPoint(new Coordinate(4.5, 0))));
   }
 
   @Test
@@ -100,16 +101,16 @@ public class FastPointInPolygonTest {
     GeometryFactory gf = new GeometryFactory();
 
     // inside left polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(-0.5, 0))), true);
+    assertTrue(pip.test(gf.createPoint(new Coordinate(-0.5, 0))));
     // in concave part of left polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(0.5, 0))), false);
+    assertFalse(pip.test(gf.createPoint(new Coordinate(0.5, 0))));
     // outside left polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(1.5, 0))), false);
+    assertFalse(pip.test(gf.createPoint(new Coordinate(1.5, 0))));
     // inside right polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(2.25, 0))), true);
+    assertTrue(pip.test(gf.createPoint(new Coordinate(2.25, 0))));
     // in hole of right polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(3, 0))), false);
+    assertFalse(pip.test(gf.createPoint(new Coordinate(3, 0))));
     // outside right polygon
-    assertEquals(pip.test(gf.createPoint(new Coordinate(4.5, 0))), false);
+    assertFalse(pip.test(gf.createPoint(new Coordinate(4.5, 0))));
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
@@ -13,7 +13,7 @@ import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 
 public class FastPolygonOperationsTest {
-  private GeometryFactory gf = new GeometryFactory();
+  private final GeometryFactory gf = new GeometryFactory();
 
   @Test
   public void testEmptyGeometryPolygon() {
@@ -31,7 +31,7 @@ public class FastPolygonOperationsTest {
     Polygon p = FastPointInPolygonTest.createPolygon();
     FastPolygonOperations pop = new FastPolygonOperations(p);
 
-    assertNull(pop.intersection((Polygon) null));
+    assertNull(pop.intersection(null));
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/helpers/OSMXmlReaderTagInterpreter.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/helpers/OSMXmlReaderTagInterpreter.java
@@ -9,13 +9,13 @@ import org.heigit.bigspatialdata.oshdb.util.xmlreader.OSMXmlReader;
 
 public class OSMXmlReaderTagInterpreter extends FakeTagInterpreter {
 
-  private int area;
-  private int areaYes;
-  private int type;
-  private int typeMultipolygon;
-  private int emptyRole;
-  private int outer;
-  private int inner;
+  private final int area;
+  private final int areaYes;
+  private final int type;
+  private final int typeMultipolygon;
+  private final int emptyRole;
+  private final int outer;
+  private final int inner;
 
   /**
    * Constructor reading all required values from a given {@link OSMXmlReader}.

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/helpers/TimestampParser.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/helpers/TimestampParser.java
@@ -10,13 +10,6 @@ public class TimestampParser {
    * {@link IsoDateTimeParser#parseIsoDateTime(String)} using a given {@link String timeString}.
    */
   public static OSHDBTimestamp toOSHDBTimestamp(String timeString) {
-    try {
-      return new OSHDBTimestamp(
-          IsoDateTimeParser.parseIsoDateTime(timeString).toEpochSecond()
-      );
-    } catch (Exception e) {
-      e.printStackTrace();
-      return null;
-    }
+    return new OSHDBTimestamp(IsoDateTimeParser.parseIsoDateTime(timeString).toEpochSecond());
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
@@ -69,14 +69,12 @@ public class OSHDBGeometryBuilderTestPolygonIncompleteDataTest {
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
-  @SuppressWarnings({"UnusedAssignment", "unused"})
   @Test
   public void testAllNodesOfWayNotExistent() {
     // relation with one way with two nodes, both missing
     OSMEntity entity1 = testData.relations().get(502L).get(0);
-    Geometry result1 = null;
     try {
-      result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
+      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
@@ -69,6 +69,7 @@ public class OSHDBGeometryBuilderTestPolygonIncompleteDataTest {
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
+  @SuppressWarnings({"UnusedAssignment", "unused"})
   @Test
   public void testAllNodesOfWayNotExistent() {
     // relation with one way with two nodes, both missing

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestWayIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestWayIncompleteDataTest.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.incomplete;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
@@ -19,7 +20,6 @@ public class OSHDBGeometryBuilderTestWayIncompleteDataTest {
   TagInterpreter areaDecider;
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
-  private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderTestWayIncompleteDataTest() {
     testData.add("./src/test/resources/incomplete-osm/way.osm");
@@ -66,7 +66,7 @@ public class OSHDBGeometryBuilderTestWayIncompleteDataTest {
     Geometry result1 = null;
     try {
       result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-      assertTrue(result1.getCoordinates().length == 0);
+      assertEquals(0, result1.getCoordinates().length);
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
@@ -57,14 +57,13 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest {
     assertEquals(1.23, ((Point) resultAfter).getY(), DELTA);
   }
 
-  @SuppressWarnings("unused")
   @Test(expected = AssertionError.class)
   public void testInvalidAccess() {
     // A single node, lat lon changed over time
     OSMEntity entity = testData.nodes().get(1L).get(0);
     // timestamp before oldest timestamp
     OSHDBTimestamp timestampBefore =  TimestampParser.toOSHDBTimestamp("2007-01-01T00:00:00Z");
-    Geometry resultBefore = OSHDBGeometryBuilder.getGeometry(entity, timestampBefore, areaDecider);
+    OSHDBGeometryBuilder.getGeometry(entity, timestampBefore, areaDecider);
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
@@ -57,6 +57,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest {
     assertEquals(1.23, ((Point) resultAfter).getY(), DELTA);
   }
 
+  @SuppressWarnings("unused")
   @Test(expected = AssertionError.class)
   public void testInvalidAccess() {
     // A single node, lat lon changed over time

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.osmhistorytestdata;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -18,12 +19,10 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygonal;
-import org.locationtech.jts.io.ParseException;
 
 public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest {
   private final OSMXmlReader testData = new OSMXmlReader();
   TagInterpreter areaDecider;
-  private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest() {
     testData.add("./src/test/resources/different-timestamps/type-not-multipolygon.osm");
@@ -31,7 +30,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testGeometryChange() throws ParseException {
+  public void testGeometryChange() {
     // relation getting more ways, one disappears, last version not valid
     OSMEntity entity = testData.relations().get(500L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -60,7 +59,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     try {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection || result2 instanceof Polygonal);
-      assertTrue(result2.getNumGeometries() == 3);
+      assertEquals(3, result2.getNumGeometries());
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
@@ -68,7 +67,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testVisibleChange() throws ParseException {
+  public void testVisibleChange() {
     // relation  visible tag changed
     OSMEntity entity = testData.relations().get(501L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -76,7 +75,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 2);
+      assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -100,7 +99,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection);
       assertTrue(result2.isValid());
-      assertTrue(result2.getNumGeometries() == 2);
+      assertEquals(2, result2.getNumGeometries());
       assertTrue(result2.getGeometryN(0) instanceof LineString);
       assertTrue(result2.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -113,7 +112,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   public void testWaysNotExistent() {
     // relation with three ways, all not existing
     OSMEntity entity = testData.relations().get(502L).get(0);
-    Geometry result = null;
+    Geometry result;
     try {
       OSHDBTimestamp timestamp = entity.getTimestamp();
       result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
@@ -127,7 +126,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testTagChange() throws ParseException {
+  public void testTagChange() {
     // relation tags changing
     OSMEntity entity = testData.relations().get(503L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -135,7 +134,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 1);
+      assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -148,7 +147,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
-      assertTrue(result1.getNumGeometries() == 1);
+      assertEquals(1, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -161,7 +160,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection);
       assertTrue(result2.isValid());
-      assertTrue(result2.getNumGeometries() == 1);
+      assertEquals(1, result2.getNumGeometries());
       assertTrue(result2.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -170,7 +169,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testGeometryChangeOfNodeRefsInWays() throws ParseException {
+  public void testGeometryChangeOfNodeRefsInWays() {
     // relation, way 109 -inner- and 110 -outer- ways changed node refs
     OSMEntity entity = testData.relations().get(504L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -178,7 +177,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 2);
+      assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -192,7 +191,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
-      assertTrue(result1.getNumGeometries() == 2);
+      assertEquals(2, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
       assertTrue(result1.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -207,7 +206,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
           .getGeometry(entityBetween, timestampBetween, areaDecider);
       assertTrue(resultBetween instanceof GeometryCollection);
       assertTrue(resultBetween.isValid());
-      assertTrue(resultBetween.getNumGeometries() == 2);
+      assertEquals(2, resultBetween.getNumGeometries());
       assertTrue(resultBetween.getGeometryN(0) instanceof LineString);
       assertTrue(resultBetween.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -217,7 +216,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInWay() throws ParseException {
+  public void testGeometryChangeOfNodeCoordinatesInWay() {
     // relation, way 112  changed node coordinates
     OSMEntity entity = testData.relations().get(505L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -225,7 +224,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 1);
+      assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -239,7 +238,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
           .getGeometry(entityAfter, timestampAfter, areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertTrue(resultAfter.isValid());
-      assertTrue(resultAfter.getNumGeometries() == 1);
+      assertEquals(1, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -248,7 +247,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInRelationAndWay() throws ParseException {
+  public void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
     // relation, with node members, nodes changed coordinates
     OSMEntity entity = testData.relations().get(506L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -256,7 +255,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 3);
+      assertEquals(3, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof Point);
       assertTrue(result.getGeometryN(1) instanceof Point);
       assertTrue(result.getGeometryN(2) instanceof LineString);
@@ -272,7 +271,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
           areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertTrue(resultAfter.isValid());
-      assertTrue(resultAfter.getNumGeometries() == 3);
+      assertEquals(3, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof Point);
       assertTrue(resultAfter.getGeometryN(1) instanceof Point);
       assertTrue(resultAfter.getGeometryN(2) instanceof LineString);
@@ -290,7 +289,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       OSHDBTimestamp timestamp = entity.getTimestamp();
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.getNumGeometries() == 6);
+      assertEquals(6, result.getNumGeometries());
       assertFalse(result instanceof MultiPolygon);
     } catch (Exception e) {
       e.printStackTrace();
@@ -302,7 +301,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   public void testNodesOfWaysNotExistent() {
     // relation with two ways, all nodes not existing
     OSMEntity entity = testData.relations().get(508L).get(0);
-    Geometry result = null;
+    Geometry result;
     try {
       OSHDBTimestamp timestamp = entity.getTimestamp();
       result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
@@ -315,7 +314,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testVisibleChangeOfNodeInWay() throws ParseException {
+  public void testVisibleChangeOfNodeInWay() {
     // relation, way member: node 52 changes visible tag
     OSMEntity entity = testData.relations().get(509L).get(0);
     // timestamp where node 52 visible is false
@@ -324,7 +323,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 1);
+      assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -339,7 +338,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
           areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertTrue(resultAfter.isValid());
-      assertTrue(resultAfter.getNumGeometries() == 1);
+      assertEquals(1, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -348,7 +347,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testTagChangeOfNodeInWay() throws ParseException {
+  public void testTagChangeOfNodeInWay() {
     // relation, way member: node 53 changes tags, 51 changes coordinates
     OSMEntity entity = testData.relations().get(510L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -356,7 +355,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 1);
+      assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -370,7 +369,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
           .getGeometry(entityAfter, timestampAfter, areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertTrue(resultAfter.isValid());
-      assertTrue(resultAfter.getNumGeometries() == 1);
+      assertEquals(1, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -379,7 +378,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testVisibleChangeOfWay() throws ParseException {
+  public void testVisibleChangeOfWay() {
     // relation, way member: way 119 changes visible tag
     OSMEntity entity = testData.relations().get(511L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -387,7 +386,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 1);
+      assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -408,7 +407,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testVisibleChangeOfOneWayOfOuterRing() throws ParseException {
+  public void testVisibleChangeOfOneWayOfOuterRing() {
     // relation, 2 way members making outer ring: way 120 changes visible tag later, 121 not
     OSMEntity entity = testData.relations().get(512L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -416,7 +415,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 2);
+      assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -430,7 +429,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
           areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
-      assertTrue(resultAfter.getNumGeometries() == 2);
+      assertEquals(2, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof LineString
           || resultAfter.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -440,7 +439,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testTagChangeOfWay() throws ParseException {
+  public void testTagChangeOfWay() {
     // relation, way member: way 122 changes tags
     OSMEntity entity = testData.relations().get(513L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -448,7 +447,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 1);
+      assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -461,7 +460,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
-      assertTrue(result1.getNumGeometries() == 1);
+      assertEquals(1, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -474,7 +473,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection);
       assertTrue(result2.isValid());
-      assertTrue(result2.getNumGeometries() == 1);
+      assertEquals(1, result2.getNumGeometries());
       assertTrue(result2.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -483,7 +482,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testOneOfTwoPolygonDisappears() throws ParseException {
+  public void testOneOfTwoPolygonDisappears() {
     // relation, at the beginning two polygons, one disappears later
     OSMEntity entity = testData.relations().get(514L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -491,7 +490,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 2);
+      assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -505,7 +504,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
-      assertTrue(result1.getNumGeometries() == 1);
+      assertEquals(1, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -514,7 +513,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
   }
 
   @Test
-  public void testWaySplitUpInTwo() throws ParseException {
+  public void testWaySplitUpInTwo() {
     // relation, at the beginning one way, split up later into 2 ways
     OSMEntity entity = testData.relations().get(515L).get(0);
     OSHDBTimestamp timestamp = entity.getTimestamp();
@@ -522,7 +521,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-      assertTrue(result.getNumGeometries() == 1);
+      assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
     } catch (Exception e) {
       e.printStackTrace();
@@ -535,7 +534,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
-      assertTrue(result1.getNumGeometries() == 2);
+      assertEquals(2, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
       assertTrue(result1.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -552,7 +551,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.getNumGeometries() == 3);
+      assertEquals(3, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof Point);
       assertTrue(result.getGeometryN(2) instanceof LineString);
@@ -570,7 +569,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.getNumGeometries() == 2);
+      assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
     } catch (Exception e) {
@@ -583,7 +582,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     try {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection);
-      assertTrue(result2.getNumGeometries() == 3);
+      assertEquals(3, result2.getNumGeometries());
       assertTrue(result2.getGeometryN(0) instanceof LineString);
       assertTrue(result2.getGeometryN(1) instanceof LineString);
       assertTrue(result2.getGeometryN(2) instanceof LineString);

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
@@ -68,7 +68,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     try {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection || result2 instanceof Polygonal);
-      assertTrue(result2.getNumGeometries() == 3);
+      assertEquals(3, result2.getNumGeometries());
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
@@ -110,6 +110,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     assertEquals(expectedPolygon2.getArea(), intersection2.getArea(), DELTA);
   }
 
+  @SuppressWarnings({"unused", "UnusedAssignment"})
   @Test
   public void testWaysNotExistent() {
     // relation with two ways, both missing
@@ -275,7 +276,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
       OSHDBTimestamp timestamp = entity.getTimestamp();
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.getNumGeometries() == 6);
+      assertEquals(6, result.getNumGeometries());
       assertFalse(result instanceof MultiPolygon);
     } catch (Exception e) {
       e.printStackTrace();
@@ -283,6 +284,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     }
   }
 
+  @SuppressWarnings({"unused", "UnusedAssignment"})
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation with two ways, all nodes not existing
@@ -399,7 +401,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
         areaDecider);
     assertTrue(resultAfter instanceof GeometryCollection);
-    assertTrue(resultAfter.getNumGeometries() == 2);
+    assertEquals(2, resultAfter.getNumGeometries());
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
@@ -110,15 +110,13 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     assertEquals(expectedPolygon2.getArea(), intersection2.getArea(), DELTA);
   }
 
-  @SuppressWarnings({"unused", "UnusedAssignment"})
   @Test
   public void testWaysNotExistent() {
     // relation with two ways, both missing
     OSMEntity entity = testData.relations().get(502L).get(0);
-    Geometry result = null;
     try {
       OSHDBTimestamp timestamp = entity.getTimestamp();
-      result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+      OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
@@ -284,15 +282,13 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     }
   }
 
-  @SuppressWarnings({"unused", "UnusedAssignment"})
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation with two ways, all nodes not existing
     OSMEntity entity = testData.relations().get(508L).get(0);
-    Geometry result = null;
     try {
       OSHDBTimestamp timestamp = entity.getTimestamp();
-      result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+      OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
@@ -15,7 +15,6 @@ import org.junit.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Polygon;
-import org.locationtech.jts.io.ParseException;
 
 public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
   private final OSMXmlReader testData = new OSMXmlReader();
@@ -27,136 +26,76 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     areaDecider = new OSMXmlReaderTagInterpreter(testData);
   }
 
+  private static void checkLineString(double[][] expectedCoordinates, Geometry result,
+      int numCoordinates) {
+    assertTrue(result instanceof LineString);
+    assertEquals(numCoordinates, result.getNumPoints());
+    for (int i = 0; i < numCoordinates; i++) {
+      assertEquals(expectedCoordinates[i][0], (((LineString) result).getCoordinateN(i)).x, DELTA);
+      assertEquals(expectedCoordinates[i][1], (((LineString) result).getCoordinateN(i)).y, DELTA);
+    }
+  }
+
   @Test
-  public void testGeometryChange() throws ParseException {
+  public void testGeometryChange() {
     // Way getting more nodes, one disappears
     // first appearance
     OSMEntity entity1 = testData.ways().get(100L).get(0);
     OSHDBTimestamp timestamp = entity1.getTimestamp();
     Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertEquals(4, result1.getNumPoints());
-    assertEquals(1.42, (((LineString) result1).getCoordinateN(0)).x, DELTA);
-    assertEquals(1.22, (((LineString) result1).getCoordinateN(0)).y, DELTA);
-    assertEquals(1.42, (((LineString) result1).getCoordinateN(1)).x, DELTA);
-    assertEquals(1.23, (((LineString) result1).getCoordinateN(1)).y, DELTA);
-    assertEquals(1.42, (((LineString) result1).getCoordinateN(2)).x, DELTA);
-    assertEquals(1.24, (((LineString) result1).getCoordinateN(2)).y, DELTA);
-    assertEquals(1.42, (((LineString) result1).getCoordinateN(3)).x, DELTA);
-    assertEquals(1.25, (((LineString) result1).getCoordinateN(3)).y, DELTA);
+    double[][] expectedCoordinates1 = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25}};
+    checkLineString(expectedCoordinates1, result1, 4);
     // second appearance
     OSMEntity entity2 = testData.ways().get(100L).get(1);
     OSHDBTimestamp timestamp2 = entity2.getTimestamp();
     Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof LineString);
-    assertEquals(8, result2.getNumPoints());
-    assertEquals(1.42, (((LineString) result2).getCoordinateN(0)).x, DELTA);
-    assertEquals(1.22, (((LineString) result2).getCoordinateN(0)).y, DELTA);
-    assertEquals(1.42, (((LineString) result2).getCoordinateN(1)).x, DELTA);
-    assertEquals(1.23, (((LineString) result2).getCoordinateN(1)).y, DELTA);
-    assertEquals(1.42, (((LineString) result2).getCoordinateN(2)).x, DELTA);
-    assertEquals(1.24, (((LineString) result2).getCoordinateN(2)).y, DELTA);
-    assertEquals(1.42, (((LineString) result2).getCoordinateN(3)).x, DELTA);
-    assertEquals(1.25, (((LineString) result2).getCoordinateN(3)).y, DELTA);
-    assertEquals(1.42, (((LineString) result2).getCoordinateN(4)).x, DELTA);
-    assertEquals(1.26, (((LineString) result2).getCoordinateN(4)).y, DELTA);
-    assertEquals(1.42, (((LineString) result2).getCoordinateN(5)).x, DELTA);
-    assertEquals(1.27, (((LineString) result2).getCoordinateN(5)).y, DELTA);
-    assertEquals(1.42, (((LineString) result2).getCoordinateN(6)).x, DELTA);
-    assertEquals(1.28, (((LineString) result2).getCoordinateN(6)).y, DELTA);
-    assertEquals(1.43, (((LineString) result2).getCoordinateN(7)).x, DELTA);
-    assertEquals(1.29, (((LineString) result2).getCoordinateN(7)).y, DELTA);
+    double[][] expectedCoordinates2 = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
+        {1.42, 1.26}, {1.42, 1.27}, {1.42, 1.28}, {1.43, 1.29}};
+    checkLineString(expectedCoordinates2, result2, 8);
     // last appearance
     OSMEntity entity3 = testData.ways().get(100L).get(2);
     OSHDBTimestamp timestamp3 = entity3.getTimestamp();
     Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
-    assertTrue(result3 instanceof LineString);
-    assertEquals(9, result3.getNumPoints());
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(0)).x, DELTA);
-    assertEquals(1.22, (((LineString) result3).getCoordinateN(0)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(1)).x, DELTA);
-    assertEquals(1.23, (((LineString) result3).getCoordinateN(1)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(2)).x, DELTA);
-    assertEquals(1.24, (((LineString) result3).getCoordinateN(2)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(3)).x, DELTA);
-    assertEquals(1.25, (((LineString) result3).getCoordinateN(3)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(4)).x, DELTA);
-    assertEquals(1.26, (((LineString) result3).getCoordinateN(4)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(5)).x, DELTA);
-    assertEquals(1.28, (((LineString) result3).getCoordinateN(5)).y, DELTA);
-    assertEquals(1.43, (((LineString) result3).getCoordinateN(6)).x, DELTA);
-    assertEquals(1.29, (((LineString) result3).getCoordinateN(6)).y, DELTA);
-    assertEquals(1.43, (((LineString) result3).getCoordinateN(7)).x, DELTA);
-    assertEquals(1.30, (((LineString) result3).getCoordinateN(7)).y, DELTA);
-    assertEquals(1.43, (((LineString) result3).getCoordinateN(8)).x, DELTA);
-    assertEquals(1.31, (((LineString) result3).getCoordinateN(8)).y, DELTA);
+    double[][] expectedCoordinates3 = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
+        {1.42, 1.26}, {1.42, 1.28}, {1.43, 1.29}, {1.43, 1.30}, {1.43, 1.31}};
+    checkLineString(expectedCoordinates3, result3, 9);
     // timestamp after last one
     OSMEntity entityAfter = testData.ways().get(100L).get(2);
     OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-01-01T00:00:00Z");
     Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
         areaDecider);
-    assertTrue(resultAfter instanceof LineString);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(0)).x, DELTA);
-    assertEquals(1.22, (((LineString) result3).getCoordinateN(0)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(1)).x, DELTA);
-    assertEquals(1.23, (((LineString) result3).getCoordinateN(1)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(2)).x, DELTA);
-    assertEquals(1.24, (((LineString) result3).getCoordinateN(2)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(3)).x, DELTA);
-    assertEquals(1.25, (((LineString) result3).getCoordinateN(3)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(4)).x, DELTA);
-    assertEquals(1.26, (((LineString) result3).getCoordinateN(4)).y, DELTA);
-    assertEquals(1.42, (((LineString) result3).getCoordinateN(5)).x, DELTA);
-    assertEquals(1.28, (((LineString) result3).getCoordinateN(5)).y, DELTA);
-    assertEquals(1.43, (((LineString) result3).getCoordinateN(6)).x, DELTA);
-    assertEquals(1.29, (((LineString) result3).getCoordinateN(6)).y, DELTA);
-    assertEquals(1.43, (((LineString) result3).getCoordinateN(7)).x, DELTA);
-    assertEquals(1.30, (((LineString) result3).getCoordinateN(7)).y, DELTA);
-    assertEquals(1.43, (((LineString) result3).getCoordinateN(8)).x, DELTA);
-    assertEquals(1.31, (((LineString) result3).getCoordinateN(8)).y, DELTA);
+    double[][] expectedCoordinatesAfter = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
+        {1.42, 1.26}, {1.42, 1.28}, {1.43, 1.29}, {1.43, 1.30}, {1.43, 1.31}};
+    checkLineString(expectedCoordinatesAfter, resultAfter, 9);
   }
 
   @Test
-  public void testGeometryChangeOfNodeInWay() throws ParseException {
+  public void testGeometryChangeOfNodeInWay() {
     // Way with two then three nodes, changing lat lon
     // first appearance
     OSMEntity entity1 = testData.ways().get(101L).get(0);
     OSHDBTimestamp timestamp = entity1.getTimestamp();
     Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertEquals(2, result1.getNumPoints());
-    assertEquals(1.42, (((LineString) result1).getCoordinateN(0)).x, DELTA);
-    assertEquals(1.22, (((LineString) result1).getCoordinateN(0)).y, DELTA);
-    assertEquals(1.44, (((LineString) result1).getCoordinateN(1)).x, DELTA);
-    assertEquals(1.22, (((LineString) result1).getCoordinateN(1)).y, DELTA);
+    double[][] expectedCoordinates1 = {{1.42, 1.22}, {1.44, 1.22}};
+    checkLineString(expectedCoordinates1, result1, 2);
     // last appearance
     OSMEntity entity2 = testData.ways().get(101L).get(1);
     OSHDBTimestamp timestamp2 = entity2.getTimestamp();
     Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof LineString);
-    assertEquals(3, result2.getNumPoints());
-    assertEquals(1.425, (((LineString) result2).getCoordinateN(0)).x, DELTA);
-    assertEquals(1.23, (((LineString) result2).getCoordinateN(0)).y, DELTA);
-    assertEquals(1.44, (((LineString) result2).getCoordinateN(1)).x, DELTA);
-    assertEquals(1.23, (((LineString) result2).getCoordinateN(1)).y, DELTA);
-    assertEquals(1.43, (((LineString) result2).getCoordinateN(2)).x, DELTA);
-    assertEquals(1.30, (((LineString) result2).getCoordinateN(2)).y, DELTA);
+    double[][] expectedCoordinates2 = {{1.425, 1.23}, {1.44, 1.23}, {1.43, 1.30}};
+    checkLineString(expectedCoordinates2, result2, 3);
     // timestamp in between
     OSHDBTimestamp timestampBetween =  TimestampParser.toOSHDBTimestamp("2009-02-01T00:00:00Z");
     OSMEntity entityBetween = testData.ways().get(101L).get(0);
     Geometry resultBetween = OSHDBGeometryBuilder.getGeometry(entityBetween, timestampBetween,
         areaDecider);
-    assertTrue(resultBetween instanceof LineString);
-    assertEquals(2, resultBetween.getNumPoints());
-    assertEquals(1.42, (((LineString) resultBetween).getCoordinateN(0)).x, DELTA);
-    assertEquals(1.225, (((LineString) resultBetween).getCoordinateN(0)).y, DELTA);
-    assertEquals(1.445, (((LineString) resultBetween).getCoordinateN(1)).x, DELTA);
-    assertEquals(1.225, (((LineString) resultBetween).getCoordinateN(1)).y, DELTA);
+    double[][] expectedCoordinatesBetween = {{1.42, 1.225}, {1.445, 1.225}};
+    checkLineString(expectedCoordinatesBetween, resultBetween, 2);
   }
 
   @Test
-  public void testVisibleChange() throws ParseException {
-    // Way visible schanged
+  public void testVisibleChange() {
+    // Way visible changed
     // first appearance
     OSMEntity entity1 = testData.ways().get(102L).get(0);
     OSHDBTimestamp timestamp = entity1.getTimestamp();
@@ -172,8 +111,8 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
   }
 
   @Test
-  public void testTagChange() throws ParseException {
-    // Way tags schanged
+  public void testTagChange() {
+    // Way tags changed
     // first appearance
     OSMEntity entity1 = testData.ways().get(103L).get(0);
     OSHDBTimestamp timestamp = entity1.getTimestamp();
@@ -196,8 +135,8 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
   }
 
   @Test
-  public void testMultipleChangesOnNodesOfWay() throws ParseException {
-    // Way various things schanged
+  public void testMultipleChangesOnNodesOfWay() {
+    // Way various things changed
     // first appearance
     OSMEntity entity1 = testData.ways().get(104L).get(0);
     OSHDBTimestamp timestamp = entity1.getTimestamp();
@@ -214,7 +153,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
   }
 
   @Test
-  public void testMultipleChangesOnNodesAndWays() throws ParseException {
+  public void testMultipleChangesOnNodesAndWays() {
     // way and nodes have different changes
     // first appearance
     OSMEntity entity1 = testData.ways().get(105L).get(0);
@@ -244,7 +183,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
 
   // MULTIPOLYGON(((1.45 1.45, 1.46 1.45, 1.46 1.44, 1.45 1.44)))
   @Test
-  public void testPolygonAreaYesTagDisappears() throws ParseException {
+  public void testPolygonAreaYesTagDisappears() {
     // way seems to be polygon with area=yes, later linestring because area=yes deleted
     // first appearance
     OSMEntity entity1 = testData.ways().get(106L).get(0);
@@ -263,7 +202,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
 
 
   @Test
-  public void testPolygonAreaYesNodeDisappears() throws ParseException {
+  public void testPolygonAreaYesNodeDisappears() {
     // way seems to be polygon with area=yes, later linestring because area=yes deleted
     // first appearance
     OSMEntity entity1 = testData.ways().get(107L).get(0);

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
@@ -35,7 +35,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     OSHDBTimestamp timestamp = entity1.getTimestamp();
     Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     assertTrue(result1 instanceof LineString);
-    assertEquals(4,result1.getNumPoints());
+    assertEquals(4, result1.getNumPoints());
     assertEquals(1.42, (((LineString) result1).getCoordinateN(0)).x, DELTA);
     assertEquals(1.22, (((LineString) result1).getCoordinateN(0)).y, DELTA);
     assertEquals(1.42, (((LineString) result1).getCoordinateN(1)).x, DELTA);
@@ -49,7 +49,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     OSHDBTimestamp timestamp2 = entity2.getTimestamp();
     Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
     assertTrue(result2 instanceof LineString);
-    assertEquals(8,result2.getNumPoints());
+    assertEquals(8, result2.getNumPoints());
     assertEquals(1.42, (((LineString) result2).getCoordinateN(0)).x, DELTA);
     assertEquals(1.22, (((LineString) result2).getCoordinateN(0)).y, DELTA);
     assertEquals(1.42, (((LineString) result2).getCoordinateN(1)).x, DELTA);
@@ -71,7 +71,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     OSHDBTimestamp timestamp3 = entity3.getTimestamp();
     Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
     assertTrue(result3 instanceof LineString);
-    assertEquals(9,result3.getNumPoints());
+    assertEquals(9, result3.getNumPoints());
     assertEquals(1.42, (((LineString) result3).getCoordinateN(0)).x, DELTA);
     assertEquals(1.22, (((LineString) result3).getCoordinateN(0)).y, DELTA);
     assertEquals(1.42, (((LineString) result3).getCoordinateN(1)).x, DELTA);
@@ -124,7 +124,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     OSHDBTimestamp timestamp = entity1.getTimestamp();
     Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     assertTrue(result1 instanceof LineString);
-    assertEquals(2,result1.getNumPoints());
+    assertEquals(2, result1.getNumPoints());
     assertEquals(1.42, (((LineString) result1).getCoordinateN(0)).x, DELTA);
     assertEquals(1.22, (((LineString) result1).getCoordinateN(0)).y, DELTA);
     assertEquals(1.44, (((LineString) result1).getCoordinateN(1)).x, DELTA);
@@ -134,7 +134,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     OSHDBTimestamp timestamp2 = entity2.getTimestamp();
     Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
     assertTrue(result2 instanceof LineString);
-    assertEquals(3,result2.getNumPoints());
+    assertEquals(3, result2.getNumPoints());
     assertEquals(1.425, (((LineString) result2).getCoordinateN(0)).x, DELTA);
     assertEquals(1.23, (((LineString) result2).getCoordinateN(0)).y, DELTA);
     assertEquals(1.44, (((LineString) result2).getCoordinateN(1)).x, DELTA);
@@ -147,7 +147,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     Geometry resultBetween = OSHDBGeometryBuilder.getGeometry(entityBetween, timestampBetween,
         areaDecider);
     assertTrue(resultBetween instanceof LineString);
-    assertEquals(2,resultBetween.getNumPoints());
+    assertEquals(2, resultBetween.getNumPoints());
     assertEquals(1.42, (((LineString) resultBetween).getCoordinateN(0)).x, DELTA);
     assertEquals(1.225, (((LineString) resultBetween).getCoordinateN(0)).y, DELTA);
     assertEquals(1.445, (((LineString) resultBetween).getCoordinateN(1)).x, DELTA);
@@ -162,7 +162,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     OSHDBTimestamp timestamp = entity1.getTimestamp();
     Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     assertTrue(result1 instanceof LineString);
-    assertEquals(3,result1.getNumPoints());
+    assertEquals(3, result1.getNumPoints());
 
     // last appearance
     OSMEntity entity2 = testData.ways().get(102L).get(1);
@@ -179,19 +179,19 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     OSHDBTimestamp timestamp = entity1.getTimestamp();
     Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     assertTrue(result1 instanceof LineString);
-    assertEquals(3,result1.getNumPoints());
+    assertEquals(3, result1.getNumPoints());
     // second appearance
     OSMEntity entity2 = testData.ways().get(103L).get(1);
     OSHDBTimestamp timestamp2 = entity2.getTimestamp();
     Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
     assertTrue(result2 instanceof LineString);
-    assertEquals(5,result2.getNumPoints());
+    assertEquals(5, result2.getNumPoints());
     // last appearance
     OSMEntity entity3 = testData.ways().get(103L).get(1);
     OSHDBTimestamp timestamp3 = entity3.getTimestamp();
     Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
     assertTrue(result3 instanceof LineString);
-    assertEquals(5,result3.getNumPoints());
+    assertEquals(5, result3.getNumPoints());
 
   }
 
@@ -227,7 +227,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
     OSHDBTimestamp timestamp2 = entity2.getTimestamp();
     Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
     assertTrue(result2 instanceof LineString);
-    assertEquals(2,result2.getNumPoints());
+    assertEquals(2, result2.getNumPoints());
     // third appearance
     OSMEntity entity3 = testData.ways().get(105L).get(2);
     OSHDBTimestamp timestamp3 = entity3.getTimestamp();
@@ -242,7 +242,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
 
   }
 
-  // MULTIPOLYGON(((1.45 1.45,1.46 1.45,1.46 1.44,1.45 1.44)))
+  // MULTIPOLYGON(((1.45 1.45, 1.46 1.45, 1.46 1.44, 1.45 1.44)))
   @Test
   public void testPolygonAreaYesTagDisappears() throws ParseException {
     // way seems to be polygon with area=yes, later linestring because area=yes deleted

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
@@ -233,8 +233,8 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertTrue(result1.crosses(result2));
-    for (int j = 0; j < result1.getLength();j++) {
-      for (int i = 0; i < result2.getLength();i++) {
+    for (int j = 0; j < result1.getLength(); j++) {
+      for (int i = 0; i < result2.getLength(); i++) {
         assertNotEquals(((LineString) result1).getCoordinateN(j),
             ((LineString) result2).getCoordinateN(i));
       }
@@ -251,8 +251,8 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertTrue(result1.intersects(result2));
-    for (int j = 0; j < result1.getLength();j++) {
-      for (int i = 0; i < result2.getLength();i++) {
+    for (int j = 0; j < result1.getLength(); j++) {
+      for (int i = 0; i < result2.getLength(); i++) {
         try {
           ((LineString) result1).getCoordinateN(j).equals(((LineString) result2).getCoordinateN(i));
         } catch (Exception e) {
@@ -274,8 +274,8 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     assertTrue(result2 instanceof LineString);
     assertTrue(result1.crosses(result2));
     assertTrue(result1.intersects(result2));
-    for (int j = 0; j < result1.getLength();j++) {
-      for (int i = 0; i < result2.getLength();i++) {
+    for (int j = 0; j < result1.getLength(); j++) {
+      for (int i = 0; i < result2.getLength(); i++) {
         try {
           ((LineString) result1).getCoordinateN(j).equals(
               ((LineString) result2).getCoordinateN(i));

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
@@ -44,11 +44,11 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     assertEquals(1.02, ((Point) result).getY(), DELTA);
   }
 
-  @Test
+  /* @Test
   public void test101() {
     // 101: 4 single nodes
     // the same like test100() just with 4 nodes
-  }
+  } */
 
   @Test
   public void test102() {
@@ -72,11 +72,11 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     assertEquals(2, result1.getCoordinates().length);
   }
 
-  @Test
+  /* @Test
   public void test111() {
     // 111 : Way with 4 nodes
     // the same like test110() just with 4 nodes
-  }
+  } */
 
   @Test
   public void test112() {
@@ -241,6 +241,7 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     }
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   public void test131() {
     // Crossing ways with common node
@@ -263,6 +264,7 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     }
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   public void test132() {
     // Crossing ways without common node, but crossing node at same position

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
@@ -6,6 +6,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
 import org.heigit.bigspatialdata.oshdb.util.OSHDBTimestamp;
 import org.heigit.bigspatialdata.oshdb.util.geometry.OSHDBGeometryBuilder;
@@ -241,7 +244,6 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     }
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   public void test131() {
     // Crossing ways with common node
@@ -252,19 +254,14 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertTrue(result1.intersects(result2));
-    for (int j = 0; j < result1.getLength(); j++) {
-      for (int i = 0; i < result2.getLength(); i++) {
-        try {
-          ((LineString) result1).getCoordinateN(j).equals(((LineString) result2).getCoordinateN(i));
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail("No common node");
-        }
-      }
-    }
+    Set<Coordinate> res1Coords = Arrays
+        .stream(result1.getCoordinates())
+        .collect(Collectors.toSet());
+    assertTrue(Arrays
+        .stream(result2.getCoordinates())
+        .anyMatch(res1Coords::contains));
   }
 
-  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   public void test132() {
     // Crossing ways without common node, but crossing node at same position
@@ -276,17 +273,12 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
     assertTrue(result2 instanceof LineString);
     assertTrue(result1.crosses(result2));
     assertTrue(result1.intersects(result2));
-    for (int j = 0; j < result1.getLength(); j++) {
-      for (int i = 0; i < result2.getLength(); i++) {
-        try {
-          ((LineString) result1).getCoordinateN(j).equals(
-              ((LineString) result2).getCoordinateN(i));
-        } catch (Exception e) {
-          e.printStackTrace();
-          fail("No common node");
-        }
-      }
-    }
+    Set<Coordinate> res1Coords = Arrays
+        .stream(result1.getCoordinates())
+        .collect(Collectors.toSet());
+    assertTrue(Arrays
+        .stream(result2.getCoordinates())
+        .anyMatch(res1Coords::contains));
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -1,6 +1,6 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.osmtestdata;
 
-import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
@@ -25,79 +25,63 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
     areaDecider = new OSMXmlReaderTagInterpreter(testData);
   }
 
+  private Geometry buildEntityGeometry(long id) {
+    OSMEntity entity = testData.nodes().get(id).get(0);
+    return OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+  }
+
   @Test
   public void test300() {
     // Normal node with uid (and user name)
-    OSMEntity entity = testData.nodes().get(200000L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildEntityGeometry(200000L);
     assertTrue(result instanceof Point);
-    Integer entityUid = testData.nodes().get(200000L).get(0).getUserId();
-    assertTrue(entityUid instanceof Integer);
+    int entityUid = testData.nodes().get(200000L).get(0).getUserId();
+    assertEquals(1, entityUid);
+  }
+
+  @Test(expected = Test.None.class /* no exception expected */)
+  public void test301() {
+    // Empty username on node should not happen
+    buildEntityGeometry(201000L);
   }
 
   @Test
-  public void test301() {
-    // Empty username on node should not happen
-    OSMEntity entity1 = testData.nodes().get(201000L).get(0);
-    try {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
-  }
-
-  /* @Test
   public void test302() {
     // No uid and no user name means user is anonymous
     // user name is not priority
-  } */
-
-  /* @Test
-  public void test303() {
-    // No uid and no user name means user is anonymous
-    // user name is not priority
-  } */
+    int entityUid = testData.nodes().get(202000L).get(0).getUserId();
+    assertTrue(entityUid < 1);
+  }
 
   @Test
+  public void test303() {
+    // uid 0 is the anonymous user
+    int entityUid = testData.nodes().get(203000L).get(0).getUserId();
+    assertEquals(0, entityUid);
+  }
+
+  @Test(expected = Test.None.class /* no exception expected */)
   public void test304() {
     // negative user ids are not allowed (but -1 could have been meant as anonymous user)
-    OSMEntity entity1 = testData.nodes().get(204000L).get(0);
-    try {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    buildEntityGeometry(204000L);
   }
 
-  @Test
+  @Test(expected = Test.None.class /* no exception expected */)
   public void test305() {
     // uid < 0 and username is inconsistent and definitely wrong
-    OSMEntity entity1 = testData.nodes().get(205000L).get(0);
-    try {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    buildEntityGeometry(205000L);
   }
 
-  /* @Test
+  @Test(expected = Test.None.class /* no exception expected */)
   public void test306() {
     // 250 characters in username is okay
     // user name is not priority
-  } */
+    buildEntityGeometry(206000L);
+  }
 
-  @Test
+  @Test(expected = Test.None.class /* no exception expected */)
   public void test307() {
     // 260 characters in username is too long
-    OSMEntity entity1 = testData.nodes().get(207000L).get(0);
-    try {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    buildEntityGeometry(207000L);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -19,7 +19,6 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
   TagInterpreter areaDecider;
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
-  private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderTestOsmTestData3xxTest() {
     testData.add("./src/test/resources/osm-testdata/all.osm");
@@ -48,17 +47,17 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
     }
   }
 
-  @Test
+  /* @Test
   public void test302() {
     // No uid and no user name means user is anonymous
     // user name is not priority
-  }
+  } */
 
-  @Test
+  /* @Test
   public void test303() {
     // No uid and no user name means user is anonymous
     // user name is not priority
-  }
+  } */
 
   @Test
   public void test304() {
@@ -84,11 +83,11 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
     }
   }
 
-  @Test
+  /* @Test
   public void test306() {
     // 250 characters in username is okay
     // user name is not priority
-  }
+  } */
 
   @Test
   public void test307() {

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -1160,26 +1160,24 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     }
   }
 
-  @SuppressWarnings("unused")
   @Test
   public void test792() {
     // Multipolygon relation containing two ways using the same nodes in different order
     OSMEntity entity1 = testData.relations().get(792900L).get(0);
     try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
     }
   }
 
-  @SuppressWarnings("unused")
   @Test
   public void test793() {
     // Multipolygon relation containing the two ways using nearly the same nodes
     OSMEntity entity1 = testData.relations().get(793900L).get(0);
     try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
@@ -1192,13 +1190,12 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     // the same like test 791
   } */
 
-  @SuppressWarnings("unused")
   @Test
   public void test795() {
     // Multipolygon with one outer and one duplicated inner ring
     OSMEntity entity1 = testData.relations().get(795900L).get(0);
     try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -314,26 +314,26 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     assertEquals(1.0, expectedPolygon.getArea() / intersection.getArea(), DELTA);
   }
 
-  @Test
+  /* @Test
   public void test721() throws ParseException {
     // "Multipolygon with one outer and one inner ring. They are both oriented anti-clockwise and
     // have the correct role.
     // the same as test(720) apart from anti-clockwise
-  }
+  } */
 
-  @Test
+  /* @Test
   public void test722() throws ParseException {
     // Multipolygon with one outer and one inner ring. The outer ring is oriented clockwise, the
     // inner anti-clockwise. They have both the correct role.
     // the same as test(720) apart from anti-clockwise
-  }
+  } */
 
-  @Test
+  /* @Test
   public void test723() throws ParseException {
     // Multipolygon with one outer and one inner ring. The outer ring is oriented anti-clockwise,
     // the inner clockwise. They have both the correct role.
     // the same as test(722) apart from anti-clockwise
-  }
+  } */
 
   @Test
   public void test724() throws ParseException {
@@ -373,17 +373,17 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     assertEquals(1.0, expectedPolygon.getArea() / intersection.getArea(), DELTA);
   }
 
-  @Test
+  /* @Test
   public void test726() throws ParseException {
     // Valid multipolygon with one inner and one outer
     // the same as test(724) apart from anti-clockwise
-  }
+  } */
 
-  @Test
+  /* @Test
   public void test727() throws ParseException {
     // Valid multipolygon with one inner and one outer
     // the same as test(724) apart from anti-clockwise
-  }
+  } */
 
   @Test
   public void test728() throws ParseException {
@@ -492,17 +492,17 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     assertEquals(1.0, expectedPolygon.getArea() / intersection.getArea(), DELTA);
   }
 
-  @Test
+  /* @Test
   public void test733() throws ParseException {
     // Valid multipolygon with two outer rings
     // The same as test 706
-  }
+  } */
 
-  @Test
+  /* @Test
   public void test734() throws ParseException {
     // Valid multipolygon with three outer rings
     // the same as test 709
-  }
+  } */
 
   @Test
   public void test740() {
@@ -543,11 +543,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     }
   }
 
-  @Test
+  /* @Test
   public void test743() {
     // Invalid multipolygon because of a 'spike'
     // the same like test 742
-  }
+  } */
 
   @Test
   public void test744() {
@@ -556,7 +556,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
       assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertTrue(result.getNumGeometries() == 2);
+      assertEquals(2, result.getNumGeometries());
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
@@ -570,7 +570,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
       assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertTrue(result.getNumGeometries() == 1);
+      assertEquals(1, result.getNumGeometries());
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
@@ -584,7 +584,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
       assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertTrue(result.getNumGeometries() == 2);
+      assertEquals(2, result.getNumGeometries());
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
@@ -753,39 +753,39 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     }
   }
 
-  @Test
+  /* @Test
   public void test758() throws ParseException {
     // Inner ring touching outer in node.
     // the same as test 755
-  }
+  } */
 
-  @Test
+  /* @Test
   public void test759() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/128
     // Outer going back on itself in single node.
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
-  @Test
+  /* @Test
   public void test760() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/128
     // Faking inner ring with outer going back on itself (with relation).
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
-  @Test
+  /* @Test
   public void test761() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/128
     // Faking inner ring with outer going back on itself (with relation).
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
-  @Test
+  /* @Test
   public void test762() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/127
     // Touching outer rings.
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
   @Test
   public void test763() throws ParseException {
@@ -835,26 +835,26 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     assertEquals(1.0, expectedPolygon.getArea() / intersection.getArea(), DELTA);
   }
 
-  @Test
+  /* @Test
   public void test765() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/126
     // Multipolygon with one outer ring that should be split into two components.
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
-  @Test
+  /* @Test
   public void test766() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/126
     // Multipolygon with one outer and inner ring that should be split into two components.
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
-  @Test
+  /* @Test
   public void test767() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/125
     // Single way going back on itself.
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
   @Test
   public void test768() {
@@ -869,11 +869,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     }
   }
 
-  @Test
+  /* @Test
   public void test770() throws ParseException {
     // Multipolygon with two outer rings touching in single node.
     // the same as 706
-  }
+  } */
 
   @Test
   public void test771() {
@@ -882,7 +882,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
       assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertTrue(result.getNumGeometries() == 2);
+      assertEquals(2, result.getNumGeometries());
     } catch (Exception e) {
       e.printStackTrace();
       fail("Should not have thrown any exception");
@@ -943,19 +943,19 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     assertEquals(1.0, expectedPolygon.getArea() / intersection.getArea(), DELTA);
   }
 
-  @Test
+  /* @Test
   public void test775() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/124
     // Multipolygon with two outer rings touching in two nodes.
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
-  @Test
+  /* @Test
   public void test776() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/124
     // Multipolygon with two outer rings touching in two nodes.
-    // -- no assertation, because the test data itself is not valid --
-  }
+    // -- no assertion, because the test data itself is not valid --
+  } */
 
   @Test
   public void test777() throws ParseException {
@@ -986,7 +986,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test778() throws ParseException {
+  public void test778() {
     /*
     778 is not a valid test case.
 
@@ -1160,6 +1160,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     }
   }
 
+  @SuppressWarnings("unused")
   @Test
   public void test792() {
     // Multipolygon relation containing two ways using the same nodes in different order
@@ -1172,6 +1173,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     }
   }
 
+  @SuppressWarnings("unused")
   @Test
   public void test793() {
     // Multipolygon relation containing the two ways using nearly the same nodes
@@ -1184,12 +1186,13 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     }
   }
 
-  @Test
+  /* @Test
   public void test794() {
     // Multipolygon relation containing three ways using the same nodes in the same order.
     // the same like test 791
-  }
+  } */
 
+  @SuppressWarnings("unused")
   @Test
   public void test795() {
     // Multipolygon with one outer and one duplicated inner ring

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -412,8 +412,8 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertFalse((result.getGeometryN(1)).intersects((result.getGeometryN(0))));
-    assertEquals(0, ((Polygon)result.getGeometryN(0)).getNumInteriorRing());
-    assertEquals(1, ((Polygon)result.getGeometryN(1)).getNumInteriorRing());
+    assertEquals(0, ((Polygon) result.getGeometryN(0)).getNumInteriorRing());
+    assertEquals(1, ((Polygon) result.getGeometryN(1)).getNumInteriorRing());
     assertEquals(2, result.getNumGeometries());
     assertEquals(15, result.getCoordinates().length);
     // compare if coordinates of created points equals the coordinates of polygon
@@ -433,7 +433,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
-    assertEquals(3, ((Polygon)result).getNumInteriorRing());
+    assertEquals(3, ((Polygon) result).getNumInteriorRing());
     assertEquals(1, result.getNumGeometries());
     assertEquals(21, result.getCoordinates().length);
     // compare if coordinates of created points equals the coordinates of polygon
@@ -455,7 +455,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
-    assertEquals(2, ((Polygon)result).getNumInteriorRing());
+    assertEquals(2, ((Polygon) result).getNumInteriorRing());
     assertEquals(1, result.getNumGeometries());
     assertEquals(25, result.getCoordinates().length);
     // compare if coordinates of created points equals the coordinates of polygon
@@ -479,8 +479,8 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
     assertEquals(1,
-        ((Polygon)result.getGeometryN(0)).getNumInteriorRing()
-        + ((Polygon)result.getGeometryN(1)).getNumInteriorRing()
+        ((Polygon) result.getGeometryN(0)).getNumInteriorRing()
+        + ((Polygon) result.getGeometryN(1)).getNumInteriorRing()
     );
     // compare if coordinates of created points equals the coordinates of polygon
     Geometry expectedPolygon = (new WKTReader()).read(
@@ -637,7 +637,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
-    assertEquals(1, ((Polygon)result).getNumInteriorRing());
+    assertEquals(1, ((Polygon) result).getNumInteriorRing());
     // In the result are 12 points, but it does not matter that we get 19, because the intersection
     // is correct.
     // compare if coordinates of created points equals the coordinates of polygon
@@ -656,7 +656,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
-    assertEquals(1, ((Polygon)result).getNumInteriorRing());
+    assertEquals(1, ((Polygon) result).getNumInteriorRing());
     // In the result are 11 points, but it does not matter that we get 16, because the intersection
     // is correct.
     //assertEquals(16, result.getCoordinates().length);
@@ -794,10 +794,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
-    assertEquals(0, ((Polygon)result.getGeometryN(0)).getNumInteriorRing());
-    assertEquals(0, ((Polygon)result.getGeometryN(1)).getNumInteriorRing());
-    assertEquals(0, ((Polygon)result.getGeometryN(2)).getNumInteriorRing());
-    assertEquals(0, ((Polygon)result.getGeometryN(3)).getNumInteriorRing());
+    assertEquals(0, ((Polygon) result.getGeometryN(0)).getNumInteriorRing());
+    assertEquals(0, ((Polygon) result.getGeometryN(1)).getNumInteriorRing());
+    assertEquals(0, ((Polygon) result.getGeometryN(2)).getNumInteriorRing());
+    assertEquals(0, ((Polygon) result.getGeometryN(3)).getNumInteriorRing());
     assertEquals(4, result.getNumGeometries());
     //assertEquals(28, result.getCoordinates().length);
 
@@ -896,7 +896,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
-    assertEquals(2, ((Polygon)result).getNumInteriorRing());
+    assertEquals(2, ((Polygon) result).getNumInteriorRing());
     assertEquals(1, result.getNumGeometries());
     //assertEquals(16, result.getCoordinates().length);
     // compare if coordinates of created points equals the coordinates of polygon
@@ -1014,8 +1014,8 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
-    assertEquals(1, ((Polygon)result.getGeometryN(0)).getNumInteriorRing()
-        + ((Polygon)result.getGeometryN(1)).getNumInteriorRing());
+    assertEquals(1, ((Polygon) result.getGeometryN(0)).getNumInteriorRing()
+        + ((Polygon) result.getGeometryN(1)).getNumInteriorRing());
 
     // compare if coordinates of created points equals the coordinates of polygon
     Geometry expectedPolygon = (new WKTReader()).read(
@@ -1076,7 +1076,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
-    assertEquals(1, ((Polygon)result).getNumInteriorRing());
+    assertEquals(1, ((Polygon) result).getNumInteriorRing());
     assertEquals(1, result.getNumGeometries());
     //assertEquals(11, result.getCoordinates().length);
     // compare if coordinates of created points equals the coordinates of polygon
@@ -1096,7 +1096,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
-    assertEquals(1, ((Polygon)result).getNumInteriorRing());
+    assertEquals(1, ((Polygon) result).getNumInteriorRing());
     assertEquals(1, result.getNumGeometries());
     //assertEquals(11, result.getCoordinates().length);
     // compare if coordinates of created points equals the coordinates of polygon

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
@@ -18,7 +18,6 @@ public class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
   private final TagInterpreter tagInterpreter;
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
-  private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderMultipolygonInvalidOutersTest() {
     testData.add("./src/test/resources/relations/invalid-outer-ring.osm");

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
@@ -1,6 +1,7 @@
 package org.heigit.bigspatialdata.oshdb.util.geometry.relations;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.heigit.bigspatialdata.oshdb.osm.OSMEntity;
@@ -21,7 +22,6 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   private final TagInterpreter tagInterpreter;
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
-  private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderRelationTypeNotMultipolygonTest() {
     testData.add("./src/test/resources/relations/relationTypeNotMultipolygon.osm");
@@ -35,7 +35,7 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
       assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.getNumGeometries() == 3);
+      assertEquals(3, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof Point);
       assertTrue(result.getGeometryN(2) instanceof LineString);
@@ -52,7 +52,7 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
       assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.getNumGeometries() == 3);
+      assertEquals(3, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof Point);
       assertTrue(result.getGeometryN(1) instanceof Point);
       assertTrue(result.getGeometryN(2) instanceof Point);
@@ -69,7 +69,7 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
       assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.getNumGeometries() == 4);
+      assertEquals(4, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof Point);
       assertTrue(result.getGeometryN(2) instanceof LineString);
@@ -87,7 +87,7 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
     try {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
       assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.getNumGeometries() == 3);
+      assertEquals(3, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
       assertTrue(result.getGeometryN(2) instanceof LineString);

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/time/OSHDBTimestampsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/time/OSHDBTimestampsTest.java
@@ -84,8 +84,7 @@ public class OSHDBTimestampsTest {
 
   @Test(expected = RuntimeException.class)
   public void testInvalidTimestamp() {
-    @SuppressWarnings("unused") // creating this object should trigger the exception
-    OSHDBTimestamps invalid = new OSHDBTimestamps("test123");
+    new OSHDBTimestamps("test123");
   }
 
 }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/MutableOSMEntity.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/MutableOSMEntity.java
@@ -13,21 +13,6 @@ public class MutableOSMEntity {
   private int userId;
   private int[] tags;
 
-  /**
-   * Set properties of {@link MutableOSMEntity} with given parameters.
-   */
-  public void setEntity(long id, int version, boolean visible, long timestamp,
-      long changeset, int userId, int[] tags) {
-    this.id = id;
-    this.version = version;
-    this.visible = visible;
-    this.timestamp.setTimestamp(timestamp);
-    this.changeset = changeset;
-    this.userId = userId;
-    this.tags = tags;
-  }
-  
-  
   public long getId() {
     return id;
   }

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/OSMXmlReader.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/OSMXmlReader.java
@@ -223,7 +223,7 @@ public class OSMXmlReader {
               Map<Long, OSHNode> wayNodes = new TreeMap<>();
               for (OSMWay way : this.ways().get(memId)) {
                 for (OSMMember wayNode : way.getRefs()) {
-                  wayNodes.putIfAbsent(wayNode.getId(), (OSHNode)wayNode.getEntity());
+                  wayNodes.putIfAbsent(wayNode.getId(), (OSHNode) wayNode.getEntity());
                 }
               }
               if (this.ways().containsKey(memId)) {

--- a/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/OSMXmlReader.java
+++ b/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/OSMXmlReader.java
@@ -53,21 +53,17 @@ public class OSMXmlReader {
 
       db.relations().asMap().forEach((id, versions) -> {
         System.out.println("id:" + id);
-        versions.forEach(osm -> {
-          System.out.println("\t" + osm);
-        });
+        versions.forEach(osm -> System.out.println("\t" + osm));
       });
 
       System.out.println("\n\n");
-      db.ways.get(27913435L).forEach(osm -> {
-        System.out.println("\t" + osm);
-      });
+      db.ways.get(27913435L).forEach(osm -> System.out.println("\t" + osm));
 
       int key = 6;
-      System.out.println(db.keys.inverse().get(Integer.valueOf(key)));
+      System.out.println(db.keys.inverse().get(key));
       System.out.println(db.keys.get("place"));
 
-      System.out.println(db.keyValues.get(key).inverse().get(Integer.valueOf(2)));
+      System.out.println(db.keyValues.get(key).inverse().get(2));
 
     }
   }
@@ -136,7 +132,7 @@ public class OSMXmlReader {
         OSMNode oldOSM = new OSMNode(osm.getId(), osm.getVersion() * (osm.isVisible() ? 1 : -1),
             osm.getTimestamp(), osm.getChangeset(), osm.getUserId(), osm.getTags(), osm.getLon(),
             osm.getLat());
-        nodes.put(Long.valueOf(id), oldOSM);
+        nodes.put(id, oldOSM);
       }
       lastId = id;
     }
@@ -168,7 +164,7 @@ public class OSMXmlReader {
         // osm.setExtension(members);
         OSMWay oldOSM = new OSMWay(osm.getId(), osm.getVersion() * (osm.isVisible() ? 1 : -1),
             osm.getTimestamp(), osm.getChangeset(), osm.getUserId(), osm.getTags(), members);
-        ways.put(Long.valueOf(id), oldOSM);
+        ways.put(id, oldOSM);
       }
       lastId = id;
     }
@@ -195,7 +191,7 @@ public class OSMXmlReader {
 
           Integer r = roles.get(role);
           if (r == null) {
-            r = Integer.valueOf(roles.size());
+            r = roles.size();
             roles.put(role, r);
           }
 
@@ -236,13 +232,13 @@ public class OSMXmlReader {
             default:
               break;
           }
-          members[idx++] = new OSMMember(memId, t, r.intValue(), data);
+          members[idx++] = new OSMMember(memId, t, r, data);
         }
         // osm.setExtension(members);
         OSMRelation oldOSM = new OSMRelation(osm.getId(),
             osm.getVersion() * (osm.isVisible() ? 1 : -1),
             osm.getTimestamp(), osm.getChangeset(), osm.getUserId(), osm.getTags(), members);
-        relations.put(Long.valueOf(id), oldOSM);
+        relations.put(id, oldOSM);
       }
       lastId = id;
     }
@@ -345,20 +341,20 @@ public class OSMXmlReader {
 
       Integer k = keys.get(key);
       if (k == null) {
-        k = Integer.valueOf(keyValues.size());
+        k = keyValues.size();
         keys.put(key, k);
         keyValues.add(HashBiMap.create());
       }
 
-      BiMap<String, Integer> values = keyValues.get(k.intValue());
+      BiMap<String, Integer> values = keyValues.get(k);
       Integer v = values.get(value);
       if (v == null) {
-        v = Integer.valueOf(values.size());
+        v = values.size();
         values.put(value, v);
       }
 
-      tags[idx++] = k.intValue();
-      tags[idx++] = v.intValue();
+      tags[idx++] = k;
+      tags[idx++] = v;
     }
     return tags;
   }


### PR DESCRIPTION
# Changes proposed in this pull request:
## Type of change
- [x] Code quality improvement

## Description
- Fixes newly introduced checkstyle issues in oshdb-util
- Refactor oshdb-util tests

## Corresponding issue
Supports #90, related to 91acd97725feec2da5d4e2de18d111a07593ce44

# 🚧 Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [x] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
### Additional checklist/🚧 items
- [x] fix newly introduced checkstyle issues
- [x] refactor tests
- [x] Decide about unparameterized tests:
  - Resolve: _Replace these 3 tests with a single Parameterized one._ https://github.com/GIScience/oshdb/blob/c637936209abe4834f751e4f16cec350ae49e7fc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java#L220
  - Resolve: _Replace these 5 tests with a single Parameterized one._ https://github.com/GIScience/oshdb/blob/c637936209abe4834f751e4f16cec350ae49e7fc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java#L167
  - Resolve: _Replace these 4 tests with a single Parameterized one._ https://github.com/GIScience/oshdb/blob/d201f3837dfac3c17c9b1ffcb52314c46c7605d5/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java#L40
  - Resolve: _Replace these 15 tests with a single Parameterized one._ https://github.com/GIScience/oshdb/blob/c637936209abe4834f751e4f16cec350ae49e7fc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java#L508
  - Resolve: _Replace these 3 tests with a single Parameterized one._ https://github.com/GIScience/oshdb/blob/c637936209abe4834f751e4f16cec350ae49e7fc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java#L608
  - Resolve: _Replace these 3 tests with a single Parameterized one._ https://github.com/GIScience/oshdb/blob/c637936209abe4834f751e4f16cec350ae49e7fc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java#L1164
  - Resolve: _Replace these 4 tests with a single Parameterized one._ https://github.com/GIScience/oshdb/blob/d201f3837dfac3c17c9b1ffcb52314c46c7605d5/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java#L34
- [x] Solve issues in `OSMXmlReader.java`
- [x] Resolve questions (maybe @tyrasd wants to take a look at them):
  - [x] Why has `GridOSHFactory.java` two `getGridOSHWays`, although, `cellZoom` and `cellId` are never used? https://github.com/GIScience/oshdb/blob/c637936209abe4834f751e4f16cec350ae49e7fc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/helpers/GridOSHFactory.java#L68 https://github.com/GIScience/oshdb/blob/c637936209abe4834f751e4f16cec350ae49e7fc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/celliterator/helpers/GridOSHFactory.java#L81
  - [x] Same question for `getGridOSHRelations`.
  - [x] Does it make sense to refactor the many asserts in two tests, as IDEA suggests in `FastBboxInPolygonTest.java`?
  - [x] Does it make sense to refactor the many asserts in two tests, as IDEA suggests in `FastBboxOutsidePolygonTest.java`?
  - [x] What is the need or requirement for the many try-catch blocks that just throw the exception again in tests? e.g. https://github.com/GIScience/oshdb/blob/c637936209abe4834f751e4f16cec350ae49e7fc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java#L473-L483
  - [x] What should this do? This test is always true: https://github.com/GIScience/oshdb/blob/d201f3837dfac3c17c9b1ffcb52314c46c7605d5/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java#L35-L36
  - [x] What to do with these empty Tests? In the current solution, they just get commented out. E.g. https://github.com/GIScience/oshdb/blob/d201f3837dfac3c17c9b1ffcb52314c46c7605d5/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java#L51-L55
  - [x] Is the class `FakeTagInterpreter` still necessary? https://github.com/GIScience/oshdb/blob/d201f3837dfac3c17c9b1ffcb52314c46c7605d5/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilderTest.java#L221-L238
  - [x] Is the method `MutableOSMEntity.setEntity(…)` still necessary? https://github.com/GIScience/oshdb/blob/b1548dec2e9743e0c6de57ad4fef7d4dd08d3edc/oshdb-util/src/test/java/org/heigit/bigspatialdata/oshdb/util/xmlreader/MutableOSMEntity.java#L19