### PR TITLE
avoid tag-translating in filter optimizer, fixes crash when filters contains a non-existent tag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 
 * when filtering for `geometry:other`: also consider GeometryCollections occurring as a side effect of clipping ([#338])
 * make `aggregateByGeometry` robust against broken geometries causing topology exceptions (regression in version 0.6) ([#362])
+* fix a crash caused by the use of non-existent tags in oshdb filters ([#363])
 
 ### upgrading from 0.6
 
@@ -40,6 +41,7 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 [#353]: https://github.com/GIScience/oshdb/pull/353
 [#360]: https://github.com/GIScience/oshdb/pull/360
 [#362]: https://github.com/GIScience/oshdb/pull/362
+[#363]: https://github.com/GIScience/oshdb/pull/363
 
 ## 0.6.3
 

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
@@ -414,6 +414,10 @@ public abstract class MapReducer<X> implements
   @Deprecated
   @Contract(pure = true)
   public MapReducer<X> osmType(Set<OSMType> typeFilter) {
+    return osmTypeInternal(typeFilter);
+  }
+
+  private MapReducer<X> osmTypeInternal(Set<OSMType> typeFilter) {
     MapReducer<X> ret = this.copy();
     typeFilter = Sets.intersection(ret.typeFilter, typeFilter);
     if (typeFilter.isEmpty()) {
@@ -2155,7 +2159,7 @@ public abstract class MapReducer<X> implements
       OSHDBTagKey key = ((TagFilterEqualsAny) filter).getTag();
       return mapRed.osmTag(key);
     } else if (filter instanceof TypeFilter) {
-      return mapRed.osmType(((TypeFilter) filter).getType());
+      return mapRed.osmTypeInternal(EnumSet.of(((TypeFilter) filter).getType()));
     } else if (filter instanceof AndOperator) {
       return optimizeFilters0(optimizeFilters0(mapRed,
           ((AndOperator) filter).getLeftOperand()),

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
@@ -22,7 +22,6 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.function.DoubleUnaryOperator;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -488,17 +487,12 @@ public abstract class MapReducer<X> implements
   @Deprecated
   @Contract(pure = true)
   private MapReducer<X> osmTag(OSMTagKey key) {
-    MapReducer<X> ret = this.copy();
     OSHDBTagKey keyId = this.getTagTranslator().getOSHDBTagKeyOf(key);
     if (!keyId.isPresentInKeytables()) {
       LOG.warn("Tag key {} not found. No data will match this filter.", key.toString());
-      ret.preFilters.add(ignored -> false);
-      ret.filters.add(ignored -> false);
-      return ret;
+      return osmTagEmptyResult();
     }
-    ret.preFilters.add(oshEntitiy -> oshEntitiy.hasTagKey(keyId));
-    ret.filters.add(osmEntity -> osmEntity.hasTagKey(keyId));
-    return ret;
+    return osmTag(keyId);
   }
 
   /**
@@ -527,19 +521,13 @@ public abstract class MapReducer<X> implements
   @Deprecated
   @Contract(pure = true)
   private MapReducer<X> osmTag(OSMTag tag) {
-    MapReducer<X> ret = this.copy();
     OSHDBTag keyValueId = this.getTagTranslator().getOSHDBTagOf(tag);
     if (!keyValueId.isPresentInKeytables()) {
       LOG.warn("Tag {}={} not found. No data will match this filter.",
           tag.getKey(), tag.getValue());
-      ret.preFilters.add(ignored -> false);
-      ret.filters.add(ignored -> false);
-      return ret;
+      return osmTagEmptyResult();
     }
-    OSHDBTagKey keyId = new OSHDBTagKey(keyValueId.getKey());
-    ret.preFilters.add(oshEntitiy -> oshEntitiy.hasTagKey(keyId));
-    ret.filters.add(osmEntity -> osmEntity.hasTagValue(keyValueId.getKey(), keyValueId.getValue()));
-    return ret;
+    return osmTag(keyValueId);
   }
 
   /**
@@ -554,15 +542,16 @@ public abstract class MapReducer<X> implements
   @Deprecated
   @Contract(pure = true)
   public MapReducer<X> osmTag(String key, Collection<String> values) {
-    MapReducer<X> ret = this.copy();
     OSHDBTagKey oshdbKey = this.getTagTranslator().getOSHDBTagKeyOf(key);
     int keyId = oshdbKey.toInt();
-    if (!oshdbKey.isPresentInKeytables() || values.size() == 0) {
-      LOG.warn((values.size() > 0 ? "Tag key {} not found." : "Empty tag value list.")
-          + " No data will match this filter.", key);
-      ret.preFilters.add(ignored -> false);
-      ret.filters.add(ignored -> false);
-      return ret;
+    if (!oshdbKey.isPresentInKeytables() || values.isEmpty()) {
+      LOG.warn(
+          (values.isEmpty()
+              ? "Empty tag value list. No data will match this filter."
+              : "Tag key {} not found. No data will match this filter."),
+          key
+      );
+      return osmTagEmptyResult();
     }
     Set<Integer> valueIds = new HashSet<>();
     for (String value : values) {
@@ -573,7 +562,8 @@ public abstract class MapReducer<X> implements
         valueIds.add(keyValueId.getValue());
       }
     }
-    ret.preFilters.add(oshEntitiy -> oshEntitiy.hasTagKey(keyId));
+    MapReducer<X> ret = this.copy();
+    ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(keyId));
     ret.filters.add(osmEntity -> {
       int[] tags = osmEntity.getRawTags();
       for (int i = 0; i < tags.length; i += 2) {
@@ -599,16 +589,14 @@ public abstract class MapReducer<X> implements
    */
   @Contract(pure = true)
   public MapReducer<X> osmTag(String key, Pattern valuePattern) {
-    MapReducer<X> ret = this.copy();
     OSHDBTagKey oshdbKey = this.getTagTranslator().getOSHDBTagKeyOf(key);
     int keyId = oshdbKey.toInt();
     if (!oshdbKey.isPresentInKeytables()) {
       LOG.warn("Tag key {} not found. No data will match this filter.", key);
-      ret.preFilters.add(ignored -> false);
-      ret.filters.add(ignored -> false);
-      return ret;
+      return osmTagEmptyResult();
     }
-    ret.preFilters.add(oshEntitiy -> oshEntitiy.hasTagKey(keyId));
+    MapReducer<X> ret = this.copy();
+    ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(keyId));
     ret.filters.add(osmEntity -> {
       int[] tags = osmEntity.getRawTags();
       for (int i = 0; i < tags.length; i += 2) {
@@ -636,12 +624,9 @@ public abstract class MapReducer<X> implements
   @Deprecated
   @Contract(pure = true)
   public MapReducer<X> osmTag(Collection<? extends OSMTagInterface> tags) {
-    MapReducer<X> ret = this.copy();
     if (tags.isEmpty()) {
       LOG.warn("Empty tag list. No data will match this filter.");
-      ret.preFilters.add(ignored -> false);
-      ret.filters.add(ignored -> false);
-      return ret;
+      return osmTagEmptyResult();
     }
     // for the "pre"-filter which removes all entities which don't match at least one of the
     // given tag keys
@@ -666,8 +651,9 @@ public abstract class MapReducer<X> implements
         keyIds.add(keyId.toInt());
       }
     }
-    ret.preFilters.add(oshEntitiy -> {
-      for (int key : oshEntitiy.getRawTagKeys()) {
+    MapReducer<X> ret = this.copy();
+    ret.preFilters.add(oshEntity -> {
+      for (int key : oshEntity.getRawTagKeys()) {
         if (preKeyIds.contains(key)) {
           return true;
         }
@@ -682,6 +668,27 @@ public abstract class MapReducer<X> implements
       }
       return false;
     });
+    return ret;
+  }
+
+  private MapReducer<X> osmTag(OSHDBTag tag) {
+    MapReducer<X> ret = this.copy();
+    ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(tag.getKey()));
+    ret.filters.add(osmEntity -> osmEntity.hasTagValue(tag.getKey(), tag.getValue()));
+    return ret;
+  }
+
+  private MapReducer<X> osmTag(OSHDBTagKey tagKey) {
+    MapReducer<X> ret = this.copy();
+    ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(tagKey));
+    ret.filters.add(osmEntity -> osmEntity.hasTagKey(tagKey));
+    return ret;
+  }
+
+  private MapReducer<X> osmTagEmptyResult() {
+    MapReducer<X>  ret = this.copy();
+    ret.preFilters.add(ignored -> false);
+    ret.filters.add(ignored -> false);
     return ret;
   }
 
@@ -2143,18 +2150,13 @@ public abstract class MapReducer<X> implements
     // basic optimizations (“low hanging fruit”):
     // single filters, and-combination of single filters, etc.
     if (filter instanceof TagFilterEquals) {
-      OSMTag tag = this.getTagTranslator().getOSMTagOf(((TagFilterEquals) filter).getTag());
-      return mapRed.osmTag(tag);
-    }
-    if (filter instanceof TagFilterEqualsAny) {
-      OSMTagKey key = this.getTagTranslator().getOSMTagKeyOf(
-          ((TagFilterEqualsAny) filter).getTag());
+      return mapRed.osmTag(((TagFilterEquals) filter).getTag());
+    } else if (filter instanceof TagFilterEqualsAny) {
+      OSHDBTagKey key = ((TagFilterEqualsAny) filter).getTag();
       return mapRed.osmTag(key);
-    }
-    if (filter instanceof TypeFilter) {
+    } else if (filter instanceof TypeFilter) {
       return mapRed.osmType(((TypeFilter) filter).getType());
-    }
-    if (filter instanceof AndOperator) {
+    } else if (filter instanceof AndOperator) {
       return optimizeFilters0(optimizeFilters0(mapRed,
           ((AndOperator) filter).getLeftOperand()),
           ((AndOperator) filter).getRightOperand());

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
@@ -417,6 +417,7 @@ public abstract class MapReducer<X> implements
     return osmTypeInternal(typeFilter);
   }
 
+  @Contract(pure = true)
   private MapReducer<X> osmTypeInternal(Set<OSMType> typeFilter) {
     MapReducer<X> ret = this.copy();
     typeFilter = Sets.intersection(ret.typeFilter, typeFilter);
@@ -675,6 +676,7 @@ public abstract class MapReducer<X> implements
     return ret;
   }
 
+  @Contract(pure = true)
   private MapReducer<X> osmTag(OSHDBTag tag) {
     MapReducer<X> ret = this.copy();
     ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(tag.getKey()));
@@ -682,6 +684,7 @@ public abstract class MapReducer<X> implements
     return ret;
   }
 
+  @Contract(pure = true)
   private MapReducer<X> osmTag(OSHDBTagKey tagKey) {
     MapReducer<X> ret = this.copy();
     ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(tagKey));
@@ -689,6 +692,7 @@ public abstract class MapReducer<X> implements
     return ret;
   }
 
+  @Contract(pure = true)
   private MapReducer<X> osmTagEmptyResult() {
     MapReducer<X>  ret = this.copy();
     ret.preFilters.add(ignored -> false);

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducerSettings.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducerSettings.java
@@ -3,9 +3,9 @@ package org.heigit.ohsome.oshdb.api.mapreducer;
 import java.util.Collection;
 import java.util.EnumSet;
 import java.util.Set;
-import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import org.heigit.ohsome.oshdb.api.generic.function.SerializablePredicate;
+import org.heigit.ohsome.oshdb.filter.Filter;
 import org.heigit.ohsome.oshdb.filter.FilterExpression;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.osm.OSMType;
@@ -98,8 +98,9 @@ interface MapReducerSettings<M> {
    *
    * @param f the filter function to call for each osm entity
    * @return `this` mapReducer (can be used to chain multiple commands together)
-   * @deprecated use oshdb-filter {@link #filter(FilterExpression)} with
-   *             {@link org.heigit.ohsome.oshdb.filter.Filter#byOSMEntity(Predicate)} instead
+   * @deprecated use oshdb-filter {@link #filter(FilterExpression)} with {@link
+   *             org.heigit.ohsome.oshdb.filter.Filter#byOSMEntity(Filter.SerializablePredicate)}
+   *             instead
    */
   @Deprecated
   M osmEntityFilter(SerializablePredicate<OSMEntity> f);


### PR DESCRIPTION
### Description
A oshdb filter goes through some optimization steps for increased performance, e.g. for simple `key=value` queries, it will use a more efficient code path than for example a filter like `key1=value1 or key2=value2`. The "fast" path crashed, when a non-existent tag is contained in the filter: The code tries to convert the tag from the OSHDB-internal representation back to strings. This normally works fine, but not for tags which don't exist.

This fixes the bug by replacing the conversion from tag ids to strings by a newly added private method for using tag ids directly for filtering.

This PR also fixes a few minor typos (`entitiy` -> `entity`) and refactors some of the `osmTag` filters slightly (to also use the new helper method and be more similar to each other).

### Corresponding issue
Closes https://github.com/GIScience/ohsome-api/issues/154

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- ~~I have written javadoc (required for public methods)~~
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~
