### PR TITLE
don't manipulate cluster state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,12 +19,14 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 
 ### bugfixes
 
+* don't change cluster state when executing queries on an Ignite cluster. ([#335]) 
 
 ### upgrading from 0.6.0
 
 * If you already used the “ohsome filter” functionality from OSHDB version 0.6 and imported one or more classes from the ohsome filter module, you would need to adjust the package names from `org.heigit.ohsome.filter` to `org.heigit.ohsome.oshdb.filter`.
 
 [#306]: https://github.com/GIScience/oshdb/pull/306
+[#335]: https://github.com/GIScience/oshdb/pull/335
 
 
 ## 0.6.1

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBIgnite.java
@@ -8,7 +8,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.Ignition;
-import org.apache.ignite.cluster.ClusterState;
 import org.apache.ignite.lang.IgniteRunnable;
 import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer;
 import org.heigit.ohsome.oshdb.api.mapreducer.backend.MapReducerIgniteAffinityCall;
@@ -40,7 +39,6 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
 
   public OSHDBIgnite(Ignite ignite) {
     this.ignite = ignite;
-    this.ignite.cluster().state(ClusterState.ACTIVE_READ_ONLY);
   }
 
   public OSHDBIgnite(String igniteConfigFilePath) {
@@ -55,7 +53,6 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
   public OSHDBIgnite(File igniteConfig) {
     Ignition.setClientMode(true);
     this.ignite = Ignition.start(igniteConfig.toString());
-    this.ignite.cluster().state(ClusterState.ACTIVE_READ_ONLY);
   }
 
   @Override

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgnite.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgnite.java
@@ -94,5 +94,7 @@ abstract class TestMapReduceOSHDBIgnite extends TestMapReduce {
       e.printStackTrace();
       fail(e.toString());
     }
+
+    ignite.cluster().state(ClusterState.ACTIVE_READ_ONLY);
   }
 }


### PR DESCRIPTION
The OSHDB-API should not change the state of an already running ignite cluster. If it is inactive, it might be for a reason, if it is in read-write mode, it might also be in that state for a reason, etc.

This is a regression in OSHDB version 0.6.0 introduced with #263.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- ~~I have commented my code~~
- ~~I have written javadoc (required for public methods)~~
- ~~I have added sufficient unit tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
