### PR TITLE
remove java 8 references from documentation

### DIFF
--- a/documentation/manual/api.md
+++ b/documentation/manual/api.md
@@ -1,7 +1,7 @@
 OSHDB Application Programming Interface
 =======================================
 
-The OSHDB API provides a library that can be used to write custom analysis queries of OSM history data. It is based on the [MapReduce](https://en.wikipedia.org/wiki/MapReduce) programming model, which is also offered by the [Stream](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html) class introduced in Java 8.
+The OSHDB API provides a library that can be used to write custom analysis queries of OSM history data. It is based on the [MapReduce](https://en.wikipedia.org/wiki/MapReduce) programming model, which is also offered by the [Stream](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html) class in Java 11.
 
 The [first steps tutorial](../first-steps) explains the main components of the OSHDB API and how they can be used to perform a simple analysis query. On the following sub-pages, the different parts of the API are described in more detail.
 

--- a/documentation/manual/installation.md
+++ b/documentation/manual/installation.md
@@ -3,9 +3,7 @@ Installation
 
 ## Configuring Java Version
 
-Compiling software that includes the OSHDB currently requires Java 8
-(i.e., version 1.8) or newer. Because maven projects use Java 1.5 by default, it is necessary to either configure your IDE accordingly or add the following
-compiler version to the properties section of your pom.xml file:
+Compiling software that includes the OSHDB currently requires Java 11 (i.e., version 11) or newer. Because maven projects use Java 1.5 by default, it is necessary to either configure your IDE accordingly or add the following compiler version to the properties section of your pom.xml file:
 
 ```
 <properties>

--- a/documentation/manual/map-reduce.md
+++ b/documentation/manual/map-reduce.md
@@ -31,7 +31,7 @@ The [`reduce`](https://docs.ohsome.org/java/oshdb/0.5.10/aggregated/org/heigit/b
 
 Every OSHDB query must have exactly one terminal reduce operation (or use the `stream` method explained [below](#stream)).
 
-> Remark: If you are already familiar with [Hadoop](https://en.wikipedia.org/wiki/Apache_Hadoop), note that for defining a reduce operation we use the terminology of the [Java stream API](https://docs.oracle.com/javase/8/docs/api/java/util/stream/package-summary.html) which is slightly different from the terminology used in Hadoop. In particular, the Java stream API and Hadoop use the same term 'combiner' for different things.
+> Remark: If you are already familiar with [Hadoop](https://en.wikipedia.org/wiki/Apache_Hadoop), note that for defining a reduce operation we use the terminology of the [Java stream API](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/package-summary.html) which is slightly different from the terminology used in Hadoop. In particular, the Java stream API and Hadoop use the same term 'combiner' for different things.
 
 specialized reducers
 --------------------

--- a/documentation/manual/views.md
+++ b/documentation/manual/views.md
@@ -22,7 +22,7 @@ MapReducer<OSMEntitySnapshot> snapshotsMapReducer = OSMEntitySnapshotView.on(osh
 MapReducer<OSMContribution> contributionsMapReducer = OSMContributionView.on(oshdb);
 ```
 
-A MapReducer is conceptually very similar to a [Stream](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html) object in Java 8: It stores all the information about what kind of filters, transformation functions and aggregation methods should be applied to the data and is executed exactly once by calling a terminal operation, such as the reduce method, or one of the supplied specialized reducers (e.g., `count`, `sum`, etc.). The chapter “[Map and Reduce](map-reduce.md)” of this manual describes the ideas of the `MapReducer` object in more detail.
+A MapReducer is conceptually very similar to a [Stream](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html) object in Java 11: It stores all the information about what kind of filters, transformation functions and aggregation methods should be applied to the data and is executed exactly once by calling a terminal operation, such as the reduce method, or one of the supplied specialized reducers (e.g., `count`, `sum`, etc.). The chapter “[Map and Reduce](map-reduce.md)” of this manual describes the ideas of the `MapReducer` object in more detail.
 
 ### Snapshot View
 

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapAggregator.java
@@ -867,8 +867,8 @@ public class MapAggregator<U extends Comparable<U> & Serializable, X> implements
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's <a
-   * href="https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-">reduce(identity,accumulator,combiner)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(U,java.util.function.BiFunction,java.util.function.BinaryOperator)">reduce(identity,accumulator,combiner)</a>
    * interface.
    * </p>
    *
@@ -951,8 +951,8 @@ public class MapAggregator<U extends Comparable<U> & Serializable, X> implements
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's <a
-   * href="https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-">reduce(identity,accumulator,combiner)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(U,java.util.function.BiFunction,java.util.function.BinaryOperator)">reduce(identity,accumulator,combiner)</a>
    * interface.
    * </p>
    *

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducer.java
@@ -1010,8 +1010,8 @@ public abstract class MapReducer<X> implements
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's <a href=
-   * "https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-">reduce(identity,accumulator,combiner)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(U,java.util.function.BiFunction,java.util.function.BinaryOperator)">reduce(identity,accumulator,combiner)</a>
    * interface.
    * </p>
    *
@@ -1159,8 +1159,8 @@ public abstract class MapReducer<X> implements
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's <a href=
-   * "https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-T-java.util.function.BinaryOperator-">reduce(identity,accumulator)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(T,java.util.function.BinaryOperator)">reduce(identity,accumulator)</a>
    * interface.
    * </p>
    *
@@ -1657,8 +1657,8 @@ public abstract class MapReducer<X> implements
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's <a href=
-   * "https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-">reduce(identity,accumulator,combiner)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(U,java.util.function.BiFunction,java.util.function.BinaryOperator)">reduce(identity,accumulator,combiner)</a>
    * interface.
    * </p>
    *
@@ -1711,8 +1711,8 @@ public abstract class MapReducer<X> implements
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's <a href=
-   * "https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-">reduce(identity,accumulator,combiner)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(U,java.util.function.BiFunction,java.util.function.BinaryOperator)">reduce(identity,accumulator,combiner)</a>
    * interface.
    * </p>
    *
@@ -1757,8 +1757,8 @@ public abstract class MapReducer<X> implements
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's <a href=
-   * "https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-">reduce(identity,accumulator,combiner)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(U,java.util.function.BiFunction,java.util.function.BinaryOperator)">reduce(identity,accumulator,combiner)</a>
    * interface.
    * </p>
    *
@@ -1811,8 +1811,8 @@ public abstract class MapReducer<X> implements
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's <a href=
-   * "https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-">reduce(identity,accumulator,combiner)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(U,java.util.function.BiFunction,java.util.function.BinaryOperator)">reduce(identity,accumulator,combiner)</a>
    * interface.
    * </p>
    *

--- a/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerAggregations.java
+++ b/oshdb-api/src/main/java/org/heigit/bigspatialdata/oshdb/api/mapreducer/MapReducerAggregations.java
@@ -38,8 +38,8 @@ interface MapReducerAggregations<X> {
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's
-   * <a href="https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-U-java.util.function.BiFunction-java.util.function.BinaryOperator-">reduce(identity,accumulator,combiner)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(U,java.util.function.BiFunction,java.util.function.BinaryOperator)">reduce(identity,accumulator,combiner)</a>
    * interface.
    * </p>
    *
@@ -85,8 +85,8 @@ interface MapReducerAggregations<X> {
    * </ul>
    *
    * <p>
-   * Functionally, this interface is similar to Java8 Stream's
-   * <a href="https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#reduce-T-java.util.function.BinaryOperator-">reduce(identity,accumulator)</a>
+   * Functionally, this interface is similar to Java11 Stream's
+   * <a href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/stream/Stream.html#reduce(T,java.util.function.BinaryOperator)">reduce(identity,accumulator)</a>
    * interface.
    * </p>
    *


### PR DESCRIPTION
# Changes proposed in this pull request:
## Type of change
- [x] documentation update

## Description
- replaced all java 8 references with java 11

## Corresponding issue
None

## New or changed dependencies:
- none

# Checklist
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
