### PR TITLE
fix crash when relation references redacted way

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 ### bugfixes
 
 * fix a crash caused when _oshdb-filters_ are used in `groupByEntity` queries. #321
+* fix a crash when relations reference redacted ways. #325
 
 ### upgrading from 0.6.0
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osh/OSHEntities.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osh/OSHEntities.java
@@ -455,6 +455,11 @@ public abstract class OSHEntities {
 
     for (Entry<OSHEntity, LinkedList<OSHDBTimestamp>> childEntityT : childEntityTs.entrySet()) {
       Iterator<OSHDBTimestamp> modTs = getModificationTimestamps(childEntityT.getKey()).iterator();
+      if (!modTs.hasNext()) {
+        // skip if the member has no "visible" version (for example because of data redactions)
+        // see https://github.com/GIScience/oshdb/issues/325
+        continue;
+      }
       LinkedList<OSHDBTimestamp> validMemberTs = childEntityT.getValue();
       OSHDBTimestamp current = modTs.next();
       outerTLoop: while (!validMemberTs.isEmpty()) {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
@@ -258,4 +258,34 @@ public class OSHRelationTest {
     assertEquals(expResult, result);
   }
 
+  @Test
+  public void testIssue325() throws IOException {
+    OSHNode hnode1 = OSHNodeImpl.build(new ArrayList<>(List.of(
+        new OSMNode(123L, 2, new OSHDBTimestamp(2L), 2L, 0, new int[]{}, 0, 0),
+        new OSMNode(123L, 1, new OSHDBTimestamp(1L), 1L, 0, new int[]{}, 0, 0))));
+    OSHNode hnode2 = OSHNodeImpl.build(new ArrayList<>(List.of(
+        new OSMNode(124L, 2, new OSHDBTimestamp(2L), 2L, 0, new int[]{}, 0, 0),
+        new OSMNode(124L, 1, new OSHDBTimestamp(1L), 1L, 0, new int[]{}, 0, 0))));
+
+    OSHWay hway1 = OSHWayImpl.build(new ArrayList<>(List.of(
+        new OSMWay(1, 1, new OSHDBTimestamp(1L), 1L, 0, new int[]{}, new OSMMember[]{
+            new OSMMember(123, OSMType.NODE, 0),
+            new OSMMember(124, OSMType.NODE, 0)})
+    )), List.of(hnode1, hnode2));
+
+    OSHWay hway2 = OSHWayImpl.build(new ArrayList<>(List.of(
+        new OSMWay(2, -4, new OSHDBTimestamp(9L), 9L, 9, new int[]{}, new OSMMember[]{})
+    )), Collections.emptyList());
+
+    OSHRelation hrelation = OSHRelationImpl.build(new ArrayList<>(List.of(
+        new OSMRelation(1, 2, new OSHDBTimestamp(8L), 8L, 8, new int[]{1, 1, 2, 2}, new OSMMember[]{
+            new OSMMember(1, OSMType.WAY, 0),
+            new OSMMember(2, OSMType.WAY, 0)}),
+        new OSMRelation(1, 1, new OSHDBTimestamp(1L), 1L, 0, new int[]{1, 1, 2, 2}, new OSMMember[]{
+            new OSMMember(1, OSMType.WAY, 0)})
+    )), List.of(hnode1, hnode2), List.of(hway1, hway2));
+
+    List<OSHDBTimestamp> tss = OSHEntities.getModificationTimestamps(hrelation, true);
+    assertNotNull(tss);
+  }
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
@@ -260,6 +260,9 @@ public class OSHRelationTest {
 
   @Test
   public void testIssue325() throws IOException {
+    // tests that the bug reported in https://github.com/GIScience/oshdb/issues/325 is fixed:
+    // relations referencing redacted ways caused a crash in the OSHEntities utility class
+    // when calculating the relation's modification timestamps
     OSHNode hnode1 = OSHNodeImpl.build(new ArrayList<>(List.of(
         new OSMNode(123L, 2, new OSHDBTimestamp(2L), 2L, 0, new int[]{}, 0, 0),
         new OSMNode(123L, 1, new OSHDBTimestamp(1L), 1L, 0, new int[]{}, 0, 0))));
@@ -269,20 +272,20 @@ public class OSHRelationTest {
 
     OSHWay hway1 = OSHWayImpl.build(new ArrayList<>(List.of(
         new OSMWay(1, 1, new OSHDBTimestamp(1L), 1L, 0, new int[]{}, new OSMMember[]{
-            new OSMMember(123, OSMType.NODE, 0),
-            new OSMMember(124, OSMType.NODE, 0)})
+            new OSMMember(123L, OSMType.NODE, 0),
+            new OSMMember(124L, OSMType.NODE, 0)})
     )), List.of(hnode1, hnode2));
 
     OSHWay hway2 = OSHWayImpl.build(new ArrayList<>(List.of(
-        new OSMWay(2, -4, new OSHDBTimestamp(9L), 9L, 9, new int[]{}, new OSMMember[]{})
+        new OSMWay(2L, -4, new OSHDBTimestamp(9L), 9L, 9, new int[]{}, new OSMMember[]{})
     )), Collections.emptyList());
 
     OSHRelation hrelation = OSHRelationImpl.build(new ArrayList<>(List.of(
-        new OSMRelation(1, 2, new OSHDBTimestamp(8L), 8L, 8, new int[]{1, 1, 2, 2}, new OSMMember[]{
-            new OSMMember(1, OSMType.WAY, 0),
-            new OSMMember(2, OSMType.WAY, 0)}),
-        new OSMRelation(1, 1, new OSHDBTimestamp(1L), 1L, 0, new int[]{1, 1, 2, 2}, new OSMMember[]{
-            new OSMMember(1, OSMType.WAY, 0)})
+        new OSMRelation(1L, 2, new OSHDBTimestamp(8L), 8L, 8, new int[]{1, 1, 2, 2}, new OSMMember[]{
+            new OSMMember(1L, OSMType.WAY, 0),
+            new OSMMember(2L, OSMType.WAY, 0)}),
+        new OSMRelation(1L, 1, new OSHDBTimestamp(1L), 1L, 0, new int[]{1, 1, 2, 2}, new OSMMember[]{
+            new OSMMember(1L, OSMType.WAY, 0)})
     )), List.of(hnode1, hnode2), List.of(hway1, hway2));
 
     List<OSHDBTimestamp> tss = OSHEntities.getModificationTimestamps(hrelation, true);


### PR DESCRIPTION
fixes #325

# Changes proposed in this pull request:
## Type of change
Please delete if not relevant:
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- I have written javadoc (required for public methods) :arrow_right:  #327
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) if necessary~~
