### PR TITLE
[oshdb-filter] also non-relations should match geometry:other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,11 +19,14 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 
 ### bugfixes
 
+* when filtering for `geometry:other`: also consider GeometryCollections occuring as a side effect of clipping ([#338])
+
 ### upgrading from 0.6
 
 * If you already used the “ohsome filter” functionality from OSHDB version 0.6 and imported one or more classes from the ohsome filter module, you would need to adjust the package names from `org.heigit.ohsome.filter` to `org.heigit.ohsome.oshdb.filter`.
 
 [#306]: https://github.com/GIScience/oshdb/pull/306
+[#338]: https://github.com/GIScience/oshdb/issues/338
 
 
 ## 0.6.3

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryTypeFilter.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryTypeFilter.java
@@ -87,10 +87,9 @@ public class GeometryTypeFilter implements Filter {
       case LINE:
         return EnumSet.of(OSMType.WAY);
       case POLYGON:
-        return POLYGON_TYPES;
       case OTHER:
       default:
-        return EnumSet.of(OSMType.RELATION);
+        return POLYGON_TYPES;
     }
   }
 
@@ -102,10 +101,9 @@ public class GeometryTypeFilter implements Filter {
       case LINE:
         return osmType == OSMType.WAY;
       case POLYGON:
-        return POLYGON_TYPES.contains(osmType);
       case OTHER:
       default:
-        return osmType == OSMType.RELATION;
+        return POLYGON_TYPES.contains(osmType);
     }
   }
 

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSHTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSHTest.java
@@ -301,11 +301,11 @@ public class ApplyOSHTest extends FilterTest {
   @Test
   public void testGeometryTypeFilterOther() throws IOException {
     FilterExpression expression = parser.parse("geometry:other");
-    assertFalse(expression.applyOSH(createTestOSHEntityWay(
-        createTestOSMEntityWay(new long[] {})
-    )));
     assertFalse(expression.applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode()
+    )));
+    assertTrue(expression.applyOSH(createTestOSHEntityWay(
+        createTestOSMEntityWay(new long[] {})
     )));
     assertTrue(expression.applyOSH(createTestOSHEntityRelation(
         createTestOSMEntityRelation()

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
@@ -53,6 +53,14 @@ public class ApplyOSMGeometryTest extends FilterTest {
     assertFalse(expression.applyOSMGeometry(validRelation, gf.createMultiPoint()));
     assertFalse(expression.applyOSMGeometry(validRelation, gf.createMultiLineString()));
     assertFalse(expression.applyOSMGeometry(validRelation, gf.createMultiPolygon()));
+
+    // also ways can result in GeometryCollections after a clipping operation!
+    OSMEntity validWay = createTestOSMEntityWay(new long[]{1, 2, 3, 4, 1});
+    assertTrue(expression.applyOSMGeometry(validWay, gf.createGeometryCollection()));
+    assertFalse(expression.applyOSMGeometry(validWay, gf.createPolygon()));
+    assertFalse(expression.applyOSMGeometry(validWay, gf.createMultiPoint()));
+    assertFalse(expression.applyOSMGeometry(validWay, gf.createMultiLineString()));
+    assertFalse(expression.applyOSMGeometry(validWay, gf.createMultiPolygon()));
   }
 
   @Test

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMTest.java
@@ -178,8 +178,8 @@ public class ApplyOSMTest extends FilterTest {
   @Test
   public void testGeometryTypeFilterOther() {
     FilterExpression expression = parser.parse("geometry:other");
-    assertFalse(expression.applyOSM(createTestOSMEntityWay(new long[] {})));
     assertFalse(expression.applyOSM(createTestOSMEntityNode()));
+    assertTrue(expression.applyOSM(createTestOSMEntityWay(new long[] {})));
     assertTrue(expression.applyOSM(createTestOSMEntityRelation()));
   }
 

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ParseTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ParseTest.java
@@ -252,7 +252,7 @@ public class ParseTest extends FilterTest {
     assertTrue(expression instanceof GeometryTypeFilter);
     assertEquals(GeometryType.OTHER, ((GeometryTypeFilter) expression).getGeometryType());
     assertEquals(
-        Collections.singleton(OSMType.RELATION),
+        EnumSet.of(OSMType.WAY, OSMType.RELATION),
         ((GeometryTypeFilter) expression).getOSMTypes()
     );
     assertEquals("geometry:other", expression.toString());


### PR DESCRIPTION
### Description

When done, this will make sure that filtering for `(geometry:point or geometry:line or geometry:polygon or geometry:other)` will actually select _all_ features.

### Corresponding issue
Fixes #338


### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public methods)
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

<!--Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.-->
