### PR TITLE
Remove java 8 properties from first-steps example

### DIFF
--- a/documentation/first-steps/OSHDBApiTutorial.java
+++ b/documentation/first-steps/OSHDBApiTutorial.java
@@ -1,3 +1,5 @@
+package org.example.oshdb.api.tutorial;
+
 import java.util.SortedMap;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBDatabase;
 import org.heigit.bigspatialdata.oshdb.api.db.OSHDBH2;

--- a/documentation/first-steps/README.md
+++ b/documentation/first-steps/README.md
@@ -29,7 +29,7 @@ If you already have an existing Java maven project, the OSHDB-API can be added t
 </dependency>
 ```
 
-Note that the OSHDB requires Java 8, so it could sometimes be necessary to specify this additional restriction in the `pom.xml` as well. Take a look at this [example `pom.xml`](./example-pom.xml) file that shows how all these settings should be put together.
+Note that the OSHDB requires Java 11, so it could sometimes be necessary to specify this additional restriction in the `pom.xml` as well. Take a look at this [example `pom.xml`](./example-pom.xml) file that shows how all these settings should be put together.
 
 If you're starting a new OSHDB project from scratch, it's typically a good idea to create a new maven project using the "create new project" wizard of your IDE of choice. After that you can use the steps described above to add OSHDB as a dependency to the new project.
 

--- a/documentation/first-steps/example-pom.xml
+++ b/documentation/first-steps/example-pom.xml
@@ -1,9 +1,9 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.heigit.ohsome.oshdb-api-tutorial</groupId>
+  <groupId>org.example.oshdb-api-tutorial</groupId>
   <artifactId>oshdb-first-steps</artifactId>
   <version>0.0.1-SNAPSHOT</version>
- 
+
   <dependencies>
     <dependency>
       <groupId>org.heigit.bigspatialdata</groupId>

--- a/documentation/first-steps/example-pom.xml
+++ b/documentation/first-steps/example-pom.xml
@@ -13,7 +13,7 @@
   </dependencies>
 
   <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
   </properties>
 </project>


### PR DESCRIPTION
# Changes proposed in this pull request:
## Type of change
- [x] documentation update

## Description
- no requirements on specific java version in first-steps anymore
- add `package` statement with example path


## Corresponding issue
None

## New or changed dependencies:
- no java8 dependency in first-steps example


# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)<br>→ Not necessary
