### PR TITLE
fix building of multipolygon geometries with degenerate inner rings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,12 +20,14 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 ### bugfixes
 
 * don't change cluster state when executing queries on an Ignite cluster. ([#335]) 
+* fix bug when building multipolygon geometries with certain invalid inner ring configurations (e.g. duplicate inner rings). ([#334])
 
 ### upgrading from 0.6.0
 
 * If you already used the “ohsome filter” functionality from OSHDB version 0.6 and imported one or more classes from the ohsome filter module, you would need to adjust the package names from `org.heigit.ohsome.filter` to `org.heigit.ohsome.oshdb.filter`.
 
 [#306]: https://github.com/GIScience/oshdb/pull/306
+[#334]: https://github.com/GIScience/oshdb/issues/334
 [#335]: https://github.com/GIScience/oshdb/pull/335
 
 

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -242,7 +242,9 @@ public class OSHDBGeometryBuilder {
     List<LinkedList<OSMNode>> innerRingsNodes = OSHDBGeometryBuilder.buildRings(innerLines);
     // check if there are any touching inner/outer rings, merge any
     mergeTouchingRings(innerRingsNodes);
+    // create JTS rings for non-degenerate rings only
     List<LinearRing> innerRings = innerRingsNodes.stream()
+        .filter(ring -> ring.size() >= LinearRing.MINIMUM_VALID_SIZE)
         .map(ring -> geometryFactory.createLinearRing(
             ring.stream().map(node -> new Coordinate(node.getLongitude(), node.getLatitude()))
                 .toArray(Coordinate[]::new)))
@@ -349,7 +351,7 @@ public class OSHDBGeometryBuilder {
           // merge this ring (ringNodes) into the previously encountered one (targetNodes)
           LinkedList<OSMNode> targetNodes = ringSegments.get(segment);
           // remove all segments pointing to the target ring, as we will rebuild it from scratch
-          ringSegments.values().remove(targetNodes);
+          ringSegments.values().removeAll(Collections.singleton(targetNodes));
           // cut and rewind target and current rings to the matching segment we found
           cutAtSegment(targetNodes, segment);
           cutAtSegment(ringNodes, segment);

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
@@ -1,0 +1,34 @@
+package org.heigit.ohsome.oshdb.util.geometry.relations;
+
+import static org.junit.Assert.assertTrue;
+
+import org.heigit.ohsome.oshdb.osm.OSMEntity;
+import org.heigit.ohsome.oshdb.util.OSHDBTimestamp;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
+import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
+import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
+import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
+import org.junit.Test;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.Polygon;
+
+public class OSHDBGeometryBuilderMultipolygonInvalidInnersTest {
+  private final OSMXmlReader testData = new OSMXmlReader();
+  private final TagInterpreter tagInterpreter;
+  private final OSHDBTimestamp timestamp =
+      TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
+
+  public OSHDBGeometryBuilderMultipolygonInvalidInnersTest() {
+    testData.add("./src/test/resources/relations/invalid-inner-rings.osm");
+    tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
+  }
+
+  @Test
+  public void test() {
+    // data has invalid (duplicate) inner rings
+    OSMEntity entity = testData.relations().get(1L).get(0);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    assertTrue(result instanceof Polygon);
+  }
+}

--- a/oshdb-util/src/test/resources/relations/invalid-inner-rings.osm
+++ b/oshdb-util/src/test/resources/relations/invalid-inner-rings.osm
@@ -1,0 +1,32 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<osm version="0.6">
+
+  <relation id="1" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+    <member type="way" ref="1" role="outer"/>
+    <member type="way" ref="2" role="inner"/>
+    <member type="way" ref="2" role="inner"/>
+    <member type="way" ref="2" role="inner"/>
+    <tag k="type" v="multipolygon"/>
+  </relation>
+  <way id="1" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="11"/>
+    <nd ref="12"/>
+    <nd ref="13"/>
+    <nd ref="14"/>
+    <nd ref="11"/>
+  </way>
+  <way id="2" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+    <nd ref="21"/>
+    <nd ref="22"/>
+    <nd ref="23"/>
+    <nd ref="21"/>
+  </way>
+  <node id="11" lat="-10" lon="-10" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="12" lat="10" lon="-10" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="13" lat="10" lon="10" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="14" lat="-10" lon="10" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="21" lat="0" lon="0" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="22" lat="0" lon="1" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+  <node id="23" lat="1" lon="1" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1"/>
+
+</osm>


### PR DESCRIPTION
Fixes crashes when a multipolygon has specific invalid configurations, like two or more identical inner rings or rings with too few coordinates.

### Corresponding issue
Closes #334 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
