### PR TITLE
improve performance of building multipolygons with a huge number of member ways

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/bigspatialdata/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -500,34 +500,35 @@ public class OSHDBGeometryBuilder {
           break; // ring is complete -> we're done
         }
         boolean joinable = false;
-        for (int i = 0; i < ways.size(); i++) {
-          LinkedList<OSMNode> what = ways.get(i);
+        var waysIterator = ways.iterator();
+        while (waysIterator.hasNext()) {
+          LinkedList<OSMNode> what = waysIterator.next();
           if (lastId == what.getFirst().getId()) {
             // end of partial ring matches to start of current line
             what.removeFirst();
             current.addAll(what);
-            ways.remove(i);
+            waysIterator.remove();
             joinable = true;
             break;
           } else if (firstId == what.getLast().getId()) {
             // start of partial ring matches end of current line
             what.removeLast();
             current.addAll(0, what);
-            ways.remove(i);
+            waysIterator.remove();
             joinable = true;
             break;
           } else if (lastId == what.getLast().getId()) {
             // end of partial ring matches end of current line
             what.removeLast();
             current.addAll(Lists.reverse(what));
-            ways.remove(i);
+            waysIterator.remove();
             joinable = true;
             break;
           } else if (firstId == what.getFirst().getId()) {
             // start of partial ring matches start of current line
             what.removeFirst();
             current.addAll(0, Lists.reverse(what));
-            ways.remove(i);
+            waysIterator.remove();
             joinable = true;
             break;
           }


### PR DESCRIPTION
This improves performance significantly for multipolygons which have a very large number of outer member ways. Some of them (e.g. `relation/6677259`) have > 10k members, which causes slow processing in the `buildRings` (formerly `join`) helper function.

In one test (with the particularly heavy example from above), this reduces the geometry building from 6 minutes down to 0.5 seconds for one particularly members heavy multipolygon.

# Checklist
- [ ] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [ ] I have commented my code
- [ ] I have written javadoc (required for public methods)
- [ ] I have added sufficient unit tests
- [ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary
