### PR TITLE
catch and handle topology exceptions when splitting geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 ### bugfixes
 
 * when filtering for `geometry:other`: also consider GeometryCollections occurring as a side effect of clipping ([#338])
+* make `aggregateByGeometry` robust against broken geometries causing topology exceptions (regression in version 0.6) ([#362])
 
 ### upgrading from 0.6
 
@@ -38,6 +39,7 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 [#352]: https://github.com/GIScience/oshdb/pull/352
 [#353]: https://github.com/GIScience/oshdb/pull/353
 [#360]: https://github.com/GIScience/oshdb/pull/360
+[#362]: https://github.com/GIScience/oshdb/pull/362
 
 ## 0.6.3
 

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/GeometrySplitter.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/GeometrySplitter.java
@@ -22,6 +22,7 @@ import org.heigit.ohsome.oshdb.util.geometry.fip.FastBboxInPolygon;
 import org.heigit.ohsome.oshdb.util.geometry.fip.FastBboxOutsidePolygon;
 import org.heigit.ohsome.oshdb.util.geometry.fip.FastPolygonOperations;
 import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygonal;
 import org.locationtech.jts.geom.TopologyException;
 import org.locationtech.jts.geom.prep.PreparedGeometry;
@@ -118,14 +119,17 @@ class GeometrySplitter<U extends Comparable<U>> implements Serializable {
           try {
             boolean intersects = pg.intersects(snapshotGeometry);
             if (!intersects) {
-              return Stream.empty(); // not actually intersecting -> skip
+              // not actually intersecting -> skip
+              return Stream.empty();
             } else {
               return Stream.of(new IndexData<>(index, new OSMEntitySnapshot(data,
-                  new LazyEvaluatedObject<>(() -> poop.intersection(snapshotGeometry))
+                  new LazyEvaluatedObject<>(() ->
+                      faultTolerantIntersection(snapshotGeometry, poop))
               )));
             }
           } catch (TopologyException ignored) {
-            return Stream.empty(); // JTS cannot handle broken osm geometry -> skip
+            // JTS cannot handle broken osm geometry -> skip
+            return Stream.empty();
           }
         }).collect(Collectors.toMap(IndexData::getIndex, IndexData::getData));
   }
@@ -180,12 +184,12 @@ class GeometrySplitter<U extends Comparable<U>> implements Serializable {
             ));
           }
 
-          // contribution fully outside -> skip
           if (bops.get(index).test(contributionGeometryBbox)) {
+            // contribution fully outside -> skip
             return Stream.empty();
           }
-          // contribution fully inside -> directly return
           if (bips.get(index).test(contributionGeometryBbox)) {
+            // contribution fully inside -> directly return
             return Stream.of(new IndexData<>(index, data));
           }
 
@@ -197,17 +201,30 @@ class GeometrySplitter<U extends Comparable<U>> implements Serializable {
             boolean intersectsAfter = contributionGeometryAfter != null
                 && pg.intersects(contributionGeometryAfter);
             if ((!intersectsBefore) && (!intersectsAfter)) {
-              return Stream.empty(); // not actually intersecting -> skip
+              // not actually intersecting -> skip
+              return Stream.empty();
             } else {
               return Stream.of(new IndexData<>(index, new OSMContribution(data,
-                  new LazyEvaluatedObject<>(() -> poop.intersection(contributionGeometryBefore)),
-                  new LazyEvaluatedObject<>(() -> poop.intersection(contributionGeometryAfter)))
+                  new LazyEvaluatedObject<>(() ->
+                      faultTolerantIntersection(contributionGeometryBefore, poop)),
+                  new LazyEvaluatedObject<>(() ->
+                      faultTolerantIntersection(contributionGeometryAfter, poop)))
               ));
             }
           } catch (TopologyException ignored) {
-            return Stream.empty(); // JTS cannot handle broken osm geometry -> skip
+            // JTS cannot handle broken osm geometry -> skip
+            return Stream.empty();
           }
         }).collect(Collectors.toMap(IndexData::getIndex, IndexData::getData));
+  }
+
+  private static Geometry faultTolerantIntersection(Geometry subject, FastPolygonOperations poop) {
+    try {
+      return poop.intersection(subject);
+    } catch (TopologyException ignored) {
+      // JTS cannot handle broken osm geometry -> return empty geometry
+      return (new GeometryFactory()).createGeometryCollection();
+    }
   }
 
   /**


### PR DESCRIPTION
### Description

After #272 (version `0.6.0`), topology exceptions thrown during the `intersection` calculations in the `GeometrySplitter` class are not (always) catched anymore. This solves the problem by adding an additional try-catch block and returning an empty geometry if a topology exception is occurring.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- ~~I have written javadoc (required for public methods)~~
- ~~I have added sufficient unit tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

<!--Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.-->
