### PR TITLE
simplify included maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,13 +77,13 @@
       <!--This will resolve artefacts of Osgeo, Boundless and potentially others through our own reopository (https://www.jfrog.com/confluence/display/RTF/Maven+Repository#MavenRepository-ResolvingArtifactsthroughArtifactory).-->
       <id>HeiGIT main</id>
       <name>Central Repository for OSHDB dependency related artefacts</name>
-      <url>http://repo.heigit.org/artifactory/main</url>
+      <url>https://repo.heigit.org/artifactory/main</url>
     </repository>
 
     <repository>
       <id>HeiGIT snapshots</id>
       <name>Heigit/GIScience maven repository (snapshots)</name>
-      <url>http://repo.heigit.org/artifactory/libs-snapshot-local</url>
+      <url>https://repo.heigit.org/artifactory/libs-snapshot-local</url>
       <snapshots />
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -74,17 +74,10 @@
 
   <repositories>
     <repository>
-      <!--This will resolve artefacts of Osgeo, Boundless and potentially others through our own reopository (https://www.jfrog.com/confluence/display/RTF/Maven+Repository#MavenRepository-ResolvingArtifactsthroughArtifactory).-->
+      <!--This will resolve artefacts of Osgeo, Boundless and potentially others through our own repository (https://www.jfrog.com/confluence/display/RTF/Maven+Repository#MavenRepository-ResolvingArtifactsthroughArtifactory).-->
       <id>HeiGIT main</id>
       <name>Central Repository for OSHDB dependency related artefacts</name>
       <url>https://repo.heigit.org/artifactory/main</url>
-    </repository>
-
-    <repository>
-      <id>HeiGIT snapshots</id>
-      <name>Heigit/GIScience maven repository (snapshots)</name>
-      <url>https://repo.heigit.org/artifactory/libs-snapshot-local</url>
-      <snapshots />
     </repository>
   </repositories>
 


### PR DESCRIPTION
* use https to get artifacts from repo.heigit.org
* drops superfluous "snapshots-only" version of repo.heigit.org -> not used (?) and snapshots would also be offered from _main_.