### PR TITLE
make sure Filter predicates are always serializable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 ### other changes
 
 * integrate [ohsome-filter](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/libs/ohsome-filter) module fully into this repository, renaming it to `oshdb-filter`. ([#306])
+* make sure predicate-filters are always serializable. ([#353])
 * improve maintainability of parts of important central processing algorithms for determining entity modification history: refactoring improves code structure, adds inline documentation and enhances test coverage. ([#327])
 
 ### bugfixes
@@ -34,7 +35,7 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 [#327]: https://github.com/GIScience/oshdb/issues/327
 [#338]: https://github.com/GIScience/oshdb/issues/338
 [#352]: https://github.com/GIScience/oshdb/pull/352
-
+[#353]: https://github.com/GIScience/oshdb/pull/353
 
 ## 0.6.3
 

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapAggregator.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapAggregator.java
@@ -36,6 +36,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer.Grouping;
 import org.heigit.ohsome.oshdb.api.object.OSHDBMapReducible;
 import org.heigit.ohsome.oshdb.api.object.OSMContribution;
 import org.heigit.ohsome.oshdb.api.object.OSMEntitySnapshot;
+import org.heigit.ohsome.oshdb.filter.Filter;
 import org.heigit.ohsome.oshdb.filter.FilterExpression;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.osm.OSMType;
@@ -290,8 +291,9 @@ public class MapAggregator<U extends Comparable<U> & Serializable, X> implements
    *
    * @param f the filter function to call for each osm entity
    * @return a modified copy of this object (can be used to chain multiple commands together)
-   * @deprecated use oshdb-filter {@link #filter(FilterExpression)} with
-   *             {@link org.heigit.ohsome.oshdb.filter.Filter#byOSMEntity(Predicate)} instead
+   * @deprecated use oshdb-filter {@link #filter(FilterExpression)} with {@link
+   *             org.heigit.ohsome.oshdb.filter.Filter#byOSMEntity(Filter.SerializablePredicate)}
+   *             instead
    */
   @Deprecated
   @Contract(pure = true)

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
@@ -431,8 +431,9 @@ public abstract class MapReducer<X> implements
    *
    * @param f the filter function to call for each osm entity
    * @return a modified copy of this mapReducer (can be used to chain multiple commands together)
-   * @deprecated use oshdb-filter {@link #filter(FilterExpression)} with
-   *             {@link org.heigit.ohsome.oshdb.filter.Filter#byOSMEntity(Predicate)} instead
+   * @deprecated use oshdb-filter {@link #filter(FilterExpression)} with {@link
+   *             org.heigit.ohsome.oshdb.filter.Filter#byOSMEntity(Filter.SerializablePredicate)}
+   *             instead
    */
   @Deprecated
   @Contract(pure = true)

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/Filter.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/Filter.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.filter;
 
+import java.io.Serializable;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
@@ -12,6 +13,12 @@ import org.locationtech.jts.geom.Geometry;
  * A filter condition which can be applied to an OSM entity.
  */
 public interface Filter extends FilterExpression {
+  /** A predicate which is also serializable. */
+  public interface SerializablePredicate<T> extends Predicate<T>, Serializable {}
+
+  /** A bi-predicate which is also serializable. */
+  interface SerializableBiPredicate<T, U> extends BiPredicate<T, U>, Serializable {}
+
   /**
    * Constructs a simple filter based on a predicate on OSH entities.
    *
@@ -23,7 +30,7 @@ public interface Filter extends FilterExpression {
    * @param oshCallback predicate which tests osh entities
    * @return a filter object which filters using the given predicate
    */
-  static Filter byOSHEntity(Predicate<OSHEntity> oshCallback) {
+  static Filter byOSHEntity(SerializablePredicate<OSHEntity> oshCallback) {
     return by(oshCallback, ignored -> true);
   }
 
@@ -38,7 +45,7 @@ public interface Filter extends FilterExpression {
    * @param osmCallback predicate which tests osm entities
    * @return a filter object which filters using the given predicate
    */
-  static Filter byOSMEntity(Predicate<OSMEntity> osmCallback) {
+  static Filter byOSMEntity(SerializablePredicate<OSMEntity> osmCallback) {
     return new NegatableFilter(osmCallback::test);
   }
 
@@ -54,7 +61,9 @@ public interface Filter extends FilterExpression {
    * @param osmCallback predicate which tests osm entities
    * @return a filter object which filters using the given predicates
    */
-  static Filter by(Predicate<OSHEntity> oshCallback, Predicate<OSMEntity> osmCallback) {
+  static Filter by(
+      SerializablePredicate<OSHEntity> oshCallback,
+      SerializablePredicate<OSMEntity> osmCallback) {
     return by(oshCallback, osmCallback, (ignored, ignored2) -> true);
   }
 
@@ -75,9 +84,9 @@ public interface Filter extends FilterExpression {
    * @return a filter object which filters using the given predicates
    */
   static Filter by(
-      Predicate<OSHEntity> oshCallback,
-      Predicate<OSMEntity> osmCallback,
-      BiPredicate<OSMEntity, Supplier<Geometry>> geomCallback
+      SerializablePredicate<OSHEntity> oshCallback,
+      SerializablePredicate<OSMEntity> osmCallback,
+      SerializableBiPredicate<OSMEntity, Supplier<Geometry>> geomCallback
   ) {
     return new NegatableFilter(new FilterInternal() {
       @Override


### PR DESCRIPTION
### Description

Makes sure users don't have to manually make supplied lambdas serializable when using `Filter.by*`.

Currently (0.6.*) users need to do this workaround when executing a query with a filter on ignite:

```java
….filter(Filter.byOSMEntity((SerializablePredicate<OSMEntity>) e -> e.getVersion() == 42)
```

After this fix, this should be sufficient:

```java
….filter(Filter.byOSMEntity(e -> e.getVersion() == 42)
```

This PR creates a local copy of the existing `SerializablePredicate` class as a an inner interface of the `Filter` class in order to avoid a circular dependency between the `oshdb-filter` and `oshdb-api` modules.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- ~~I have commented my code~~
- [x] I have written javadoc (required for public methods)
- ~~I have added sufficient unit tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~