### PR TITLE
maxzoom is 14 not 15

### DIFF
--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDB.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDB.java
@@ -2,7 +2,7 @@ package org.heigit.ohsome.oshdb;
 
 public abstract class OSHDB {
 
-  public static final int MAXZOOM = 15;
+  public static final int MAXZOOM = 14;
 
   // osm only stores 7 decimals for each coordinate
   public static final long GEOM_PRECISION_TO_LONG = 10000000L;


### PR DESCRIPTION
# Changes proposed in this pull request:
hard coded maxzoom is actual 14 not 15
## Type of change
change hard coded maxzoom from 15 to 14

## Description
currently the OSHDB.MAXZOOM is used by 
- MapReducer.getCellIdRanges

In the current and the last past, datasets the maxzoom was/is actually 14 and so this function does more work then actually needed.
