### PR TITLE
Use test-compile before executing several warnings

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
           sh "mkdir -p ${report_dir} && rm -Rf ${report_dir}* && find . -path '*/target/site/jacoco' -exec cp -R --parents {} ${report_dir} \\; && find ${report_dir} -path '*/target/site/jacoco' | while read line; do echo \$line; neu=\${line/target\\/site\\/jacoco/} ;  mv \$line/* \$neu ; done && find ${report_dir} -type d -empty -delete"
 
           // warnings plugin
-          rtMaven.run pom: 'pom.xml', goals: '--batch-mode -V -e compile checkstyle:checkstyle pmd:pmd pmd:cpd spotbugs:spotbugs -Dmaven.repo.local=.m2 $MAVEN_TEST_OPTIONS'
+          rtMaven.run pom: 'pom.xml', goals: '--batch-mode -V -e test-compile checkstyle:checkstyle pmd:pmd pmd:cpd spotbugs:spotbugs -Dmaven.repo.local=.m2 $MAVEN_TEST_OPTIONS'
 
           recordIssues enabledForFailure: true, tools: [mavenConsole(),  java(), javaDoc()]
           recordIssues enabledForFailure: true, tool: checkStyle()

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -97,19 +97,6 @@
         <artifactId>maven-jar-plugin</artifactId>
         <executions>
           <execution>
-            <id>test-jar--compile</id>
-            <phase>
-              compile
-            </phase>
-            <goals>
-              <goal>test-jar</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>test-jar--test</id>
-            <phase>
-              test
-            </phase>
             <goals>
               <goal>test-jar</goal>
             </goals>

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -14,6 +14,7 @@
 
   <properties>
     <tdigest.version>3.2</tdigest.version>
+    <mavenjar.version>3.2.0</mavenjar.version>
   </properties>
 
   <dependencies>
@@ -95,6 +96,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>${mavenjar.version}</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
### Description
Use test-compile before executing several warnings, e.g. `spotbugs:spotbugs`.

### Corresponding issue
fixes invalid pom warnings from development tools

### New or changed dependencies
- set `maven-jar-plugin` version explicitly to 3.2.0

### Checklist
- [x] Squash commits
- ~[ ] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results~
- ~[ ] I have commented my code~
- ~[ ] I have written javadoc (required for public classes and methods)~
- ~[ ] I have added sufficient unit tests~
- ~[ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)~
- ~[ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~[ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
