### PR TITLE
fix not-running oshdb(-core) tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -47,7 +47,10 @@ pipeline {
           rtMaven.deployer.deployArtifacts = false
 
           withCredentials([string(credentialsId: 'gpg-signing-key-passphrase', variable: 'PASSPHRASE')]) {
+            // START CUSTOM oshdb
+            // CUSTOM: added withDep profile
             buildInfo = rtMaven.run pom: 'pom.xml', goals: 'clean compile javadoc:jar source:jar install -P sign,git,withDep -Dmaven.repo.local=.m2 $MAVEN_TEST_OPTIONS -Dgpg.passphrase=$PASSPHRASE'
+            // END CUSTOM oshdb
           }
         }
       }

--- a/oshdb/pom.xml
+++ b/oshdb/pom.xml
@@ -57,9 +57,6 @@
   <profiles>
     <profile>
       <id>withDep</id>
-      <properties>
-        <skipTests>true</skipTests>
-      </properties>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
### Description
If the `withDep` profile is used, the tests for the [oshdb core module](oshdb/) are skipped, as defined [here](https://github.com/GIScience/oshdb/blob/b5ca49bacd0a14dbc0f359cacd566ab82cdb25ab/oshdb/pom.xml#L61) in conjunction with the usage of this profile in the Jenkins [testing stage](https://github.com/GIScience/oshdb/blob/b5ca49bacd0a14dbc0f359cacd566ab82cdb25ab/Jenkinsfile#L50).

### Corresponding issue
Introduced in #80 

### New or changed dependencies
None

### Checklist
- ~[ ] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results~
- ~[ ] I have commented my code~
- ~[ ] I have written javadoc (required for public methods)~
- ~[ ] I have added sufficient unit tests~
- ~[ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)~
- ~[ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~[ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~
