### PR TITLE
long to int coordinates, refactoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ Changelog
   | renamed method | `OSMWay.getRef()` | `OSMWay.getMember()` |
   | renamed method | `OSHDBTimestamp.getRawUnixTimestamp()` | `OSHDBTimestamp.getEpochSecond()` |
   | moved class | `oshdb.util.OSHDBTimestamp` | `oshdb.OSHDBTimestamp` |
+  | moved class | `oshdb.util.OSHDBBoundingBox` | `oshdb.OSHDBBoundingBox` |
+  | deprecated method | `new OSHDBBoundingBox(double, double, double, double)` | replaced by `OSHDBBoundingBox.bboxWgs84Coordinates(...)`|
+  | renamed method | `OSHDBBoundingBox.get(Max/Min)(Lon/Lat)Long()` | `OSHDBBoundingBox.get(Max/Min)(Longitude/Latitude)()` |
   | moved class | `oshdb.util.OSHDBTag` | `oshdb.OSHDBTag` |
   | moved class | `CellIterator.OSHEntityFilter` | `oshdb-util/oshdb.osh.OSHEntityFilter` |
   | moved class | `CellIterator.OSMEntityFilter` | `oshdb-util/oshdb.osm.OSMEntityFilter` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 * rename and move submodules of `oshdb-tool` ([#384])
 * rename some classes, methods and enum constants; move some classes/interfaces ([#369], [#374])
 * move the oshdb-api's ignite backend implementation into its own submodule `oshdb-api-ignite` ([#387])
+* refactoring of internal coordinate representation form long to int, mainly `OSHDBBoundingBox`, `OSMNode`, `OSHEntity` ([#395])
 
 > See the _upgrading from 0.6_ section below for instructions how to update your code according to these breaking changes.
 
@@ -78,6 +79,7 @@ Changelog
 [#384]: https://github.com/GIScience/oshdb/pull/384
 [#386]: https://github.com/GIScience/oshdb/issues/386
 [#387]: https://github.com/GIScience/oshdb/pull/387
+[#395]: https://github.com/GIScience/oshdb/pull/395
 
 
 ## 0.6.4

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.mapreducer;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
@@ -165,7 +165,7 @@ public abstract class MapReducer<X> implements
       TimestampFormatter.getInstance().date(new Date()),
       OSHDBTimestamps.Interval.MONTHLY
       );
-  protected OSHDBBoundingBox bboxFilter = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
+  protected OSHDBBoundingBox bboxFilter = bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0);
   private Geometry polyFilter = null;
   protected EnumSet<OSMType> typeFilter = EnumSet.of(OSMType.NODE, OSMType.WAY, OSMType.RELATION);
   private final List<SerializablePredicate<OSHEntity>> preFilters = new ArrayList<>();

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
@@ -25,7 +25,7 @@ public class TestCollect {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
@@ -25,7 +25,7 @@ public class TestCollect {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class TestFlatMapAggregate {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
+  private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -26,7 +27,7 @@ import org.junit.Test;
 public class TestFlatMapAggregate {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
+  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -24,7 +25,7 @@ import org.junit.Test;
 public class TestFlatMapAggregateGroupedByEntity {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
+  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -25,7 +25,7 @@ import org.junit.Test;
 public class TestFlatMapAggregateGroupedByEntity {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
+  private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -27,7 +27,7 @@ import org.junit.Test;
 public class TestFlatMapReduce {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
+  private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
@@ -26,7 +27,7 @@ import org.junit.Test;
 public class TestFlatMapReduce {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
+  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -22,7 +23,7 @@ import org.junit.Test;
 abstract class TestFlatMapReduceGroupedByEntity {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
+  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps6 = new OSHDBTimestamps("2010-01-01", "2015-01-01",
       OSHDBTimestamps.Interval.YEARLY);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -23,7 +23,7 @@ import org.junit.Test;
 abstract class TestFlatMapReduceGroupedByEntity {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
+  private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps6 = new OSHDBTimestamps("2010-01-01", "2015-01-01",
       OSHDBTimestamps.Interval.YEARLY);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
@@ -20,7 +20,7 @@ public class TestForEach {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
@@ -20,7 +20,7 @@ public class TestForEach {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
@@ -26,7 +26,7 @@ public class TestHelpersOSMContributionView {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2015-01-01");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
@@ -26,7 +26,7 @@ public class TestHelpersOSMContributionView {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2015-01-01");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
@@ -23,7 +23,7 @@ public class TestHelpersOSMEntitySnapshotView {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2014-01-01");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
@@ -23,7 +23,7 @@ public class TestHelpersOSMEntitySnapshotView {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2014-01-01");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
@@ -21,7 +22,7 @@ import org.junit.Test;
 public class TestLambdaFilter {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
+  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
@@ -22,7 +22,7 @@ import org.junit.Test;
 public class TestLambdaFilter {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
+  private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -33,7 +33,7 @@ import org.locationtech.jts.geom.Polygon;
 public class TestMapAggregateByGeometry {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
+  private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2015-12-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2010-01-01", "2015-12-01");
 
@@ -62,16 +62,16 @@ public class TestMapAggregateByGeometry {
   private Map<String, Polygon> getSubRegions() {
     Map<String, Polygon> res = new TreeMap<>();
     res.put("left", OSHDBGeometryBuilder.getGeometry(
-        bboxLonLatCoordinates(8, 49, 8.66128, 50)
+        bboxWgs84Coordinates(8, 49, 8.66128, 50)
     ));
     res.put("right", OSHDBGeometryBuilder.getGeometry(
-        bboxLonLatCoordinates(8.66128 + 1E-8, 49, 9, 50)
+        bboxWgs84Coordinates(8.66128 + 1E-8, 49, 9, 50)
     ));
     res.put("total", OSHDBGeometryBuilder.getGeometry(
         bbox
     ));
     res.put("null island", OSHDBGeometryBuilder.getGeometry(
-        bboxLonLatCoordinates(-1.0, -1.0, 1.0, 1.0)
+        bboxWgs84Coordinates(-1.0, -1.0, 1.0, 1.0)
     ));
     return res;
   }

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -32,7 +33,7 @@ import org.locationtech.jts.geom.Polygon;
 public class TestMapAggregateByGeometry {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
+  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2015-12-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2010-01-01", "2015-12-01");
 
@@ -61,16 +62,16 @@ public class TestMapAggregateByGeometry {
   private Map<String, Polygon> getSubRegions() {
     Map<String, Polygon> res = new TreeMap<>();
     res.put("left", OSHDBGeometryBuilder.getGeometry(
-        new OSHDBBoundingBox(8, 49, 8.66128, 50)
+        bboxLonLatCoordinates(8, 49, 8.66128, 50)
     ));
     res.put("right", OSHDBGeometryBuilder.getGeometry(
-        new OSHDBBoundingBox(8.66128 + 1E-8, 49, 9, 50)
+        bboxLonLatCoordinates(8.66128 + 1E-8, 49, 9, 50)
     ));
     res.put("total", OSHDBGeometryBuilder.getGeometry(
         bbox
     ));
     res.put("null island", OSHDBGeometryBuilder.getGeometry(
-        new OSHDBBoundingBox(-1, -1, 1, 1)
+        bboxLonLatCoordinates(-1.0, -1.0, 1.0, 1.0)
     ));
     return res;
   }

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
@@ -25,7 +26,7 @@ import org.junit.Test;
 public class TestMapAggregateByIndex {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
+  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2015-12-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2010-01-01", "2015-12-01");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
@@ -26,7 +26,7 @@ import org.junit.Test;
 public class TestMapAggregateByIndex {
   private final OSHDBDatabase oshdb;
 
-  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
+  private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2015-12-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2010-01-01", "2015-12-01");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
@@ -27,7 +27,7 @@ public class TestMapAggregateByTimestamp {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2014-01-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2014-12-30");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
@@ -27,7 +27,7 @@ public class TestMapAggregateByTimestamp {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2014-01-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2014-12-30");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -27,7 +27,7 @@ abstract class TestMapReduce {
   final OSHDBDatabase oshdb;
   OSHDBJdbc keytables = null;
 
-  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
+  private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps6 = new OSHDBTimestamps("2010-01-01", "2015-01-01",
       OSHDBTimestamps.Interval.YEARLY);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -26,7 +27,7 @@ abstract class TestMapReduce {
   final OSHDBDatabase oshdb;
   OSHDBJdbc keytables = null;
 
-  private final OSHDBBoundingBox bbox = new OSHDBBoundingBox(8, 49, 9, 50);
+  private final OSHDBBoundingBox bbox = bboxLonLatCoordinates(8.0, 49.0, 9.0, 50.0);
   private final OSHDBTimestamps timestamps6 = new OSHDBTimestamps("2010-01-01", "2015-01-01",
       OSHDBTimestamps.Interval.YEARLY);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
@@ -32,7 +32,7 @@ public class TestOSHDBFilter {
   private final FilterParser filterParser;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
 
   /**
    * Creates a test runner using the H2 backend.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
@@ -32,7 +32,7 @@ public class TestOSHDBFilter {
   private final FilterParser filterParser;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
 
   /**
    * Creates a test runner using the H2 backend.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
@@ -34,7 +34,7 @@ public class TestOSMDataFilters {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2014-01-01");
 
   public TestOSMDataFilters() throws Exception {

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
@@ -34,7 +34,7 @@ public class TestOSMDataFilters {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2014-01-01");
 
   public TestOSMDataFilters() throws Exception {

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
@@ -26,7 +26,7 @@ public class TestQuantiles {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2015-01-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2015-01-01");
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
@@ -26,7 +26,7 @@ public class TestQuantiles {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2015-01-01");
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2015-01-01");
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
@@ -20,7 +20,7 @@ public class TestStream {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      new OSHDBBoundingBox(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
@@ -20,7 +20,7 @@ public class TestStream {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
-      OSHDBBoundingBox.bboxLonLatCoordinates(8.651133, 49.387611, 8.6561, 49.390513);
+      OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/extract/collector/StatsCollector.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/extract/collector/StatsCollector.java
@@ -1,5 +1,7 @@
 package org.heigit.ohsome.oshdb.tool.importer.extract.collector;
 
+import static org.heigit.ohsome.oshdb.osm.OSMCoordinates.GEOM_PRECISION;
+
 import crosby.binary.Osmformat.HeaderBBox;
 import crosby.binary.Osmformat.HeaderBlock;
 import java.io.PrintStream;
@@ -9,7 +11,6 @@ import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
-import org.heigit.ohsome.oshdb.OSHDB;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshpbf.parser.osm.v06.Entity;
 import org.heigit.ohsome.oshpbf.parser.osm.v06.Node;
@@ -139,9 +140,9 @@ public class StatsCollector {
     }
 
     if (minLon != Integer.MAX_VALUE) {
-      out.printf("data.bbox=%.7f,%.7f,%.7f,%.7f%n", minLon * OSHDB.GEOM_PRECISION,
-          minLat * OSHDB.GEOM_PRECISION, maxLon * OSHDB.GEOM_PRECISION,
-          maxLat * OSHDB.GEOM_PRECISION);
+      out.printf("data.bbox=%.7f,%.7f,%.7f,%.7f%n", minLon * GEOM_PRECISION,
+          minLat * GEOM_PRECISION, maxLon * GEOM_PRECISION,
+          maxLat * GEOM_PRECISION);
     }
 
     out.printf("data.timerange=%s,%s%n",

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/load/LoaderNode.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/load/LoaderNode.java
@@ -3,6 +3,7 @@ package org.heigit.ohsome.oshdb.tool.importer.load;
 import it.unimi.dsi.fastutil.longs.Long2ObjectAVLTreeMap;
 import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -48,7 +49,7 @@ public class LoaderNode extends Loader {
       files = StreamSupport.stream(stream.spliterator(), false).collect(Collectors.toList())
           .toArray(new Path[0]);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
 
     reader = new TransfromNodeReaders(files);

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/load/handle/OSHDBHandler.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/load/handle/OSHDBHandler.java
@@ -1,8 +1,6 @@
 package org.heigit.ohsome.oshdb.tool.importer.load.handle;
 
 import it.unimi.dsi.fastutil.longs.Long2ObjectAVLTreeMap;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -47,36 +45,16 @@ public abstract class OSHDBHandler extends LoaderHandler {
     if (zid < 0) {
       return;
     }
-    int zoom = ZGrid.getZoom(zid);
-    XYGrid xyGrid = new XYGrid(zoom);
-
-    OSHDBBoundingBox bbox = ZGrid.getBoundingBox(zid);
-    long longitude = bbox.getMinLonLong() + (bbox.getMaxLonLong() - bbox.getMinLonLong()) / 2;
-    long latitude = bbox.getMinLatLong() + (bbox.getMaxLatLong() - bbox.getMinLatLong()) / 2;
-    long xyId = xyGrid.getId(longitude, latitude);
-
-    List<OSHNode> gridNodes = nodes.stream().map(osh2 -> {
+    List<OSHNode> entries = nodes.stream().map(osh2 -> {
       List<OSMNode> versions = osh2.stream().collect(Collectors.toList());
-      try {
-        OSHNode osh = OSHNodeImpl.build(versions);
-        return osh;
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
+      return OSHNodeImpl.build(versions);
     }).collect(Collectors.toList());
 
-    try {
-      if (gridNodes.size() != 0) {
-
-        GridOSHNodes grid = GridOSHNodes.rebase(xyId, zoom, gridNodes.get(0).getId(), 0, longitude,
-            latitude, gridNodes);
-        handleNodeGrid(grid);
-      } else {
-        System.out.println("no noded at " + xyId);
-      }
-
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
+    if (!entries.isEmpty()) {
+      entries.sort((a, b) -> Long.compare(a.getId(), b.getId()));
+      var grid = grid(zid, (xyId, zoom, lon, lat) ->
+          GridOSHNodes.rebase(xyId, zoom, entries.get(0).getId(), 0, lon, lat, entries));
+      handleNodeGrid(grid);
     }
   }
 
@@ -90,28 +68,9 @@ public abstract class OSHDBHandler extends LoaderHandler {
     if (zid < 0) {
       return;
     }
-    int zoom = ZGrid.getZoom(zid);
-    XYGrid xyGrid = new XYGrid(zoom);
+    var idOshMap = mapNodes(nodes);
 
-    OSHDBBoundingBox bbox = ZGrid.getBoundingBox(zid);
-    long longitude = bbox.getMinLonLong() + (bbox.getMaxLonLong() - bbox.getMinLonLong()) / 2;
-    long latitude = bbox.getMinLatLong() + (bbox.getMaxLatLong() - bbox.getMinLatLong()) / 2;
-    long xyId = xyGrid.getId(longitude, latitude);
-
-    Map<Long, OSHNode> idOshMap = new HashMap<>(nodes.size());
-    nodes.forEach(osh2 -> {
-      Long id = osh2.getId();
-      List<OSMNode> versions = osh2.stream().collect(Collectors.toList());
-      OSHNode osh;
-      try {
-        osh = OSHNodeImpl.build(versions);
-        idOshMap.put(id, osh);
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    });
-
-    List<OSHWay> gridWays = ways.stream().map(tosh -> {
+    List<OSHWay> entities = ways.stream().map(tosh -> {
       List<OSMWay> versions = tosh.stream().collect(Collectors.toList());
 
       List<OSHNode> nodesForThisWay = new ArrayList<>(tosh.getNodeIds().length);
@@ -122,60 +81,58 @@ public abstract class OSHDBHandler extends LoaderHandler {
         nodesForThisWay.add(idOshMap.get(id));
       }
 
-      try {
-        OSHWay osh = OSHWayImpl.build(versions, nodesForThisWay);
-        if (bitmapWayRelation.contains(osh.getId())) {
-          waysForRelation.put(osh.getId(), osh);
-        }
-        return osh;
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
+      var osh = OSHWayImpl.build(versions, nodesForThisWay);
+      if (bitmapWayRelation.contains(osh.getId())) {
+        waysForRelation.put(osh.getId(), osh);
       }
+      return osh;
     }).collect(Collectors.toList());
 
-    gridWays.sort((a, b) -> Long.compare(a.getId(), b.getId()));
-
-    try {
-      if (gridWays.size() != 0) {
-        GridOSHWays grid = GridOSHWays.compact(xyId, zoom, gridWays.get(0).getId(), 0, longitude,
-            latitude, gridWays);
-        handleWayGrid(grid);
-      }
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
+    if (!entities.isEmpty()) {
+      entities.sort((a, b) -> Long.compare(a.getId(), b.getId()));
+      var grid = grid(zid, (xyId, zoom, lon, lat) ->
+          GridOSHWays.compact(xyId, zoom, entities.get(0).getId(), 0, lon, lat, entities));
+      handleWayGrid(grid);
     }
+  }
+
+  private <T> T grid(long zid, GridInstance<T> newInstance) {
+    OSHDBBoundingBox bbox = ZGrid.getBoundingBox(zid);
+    int longitude = bbox.getMinLon() + (bbox.getMaxLon() - bbox.getMinLon()) / 2;
+    int latitude = bbox.getMinLat() + (bbox.getMaxLat() - bbox.getMinLat()) / 2;
+    int zoom = ZGrid.getZoom(zid);
+    var xyGrid = new XYGrid(zoom);
+    long xyId = xyGrid.getId(longitude, latitude);
+    return newInstance.newGrid(xyId, zoom, longitude, latitude);
+  }
+
+  @FunctionalInterface
+  private interface GridInstance<T> {
+    T newGrid(long xyId, int zoom, int longitude, int latitude);
+  }
+
+  private Map<Long, OSHNode> mapNodes(Collection<TransformOSHNode> nodes) {
+    Map<Long, OSHNode> idOshMap = new HashMap<>(nodes.size());
+    nodes.forEach(osh2 -> {
+      Long id = osh2.getId();
+      List<OSMNode> versions = osh2.stream().collect(Collectors.toList());
+      OSHNode osh = OSHNodeImpl.build(versions);
+      idOshMap.put(id, osh);
+    });
+    return idOshMap;
   }
 
   public abstract void handleRelationsGrid(GridOSHRelations grid);
 
   @Override
-  public void handleRelationGrid(long zid, Collection<TransfomRelation> entities,
+  public void handleRelationGrid(long zid, Collection<TransfomRelation> relations,
       Collection<TransformOSHNode> nodes, Collection<TransformOSHWay> ways) {
     if (zid < 0) {
       return;
     }
-    int zoom = ZGrid.getZoom(zid);
-    XYGrid xyGrid = new XYGrid(zoom);
 
-    OSHDBBoundingBox bbox = ZGrid.getBoundingBox(zid);
-    long longitude = bbox.getMinLonLong() + (bbox.getMaxLonLong() - bbox.getMinLonLong()) / 2;
-    long latitude = bbox.getMinLatLong() + (bbox.getMaxLatLong() - bbox.getMinLatLong()) / 2;
-    long xyId = xyGrid.getId(longitude, latitude);
-
-    Map<Long, OSHNode> idOshMap = new HashMap<>(nodes.size());
-    nodes.forEach(osh2 -> {
-      Long id = osh2.getId();
-      List<OSMNode> versions = osh2.stream().collect(Collectors.toList());
-      OSHNode osh;
-      try {
-        osh = OSHNodeImpl.build(versions);
-        idOshMap.put(id, osh);
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
-    });
-
-    List<OSHRelation> gridRelation = entities.stream().map(osh2 -> {
+    Map<Long, OSHNode> idOshMap = mapNodes(nodes);
+    List<OSHRelation> entities = relations.stream().map(osh2 -> {
       List<OSMRelation> versions = osh2.stream().collect(Collectors.toList());
 
       List<OSHNode> nodesForThisRelation = new ArrayList<>(osh2.getNodeIds().length);
@@ -184,7 +141,6 @@ public abstract class OSHDBHandler extends LoaderHandler {
         if (node != null) {
           nodesForThisRelation.add(node);
         }
-
       }
 
       List<OSHWay> waysForThisRelation = new ArrayList<>(osh2.getWayIds().length);
@@ -195,21 +151,14 @@ public abstract class OSHDBHandler extends LoaderHandler {
         }
       }
 
-      try {
-        OSHRelation ret =
-            OSHRelationImpl.build(versions, nodesForThisRelation, waysForThisRelation);
-        return ret;
-      } catch (IOException e) {
-        throw new UncheckedIOException(e);
-      }
+      return OSHRelationImpl.build(versions, nodesForThisRelation, waysForThisRelation);
     }).collect(Collectors.toList());
 
-    try {
-      GridOSHRelations grid = GridOSHRelations.compact(xyId, zoom, gridRelation.get(0).getId(), 0,
-          longitude, latitude, gridRelation);
+    if (!entities.isEmpty()) {
+      entities.sort((a, b) -> Long.compare(a.getId(), b.getId()));
+      var grid = grid(zid, (xyId, zoom, lon, lat) ->
+          GridOSHRelations.compact(xyId, zoom, entities.get(0).getId(), 0, lon, lat, entities));
       handleRelationsGrid(grid);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
     }
   }
 }

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/load/handle/OSHDBHandler.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/load/handle/OSHDBHandler.java
@@ -98,8 +98,8 @@ public abstract class OSHDBHandler extends LoaderHandler {
 
   private <T> T grid(long zid, GridInstance<T> newInstance) {
     OSHDBBoundingBox bbox = ZGrid.getBoundingBox(zid);
-    int longitude = bbox.getMinLon() + (bbox.getMaxLon() - bbox.getMinLon()) / 2;
-    int latitude = bbox.getMinLat() + (bbox.getMaxLat() - bbox.getMinLat()) / 2;
+    int longitude = bbox.getMinLongitude() + (bbox.getMaxLongitude() - bbox.getMinLongitude()) / 2;
+    int latitude = bbox.getMinLatitude() + (bbox.getMaxLatitude() - bbox.getMinLatitude()) / 2;
     int zoom = ZGrid.getZoom(zid);
     var xyGrid = new XYGrid(zoom);
     long xyId = xyGrid.getId(longitude, latitude);

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/TransformerNode.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/TransformerNode.java
@@ -85,6 +85,6 @@ public class TransformerNode extends Transformer {
         entity.getChangeset(),
         entity.getUserId(),
         getKeyValue(entity.getTags()),
-        (int) entity.getLongitude(), (int) entity.getLatitude());
+        entity.getLongitude(), entity.getLatitude());
   }
 }

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/TransformerNode.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/TransformerNode.java
@@ -54,8 +54,8 @@ public class TransformerNode extends Transformer {
 
       final OSHDBBoundingBox bbox = getCellBounce(cellId);
 
-      final long baseLongitude = bbox.getMinLon();
-      final long baseLatitude = bbox.getMinLat();
+      final long baseLongitude = bbox.getMinLongitude();
+      final long baseLatitude = bbox.getMinLatitude();
 
       final LongFunction<byte[]> toByteArray = baseId -> {
         try {

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/TransformerNode.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/TransformerNode.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.oshdb.tool.importer.transform;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -47,33 +48,33 @@ public class TransformerNode extends Transformer {
       }
       nodes.add(getNode(node));
     }
-    final long cellId = cellIds.size() > 0 ? findBestFittingCellId(cellIds) : -1;
+    final long cellId = !cellIds.isEmpty() ? findBestFittingCellId(cellIds) : -1;
 
     try {
 
       final OSHDBBoundingBox bbox = getCellBounce(cellId);
 
-      final long baseLongitude = bbox.getMinLonLong();
-      final long baseLatitude = bbox.getMinLatLong();
+      final long baseLongitude = bbox.getMinLon();
+      final long baseLatitude = bbox.getMinLat();
 
       final LongFunction<byte[]> toByteArray = baseId -> {
         try {
           TransformOSHNode.build(baData, baRecord, baAux, nodes,
               baseId, 0L, baseLongitude, baseLatitude);
 
-          final byte[] record = new byte[baRecord.length()];
-          System.arraycopy(baRecord.array(), 0, record, 0, record.length);
+          final byte[] bytes = new byte[baRecord.length()];
+          System.arraycopy(baRecord.array(), 0, bytes, 0, bytes.length);
 
-          return record;
+          return bytes;
         } catch (IOException e) {
-          throw new RuntimeException(e);
+          throw new UncheckedIOException(e);
         }
       };
 
       store(cellId, id, toByteArray);
       addIdToCell(id, cellId);
     } catch (IOException e) {
-      throw new RuntimeException(e);
+      throw new UncheckedIOException(e);
     }
   }
 
@@ -84,6 +85,6 @@ public class TransformerNode extends Transformer {
         entity.getChangeset(),
         entity.getUserId(),
         getKeyValue(entity.getTags()),
-        entity.getLongitude(), entity.getLatitude());
+        (int) entity.getLongitude(), (int) entity.getLatitude());
   }
 }

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/OSHNode2.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/OSHNode2.java
@@ -95,8 +95,7 @@ public class OSHNode2 extends OSHEntity2 implements OSH<OSMNode> {
         latitude = in.readS64Delta(latitude);
       }
       return new OSMNode(entity.id, version, entity.baseTimestamp + timestamp, changeset, userId,
-          keyValues, (int) (entity.baseLongitude + longitude),
-          (int) (entity.baseLatitude + latitude));
+          keyValues, entity.baseLongitude + longitude, entity.baseLatitude + latitude);
     }
   }
 }

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/OSHNode2.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/OSHNode2.java
@@ -95,7 +95,8 @@ public class OSHNode2 extends OSHEntity2 implements OSH<OSMNode> {
         latitude = in.readS64Delta(latitude);
       }
       return new OSMNode(entity.id, version, entity.baseTimestamp + timestamp, changeset, userId,
-          keyValues, entity.baseLongitude + longitude, entity.baseLatitude + latitude);
+          keyValues, (int) (entity.baseLongitude + longitude),
+          (int) (entity.baseLatitude + latitude));
     }
   }
 }

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransfomRelation.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransfomRelation.java
@@ -49,7 +49,7 @@ public class TransfomRelation extends OSHRelation2 {
     long nodeId = 0;
     LongIterator itr = ids.iterator();
     for (int i = 0; itr.hasNext(); i++) {
-      out.writeU64Delta(itr.nextLong(), nodeId);
+      nodeId = out.writeU64Delta(itr.nextLong(), nodeId);
       offsets.put(nodeId, i);
     }
     return offsets;

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransformOSHEntity.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransformOSHEntity.java
@@ -5,33 +5,11 @@ import org.heigit.ohsome.oshdb.impl.osh.OSHEntityImpl;
 
 public abstract class TransformOSHEntity extends OSHEntityImpl {
 
-  protected TransformOSHEntity(byte[] data, int offset, int length, long baseTimestamp,
+  public TransformOSHEntity(byte[] data, int offset, int length, long baseTimestamp,
       long baseLongitude, long baseLatitude, byte header, long id, OSHDBBoundingBox bbox,
       int[] keys, int dataOffset, int dataLength) {
-    super(props(data, offset, length, 0, baseTimestamp, Math.toIntExact(baseLongitude),
-        Math.toIntExact(baseLatitude), header, id, bbox.getMinLongitude(), bbox.getMinLatitude(),
-        bbox.getMaxLongitude(), bbox.getMaxLatitude(), keys, dataOffset, dataLength));
-  }
-
-  private static CommonEntityProps props(byte[] data, int offset, int length, long baseId,
-      long baseTimestamp, int baseLongitude, int baseLatitude, byte header, long id, int minLon,
-      int minLat, int maxLon, int maxLat, int[] keys, int dataOffset, int dataLength) {
-    var p = new CommonEntityProps(data, offset, length);
-    p.setHeader(header);
-
-    p.setMinLon(minLon);
-    p.setMaxLon(maxLon);
-    p.setMinLat(minLat);
-    p.setMaxLat(maxLat);
-
-    p.setBaseId(baseId);
-    p.setBaseTimestamp(baseTimestamp);
-    p.setBaseLongitude(baseLongitude);
-    p.setBaseLatitude(baseLatitude);
-    p.setId(id);
-    p.setKeys(keys);
-    p.setDataOffset(dataOffset);
-    p.setDataLength(dataLength);
-    return p;
+    super(data, offset, length, baseTimestamp, baseLongitude, baseLatitude, header, id,
+        bbox.getMinLongitude(), bbox.getMinLatitude(), bbox.getMaxLongitude(), bbox.getMaxLatitude(),
+        keys, dataOffset, dataLength);
   }
 }

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransformOSHEntity.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransformOSHEntity.java
@@ -9,8 +9,8 @@ public abstract class TransformOSHEntity extends OSHEntityImpl {
       long baseLongitude, long baseLatitude, byte header, long id, OSHDBBoundingBox bbox,
       int[] keys, int dataOffset, int dataLength) {
     super(props(data, offset, length, 0, baseTimestamp, Math.toIntExact(baseLongitude),
-        Math.toIntExact(baseLatitude), header, id, bbox.getMinLon(), bbox.getMinLat(),
-        bbox.getMaxLon(), bbox.getMaxLat(), keys, dataOffset, dataLength));
+        Math.toIntExact(baseLatitude), header, id, bbox.getMinLongitude(), bbox.getMinLatitude(),
+        bbox.getMaxLongitude(), bbox.getMaxLatitude(), keys, dataOffset, dataLength));
   }
 
   private static CommonEntityProps props(byte[] data, int offset, int length, long baseId,

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransformOSHEntity.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransformOSHEntity.java
@@ -5,11 +5,33 @@ import org.heigit.ohsome.oshdb.impl.osh.OSHEntityImpl;
 
 public abstract class TransformOSHEntity extends OSHEntityImpl {
 
-  public TransformOSHEntity(byte[] data, int offset, int length, long baseTimestamp,
+  protected TransformOSHEntity(byte[] data, int offset, int length, long baseTimestamp,
       long baseLongitude, long baseLatitude, byte header, long id, OSHDBBoundingBox bbox,
       int[] keys, int dataOffset, int dataLength) {
-    super(data, offset, length, baseTimestamp, baseLongitude, baseLatitude, header, id,
-        bbox.getMinLonLong(), bbox.getMinLatLong(), bbox.getMaxLonLong(), bbox.getMaxLatLong(),
-        keys, dataOffset, dataLength);
+    super(props(data, offset, length, 0, baseTimestamp, Math.toIntExact(baseLongitude),
+        Math.toIntExact(baseLatitude), header, id, bbox.getMinLon(), bbox.getMinLat(),
+        bbox.getMaxLon(), bbox.getMaxLat(), keys, dataOffset, dataLength));
+  }
+
+  private static CommonEntityProps props(byte[] data, int offset, int length, long baseId,
+      long baseTimestamp, int baseLongitude, int baseLatitude, byte header, long id, int minLon,
+      int minLat, int maxLon, int maxLat, int[] keys, int dataOffset, int dataLength) {
+    var p = new CommonEntityProps(data, offset, length);
+    p.setHeader(header);
+
+    p.setMinLon(minLon);
+    p.setMaxLon(maxLon);
+    p.setMinLat(minLat);
+    p.setMaxLat(maxLat);
+
+    p.setBaseId(baseId);
+    p.setBaseTimestamp(baseTimestamp);
+    p.setBaseLongitude(baseLongitude);
+    p.setBaseLatitude(baseLatitude);
+    p.setId(id);
+    p.setKeys(keys);
+    p.setDataOffset(dataOffset);
+    p.setDataLength(dataLength);
+    return p;
   }
 }

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransformOSHEntity.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/TransformOSHEntity.java
@@ -9,7 +9,7 @@ public abstract class TransformOSHEntity extends OSHEntityImpl {
       long baseLongitude, long baseLatitude, byte header, long id, OSHDBBoundingBox bbox,
       int[] keys, int dataOffset, int dataLength) {
     super(data, offset, length, baseTimestamp, baseLongitude, baseLatitude, header, id,
-        bbox.getMinLongitude(), bbox.getMinLatitude(), bbox.getMaxLongitude(), bbox.getMaxLatitude(),
-        keys, dataOffset, dataLength);
+        bbox.getMinLongitude(), bbox.getMinLatitude(), bbox.getMaxLongitude(),
+        bbox.getMaxLatitude(), keys, dataOffset, dataLength);
   }
 }

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/reader/TransformReader.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/reader/TransformReader.java
@@ -93,8 +93,8 @@ public abstract class TransformReader<T extends OSHEntity2> implements Closeable
       data.flip();
 
       final OSHDBBoundingBox bbox = ZGrid.getBoundingBox(cellId);
-      final long baseLongitude = bbox.getMinLonLong();
-      final long baseLatitude = bbox.getMinLatLong();
+      final long baseLongitude = bbox.getMinLon();
+      final long baseLatitude = bbox.getMinLat();
 
       final Set<T> ret = new TreeSet<>((a, b) -> Long.compare(a.getId(), b.getId()));
       long id = 0;

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/reader/TransformReader.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/reader/TransformReader.java
@@ -93,8 +93,8 @@ public abstract class TransformReader<T extends OSHEntity2> implements Closeable
       data.flip();
 
       final OSHDBBoundingBox bbox = ZGrid.getBoundingBox(cellId);
-      final long baseLongitude = bbox.getMinLon();
-      final long baseLatitude = bbox.getMinLat();
+      final long baseLongitude = bbox.getMinLongitude();
+      final long baseLatitude = bbox.getMinLatitude();
 
       final Set<T> ret = new TreeSet<>((a, b) -> Long.compare(a.getId(), b.getId()));
       long id = 0;

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/util/ZGrid.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/util/ZGrid.java
@@ -1,21 +1,21 @@
 package org.heigit.ohsome.oshdb.tool.importer.util;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+
 import java.util.Comparator;
-import org.heigit.ohsome.oshdb.OSHDB;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
 
 @SuppressWarnings("checkstyle:abbreviationAsWordInName")
 public class ZGrid {
-
-  public static OSHDBBoundingBox WORLD = new OSHDBBoundingBox(-180.0, -90.0, 180.0, 180.0);
 
   private static final int DIMENSION = 2;
   private static long ZOOM_FACTOR = 1L << 56;
   private static long ID_MASK = 0x00FFFFFFFFFFFFFFL;
 
-  private static final long space = (long) (360.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+  private static final long space = (long) (360.0 * OSMCoordinates.GEOM_PRECISION_TO_LONG);
   private final int maxZoom;
-  private static final OSHDBBoundingBox zeroBoundingBox = new OSHDBBoundingBox(0, 0, 0, 0);
+  private static final OSHDBBoundingBox zeroBoundingBox = bboxLonLatCoordinates(0.0, 0.0, 0.0, 0.0);
 
   /**
    * Creates a {@code ZGrid} index based on maximal Zoom.
@@ -124,12 +124,12 @@ public class ZGrid {
 
     long[] xy = getXy(id);
 
-    final long minLon = denormalizeLon(xy[0] * cellWidth);
-    final long maxLon = minLon + cellWidth - 1;
-    final long minLat = denormalizeLat(xy[1] * cellWidth);
-    final long maxLat = minLat + cellWidth - 1;
+    final int minLon = (int) denormalizeLon(xy[0] * cellWidth);
+    final int maxLon = (int) (minLon + cellWidth - 1);
+    final int minLat = (int) denormalizeLat(xy[1] * cellWidth);
+    final int maxLat = (int) (minLat + cellWidth - 1);
 
-    return new OSHDBBoundingBox(minLon, minLat, maxLon, maxLat);
+    return OSHDBBoundingBox.bboxOSMCoordinates(minLon, minLat, maxLon, maxLat);
   }
 
   private static long[] getXy(long id) {
@@ -172,19 +172,19 @@ public class ZGrid {
   }
 
   private static long normalizeLon(long lon) {
-    return lon + (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+    return lon + OSMCoordinates.toOSM(180.0);
   }
 
   private static long denormalizeLon(long lon) {
-    return lon - (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+    return lon - OSMCoordinates.toOSM(180.0);
   }
 
   private static long normalizeLat(long lat) {
-    return lat + (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+    return lat + OSMCoordinates.toOSM(90.0);
   }
 
   private static long denormalizeLat(long lat) {
-    return lat - (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+    return lat - OSMCoordinates.toOSM(90.0);
   }
 
   private static boolean validateLon(long lon) {

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/util/ZGrid.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/util/ZGrid.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.tool.importer.util;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 
 import java.util.Comparator;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
@@ -15,7 +15,7 @@ public class ZGrid {
 
   private static final long space = (long) (360.0 * OSMCoordinates.GEOM_PRECISION_TO_LONG);
   private final int maxZoom;
-  private static final OSHDBBoundingBox zeroBoundingBox = bboxLonLatCoordinates(0.0, 0.0, 0.0, 0.0);
+  private static final OSHDBBoundingBox zeroBoundingBox = bboxWgs84Coordinates(0.0, 0.0, 0.0, 0.0);
 
   /**
    * Creates a {@code ZGrid} index based on maximal Zoom.

--- a/oshdb-etl/src/test/java/org/heigit/ohsome/oshdb/tool/importer/load/handle/OSHDBHandlerTest.java
+++ b/oshdb-etl/src/test/java/org/heigit/ohsome/oshdb/tool/importer/load/handle/OSHDBHandlerTest.java
@@ -1,0 +1,122 @@
+package org.heigit.ohsome.oshdb.tool.importer.load.handle;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.Iterables;
+import it.unimi.dsi.fastutil.longs.LongAVLTreeSet;
+import it.unimi.dsi.fastutil.longs.LongSortedSet;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.heigit.ohsome.oshdb.grid.GridOSHNodes;
+import org.heigit.ohsome.oshdb.grid.GridOSHRelations;
+import org.heigit.ohsome.oshdb.grid.GridOSHWays;
+import org.heigit.ohsome.oshdb.osm.OSMMember;
+import org.heigit.ohsome.oshdb.osm.OSMNode;
+import org.heigit.ohsome.oshdb.osm.OSMRelation;
+import org.heigit.ohsome.oshdb.osm.OSMType;
+import org.heigit.ohsome.oshdb.osm.OSMWay;
+import org.heigit.ohsome.oshdb.tool.importer.transform.oshdb.TransfomRelation;
+import org.heigit.ohsome.oshdb.tool.importer.transform.oshdb.TransformOSHNode;
+import org.heigit.ohsome.oshdb.tool.importer.transform.oshdb.TransformOSHWay;
+import org.heigit.ohsome.oshdb.util.bytearray.ByteArrayOutputWrapper;
+import org.junit.Test;
+import org.roaringbitmap.longlong.Roaring64NavigableMap;
+
+
+public class OSHDBHandlerTest {
+  private final ByteArrayOutputWrapper baData = new ByteArrayOutputWrapper(1024);
+  private final ByteArrayOutputWrapper baRecord = new ByteArrayOutputWrapper(1024);
+  private final ByteArrayOutputWrapper baAux = new ByteArrayOutputWrapper(1024);
+
+  @Test
+  public void testNodeGrid() throws IOException {
+    var nodes = new ArrayList<OSMNode>();
+    nodes.add(new OSMNode(1, 1, 1000, 100, 23, new int[0], 0, 0));
+    var handler = new Adapter(null, null) {
+      GridOSHNodes grid;
+      @Override
+      public void handleNodeGrid(GridOSHNodes grid) {
+        this.grid = grid;
+      }
+    };
+    handler.handleNodeGrid(0, List.of(
+        TransformOSHNode.build(baData, baRecord, baAux, nodes,
+        0, 0L, 0, 0)));
+    var grid = handler.grid;
+    assertEquals(1, Iterables.size(grid.getEntities()));
+  }
+
+  @Test
+  public void testWayGrid() throws IOException {
+    var nodes = new ArrayList<OSMNode>();
+    nodes.add(new OSMNode(1, 1, 1000, 100, 23, new int[0], 0, 0));
+    TransformOSHNode.build(baData, baRecord, baAux, nodes, 0, 0L, 0, 0);
+    final byte[] record = new byte[baRecord.length()];
+    System.arraycopy(baRecord.array(), 0, record, 0, record.length);
+    var tnodes = List.of(TransformOSHNode.instance(record, 0, record.length));
+    LongSortedSet nodeIds = new LongAVLTreeSet();
+    nodeIds.add(1);
+    var ways = new ArrayList<OSMWay>();
+    ways.add(new OSMWay(1, 1, 1000, 100, 23, new int[0],
+        new OSMMember[] {new OSMMember(1, OSMType.NODE, 0)}));
+    var handler = new Adapter(new Roaring64NavigableMap(), new Roaring64NavigableMap()) {
+      GridOSHWays grid;
+      @Override
+      public void handleWayGrid(GridOSHWays grid) {
+        this.grid = grid;
+      }
+    };
+    handler.handleWayGrid(0, List.of(
+        TransformOSHWay.build(baData, baRecord, baAux, ways, nodeIds,
+        0, 0L, 0, 0)), tnodes);
+    var grid = handler.grid;
+    assertEquals(1, Iterables.size(grid.getEntities()));
+  }
+
+  @Test
+  public void testRelGrid() throws IOException {
+    var nodes = new ArrayList<OSMNode>();
+    nodes.add(new OSMNode(1, 1, 1000, 100, 23, new int[0], 0, 0));
+    TransformOSHNode.build(baData, baRecord, baAux, nodes, 0, 0L, 0, 0);
+    final byte[] record = new byte[baRecord.length()];
+    System.arraycopy(baRecord.array(), 0, record, 0, record.length);
+    var tnodes = List.of(TransformOSHNode.instance(record, 0, record.length));
+    LongSortedSet nodeIds = new LongAVLTreeSet();
+    nodeIds.add(1);
+    var tways = List.<TransformOSHWay>of();
+    LongSortedSet wayIds = new LongAVLTreeSet();
+    var relations = new ArrayList<OSMRelation>();
+    relations.add(new OSMRelation(1, 1, 1000, 100, 23, new int[0],
+        new OSMMember[] {new OSMMember(1, OSMType.NODE, 0)}));
+    var handler = new Adapter(null, null) {
+      GridOSHRelations grid;
+      @Override
+      public void handleRelationsGrid(GridOSHRelations grid) {
+        this.grid = grid;
+      }
+    };
+    handler.handleRelationGrid(0, List.of(
+        TransfomRelation.build(baData, baRecord, baAux, relations, nodeIds, wayIds, 0L, 0L, 0, 0)),
+        tnodes, tways);
+    var grid = handler.grid;
+    assertEquals(1, Iterables.size(grid.getEntities()));
+  }
+
+  private static class Adapter extends OSHDBHandler {
+
+    protected Adapter(Roaring64NavigableMap bitmapNodeRelation,
+        Roaring64NavigableMap bitmapWayRelation) {
+      super(bitmapNodeRelation, bitmapWayRelation);
+    }
+
+    @Override
+    public void handleNodeGrid(GridOSHNodes grid) {}
+
+    @Override
+    public void handleWayGrid(GridOSHWays grid) {}
+
+    @Override
+    public void handleRelationsGrid(GridOSHRelations grid) {}
+  }
+}

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/NegatableFilter.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/NegatableFilter.java
@@ -1,10 +1,8 @@
 package org.heigit.ohsome.oshdb.filter;
 
 import com.google.common.collect.Streams;
-import java.io.IOException;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.heigit.ohsome.oshdb.osh.OSHEntity;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -56,34 +54,25 @@ class NegatableFilter implements Filter {
      * @return true if any of the versions of the entity or its referenced child entities matches
      *         the given predicate.
      */
-    protected static boolean applyToOSHEntityRecursively(
-        OSHEntity entity, Predicate<OSMEntity> predicate) {
-      try {
-        switch (entity.getType()) {
-          case NODE:
-            return Streams.stream(entity.getVersions()).anyMatch(predicate);
-          case WAY:
-            return Streams.concat(
-                Streams.stream(entity.getVersions()),
-                entity.getNodes().stream().flatMap(n -> Streams.stream(n.getVersions()))
-            ).anyMatch(predicate);
-          case RELATION:
-          default:
-            return Streams.concat(
-                Streams.stream(entity.getVersions()),
-                entity.getNodes().stream().flatMap(n -> Streams.stream(n.getVersions())),
-                entity.getWays().stream().flatMap(w -> Streams.stream(w.getVersions())),
-                entity.getWays().stream().flatMap(w -> {
-                  try {
-                    return w.getNodes().stream().flatMap(wn -> Streams.stream(wn.getVersions()));
-                  } catch (IOException ignored) {
-                    return Stream.<OSMEntity>empty();
-                  }
-                })
-            ).anyMatch(predicate);
-        }
-      } catch (IOException ignored) {
-        return true;
+    protected static boolean applyToOSHEntityRecursively(OSHEntity entity,
+        Predicate<OSMEntity> predicate) {
+      switch (entity.getType()) {
+        case NODE:
+          return Streams.stream(entity.getVersions()).anyMatch(predicate);
+        case WAY:
+          return Streams
+              .concat(Streams.stream(entity.getVersions()),
+                  entity.getNodes().stream().flatMap(n -> Streams.stream(n.getVersions())))
+              .anyMatch(predicate);
+        case RELATION:
+        default:
+          return Streams
+              .concat(Streams.stream(entity.getVersions()),
+                  entity.getNodes().stream().flatMap(n -> Streams.stream(n.getVersions())),
+                  entity.getWays().stream().flatMap(w -> Streams.stream(w.getVersions())),
+                  entity.getWays().stream().flatMap(
+                      w -> w.getNodes().stream().flatMap(wn -> Streams.stream(wn.getVersions()))))
+              .anyMatch(predicate);
       }
     }
   }

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
@@ -118,11 +118,12 @@ public class ApplyOSMGeometryTest extends FilterTest {
     // negated
     assertFalse(expression.negate().applyOSMGeometry(entity,
         // approx 1.2m²
-        OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0, 0, 1E-5, 1E-5))
+        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 1E-5, 1E-5))
     ));
     assertTrue(expression.negate().applyOSMGeometry(entity,
         // approx 0.3m²
-        OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0, 0, 5E-6, 5E-6))
+        OSHDBGeometryBuilder
+            .getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 5E-6, 5E-6))
     ));
   }
 

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
@@ -105,15 +105,15 @@ public class ApplyOSMGeometryTest extends FilterTest {
     OSMEntity entity = createTestOSMEntityWay(new long[] {1, 2, 3, 4, 1});
     assertFalse(expression.applyOSMGeometry(entity,
         // approx 0.3m²
-        OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0, 0, 5E-6, 5E-6))
+        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 5E-6, 5E-6))
     ));
     assertTrue(expression.applyOSMGeometry(entity,
         // approx 1.2m²
-        OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0, 0, 1E-5, 1E-5))
+        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 1E-5, 1E-5))
     ));
     assertFalse(expression.applyOSMGeometry(entity,
         // approx 4.9m²
-        OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0, 0, 2E-5, 2E-5))
+        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 2E-5, 2E-5))
     ));
     // negated
     assertFalse(expression.negate().applyOSMGeometry(entity,

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
@@ -105,25 +105,25 @@ public class ApplyOSMGeometryTest extends FilterTest {
     OSMEntity entity = createTestOSMEntityWay(new long[] {1, 2, 3, 4, 1});
     assertFalse(expression.applyOSMGeometry(entity,
         // approx 0.3m²
-        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 5E-6, 5E-6))
+        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxWgs84Coordinates(0, 0, 5E-6, 5E-6))
     ));
     assertTrue(expression.applyOSMGeometry(entity,
         // approx 1.2m²
-        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 1E-5, 1E-5))
+        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxWgs84Coordinates(0, 0, 1E-5, 1E-5))
     ));
     assertFalse(expression.applyOSMGeometry(entity,
         // approx 4.9m²
-        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 2E-5, 2E-5))
+        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxWgs84Coordinates(0, 0, 2E-5, 2E-5))
     ));
     // negated
     assertFalse(expression.negate().applyOSMGeometry(entity,
         // approx 1.2m²
-        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 1E-5, 1E-5))
+        OSHDBGeometryBuilder.getGeometry(OSHDBBoundingBox.bboxWgs84Coordinates(0, 0, 1E-5, 1E-5))
     ));
     assertTrue(expression.negate().applyOSMGeometry(entity,
         // approx 0.3m²
         OSHDBGeometryBuilder
-            .getGeometry(OSHDBBoundingBox.bboxLonLatCoordinates(0, 0, 5E-6, 5E-6))
+            .getGeometry(OSHDBBoundingBox.bboxWgs84Coordinates(0, 0, 5E-6, 5E-6))
     ));
   }
 

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterTest.java
@@ -5,7 +5,6 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import org.heigit.ohsome.oshdb.OSHDBTag;
 import org.heigit.ohsome.oshdb.impl.osh.OSHNodeImpl;
 import org.heigit.ohsome.oshdb.impl.osh.OSHRelationImpl;

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -20,6 +20,7 @@ import org.heigit.ohsome.oshdb.OSHDBTemporal;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osh.OSHEntities;
 import org.heigit.ohsome.oshdb.osh.OSHEntity;
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.osm.OSMMember;
 import org.heigit.ohsome.oshdb.osm.OSMNode;
@@ -162,14 +163,22 @@ public class OSHDBGeometryBuilder {
 
     GeometryFactory gf = new GeometryFactory();
 
-    Coordinate sw = new Coordinate(bbox.getMinLongitude(), bbox.getMinLatitude());
-    Coordinate se = new Coordinate(bbox.getMaxLongitude(), bbox.getMinLatitude());
-    Coordinate nw = new Coordinate(bbox.getMaxLongitude(), bbox.getMaxLatitude());
-    Coordinate ne = new Coordinate(bbox.getMinLongitude(), bbox.getMaxLatitude());
+    Coordinate sw = getCoordinate(bbox.getMinLongitude(), bbox.getMinLatitude());
+    Coordinate se = getCoordinate(bbox.getMaxLongitude(), bbox.getMinLatitude());
+    Coordinate nw = getCoordinate(bbox.getMaxLongitude(), bbox.getMaxLatitude());
+    Coordinate ne = getCoordinate(bbox.getMinLongitude(), bbox.getMaxLatitude());
 
     Coordinate[] cordAr = {sw, se, nw, ne, sw};
 
     return gf.createPolygon(cordAr);
+  }
+
+  public static Coordinate getCoordinate(OSMNode node) {
+    return getCoordinate(node.getLon(), node.getLat());
+  }
+
+  public static Coordinate getCoordinate(int lon, int lat) {
+    return new Coordinate(OSMCoordinates.toDouble(lon), OSMCoordinates.toDouble(lat));
   }
 
   private static Geometry getGeometryCollectionGeometry(
@@ -622,7 +631,7 @@ public class OSHDBGeometryBuilder {
 
     @Override
     public int hashCode() {
-      return ((int) this.id1) + ((int) this.id2);
+      return (int) this.id1 + (int) this.id2;
     }
   }
 }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -162,10 +162,10 @@ public class OSHDBGeometryBuilder {
 
     GeometryFactory gf = new GeometryFactory();
 
-    Coordinate sw = new Coordinate(bbox.getMinLon(), bbox.getMinLat());
-    Coordinate se = new Coordinate(bbox.getMaxLon(), bbox.getMinLat());
-    Coordinate nw = new Coordinate(bbox.getMaxLon(), bbox.getMaxLat());
-    Coordinate ne = new Coordinate(bbox.getMinLon(), bbox.getMaxLat());
+    Coordinate sw = new Coordinate(bbox.getMinLongitude(), bbox.getMinLatitude());
+    Coordinate se = new Coordinate(bbox.getMaxLongitude(), bbox.getMinLatitude());
+    Coordinate nw = new Coordinate(bbox.getMaxLongitude(), bbox.getMaxLatitude());
+    Coordinate ne = new Coordinate(bbox.getMinLongitude(), bbox.getMaxLatitude());
 
     Coordinate[] cordAr = {sw, se, nw, ne, sw};
 
@@ -592,7 +592,7 @@ public class OSHDBGeometryBuilder {
    * @return the same bounding box as an OSHDBBoundingBox object
    */
   public static OSHDBBoundingBox boundingBoxOf(Envelope envelope) {
-    return new OSHDBBoundingBox(
+    return OSHDBBoundingBox.bboxLonLatCoordinates(
         envelope.getMinX(),
         envelope.getMinY(),
         envelope.getMaxX(),

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -177,8 +177,15 @@ public class OSHDBGeometryBuilder {
     return getCoordinate(node.getLon(), node.getLat());
   }
 
-  public static Coordinate getCoordinate(int lon, int lat) {
-    return new Coordinate(OSMCoordinates.toDouble(lon), OSMCoordinates.toDouble(lat));
+  /**
+   * Creates a new instance of jts Coordinate from lon, lat in osm-coordinate system.
+   *
+   * @param osmLon Longitude in osm-coordinate system
+   * @param osmLat Latitude in osm-coordinate system
+   * @return new Coordinate instance
+   */
+  public static Coordinate getCoordinate(int osmLon, int osmLat) {
+    return new Coordinate(OSMCoordinates.toDouble(osmLon), OSMCoordinates.toDouble(osmLat));
   }
 
   private static Geometry getGeometryCollectionGeometry(

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -185,7 +185,7 @@ public class OSHDBGeometryBuilder {
    * @return new Coordinate instance
    */
   public static Coordinate getCoordinate(int osmLon, int osmLat) {
-    return new Coordinate(OSMCoordinates.toDouble(osmLon), OSMCoordinates.toDouble(osmLat));
+    return new Coordinate(OSMCoordinates.toWgs84(osmLon), OSMCoordinates.toWgs84(osmLat));
   }
 
   private static Geometry getGeometryCollectionGeometry(

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -608,7 +608,7 @@ public class OSHDBGeometryBuilder {
    * @return the same bounding box as an OSHDBBoundingBox object
    */
   public static OSHDBBoundingBox boundingBoxOf(Envelope envelope) {
-    return OSHDBBoundingBox.bboxLonLatCoordinates(
+    return OSHDBBoundingBox.bboxWgs84Coordinates(
         envelope.getMinX(),
         envelope.getMinY(),
         envelope.getMaxX(),

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygon.java
@@ -1,5 +1,7 @@
 package org.heigit.ohsome.oshdb.util.geometry.fip;
 
+import static org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder.getCoordinate;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -7,7 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Predicate;
 import org.heigit.ohsome.oshdb.OSHDBBoundable;
-import org.locationtech.jts.geom.Coordinate;
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -57,16 +59,16 @@ public class FastBboxInPolygon extends FastInPolygon implements Predicate<OSHDBB
   public boolean test(OSHDBBoundable boundingBox) {
     GeometryFactory gf = new GeometryFactory();
     Point p1 =
-        gf.createPoint(new Coordinate(boundingBox.getMinLongitude(), boundingBox.getMinLatitude()));
+        gf.createPoint(getCoordinate(boundingBox.getMinLongitude(), boundingBox.getMinLatitude()));
     if (crossingNumber(p1, true) % 2 == 0) {
       return false;
     }
     Point p2 =
-        gf.createPoint(new Coordinate(boundingBox.getMaxLongitude(), boundingBox.getMinLatitude()));
+        gf.createPoint(getCoordinate(boundingBox.getMaxLongitude(), boundingBox.getMinLatitude()));
     Point p3 =
-        gf.createPoint(new Coordinate(boundingBox.getMaxLongitude(), boundingBox.getMaxLatitude()));
+        gf.createPoint(getCoordinate(boundingBox.getMaxLongitude(), boundingBox.getMaxLatitude()));
     Point p4 =
-        gf.createPoint(new Coordinate(boundingBox.getMinLongitude(), boundingBox.getMaxLatitude()));
+        gf.createPoint(getCoordinate(boundingBox.getMinLongitude(), boundingBox.getMaxLatitude()));
     if (crossingNumber(p1, true) != crossingNumber(p2, true)
         || crossingNumber(p3, true) != crossingNumber(p4, true)
         || crossingNumber(p2, false) != crossingNumber(p3, false)
@@ -74,10 +76,10 @@ public class FastBboxInPolygon extends FastInPolygon implements Predicate<OSHDBB
       return false; // at least one of the bbox'es edges crosses the polygon
     }
     for (Envelope innerBbox : innerBboxes) {
-      if (boundingBox.getMinLatitude() <= innerBbox.getMinY()
-          && boundingBox.getMaxLatitude() >= innerBbox.getMaxY()
-          && boundingBox.getMinLongitude() <= innerBbox.getMinX()
-          && boundingBox.getMaxLongitude() >= innerBbox.getMaxX()) {
+      if (OSMCoordinates.toDouble(boundingBox.getMinLatitude()) <= innerBbox.getMinY()
+          && OSMCoordinates.toDouble(boundingBox.getMaxLatitude()) >= innerBbox.getMaxY()
+          && OSMCoordinates.toDouble(boundingBox.getMinLongitude()) <= innerBbox.getMinX()
+          && OSMCoordinates.toDouble(boundingBox.getMaxLongitude()) >= innerBbox.getMaxX()) {
         // the bounding box fully covers at least one of the (multi)polygon's inner rings
         return false;
       }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygon.java
@@ -76,10 +76,10 @@ public class FastBboxInPolygon extends FastInPolygon implements Predicate<OSHDBB
       return false; // at least one of the bbox'es edges crosses the polygon
     }
     for (Envelope innerBbox : innerBboxes) {
-      if (OSMCoordinates.toDouble(boundingBox.getMinLatitude()) <= innerBbox.getMinY()
-          && OSMCoordinates.toDouble(boundingBox.getMaxLatitude()) >= innerBbox.getMaxY()
-          && OSMCoordinates.toDouble(boundingBox.getMinLongitude()) <= innerBbox.getMinX()
-          && OSMCoordinates.toDouble(boundingBox.getMaxLongitude()) >= innerBbox.getMaxX()) {
+      if (OSMCoordinates.toWgs84(boundingBox.getMinLatitude()) <= innerBbox.getMinY()
+          && OSMCoordinates.toWgs84(boundingBox.getMaxLatitude()) >= innerBbox.getMaxY()
+          && OSMCoordinates.toWgs84(boundingBox.getMinLongitude()) <= innerBbox.getMinX()
+          && OSMCoordinates.toWgs84(boundingBox.getMaxLongitude()) >= innerBbox.getMaxX()) {
         // the bounding box fully covers at least one of the (multi)polygon's inner rings
         return false;
       }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygon.java
@@ -56,13 +56,17 @@ public class FastBboxInPolygon extends FastInPolygon implements Predicate<OSHDBB
   @Override
   public boolean test(OSHDBBoundable boundingBox) {
     GeometryFactory gf = new GeometryFactory();
-    Point p1 = gf.createPoint(new Coordinate(boundingBox.getMinLon(), boundingBox.getMinLat()));
+    Point p1 =
+        gf.createPoint(new Coordinate(boundingBox.getMinLongitude(), boundingBox.getMinLatitude()));
     if (crossingNumber(p1, true) % 2 == 0) {
       return false;
     }
-    Point p2 = gf.createPoint(new Coordinate(boundingBox.getMaxLon(), boundingBox.getMinLat()));
-    Point p3 = gf.createPoint(new Coordinate(boundingBox.getMaxLon(), boundingBox.getMaxLat()));
-    Point p4 = gf.createPoint(new Coordinate(boundingBox.getMinLon(), boundingBox.getMaxLat()));
+    Point p2 =
+        gf.createPoint(new Coordinate(boundingBox.getMaxLongitude(), boundingBox.getMinLatitude()));
+    Point p3 =
+        gf.createPoint(new Coordinate(boundingBox.getMaxLongitude(), boundingBox.getMaxLatitude()));
+    Point p4 =
+        gf.createPoint(new Coordinate(boundingBox.getMinLongitude(), boundingBox.getMaxLatitude()));
     if (crossingNumber(p1, true) != crossingNumber(p2, true)
         || crossingNumber(p3, true) != crossingNumber(p4, true)
         || crossingNumber(p2, false) != crossingNumber(p3, false)
@@ -70,10 +74,10 @@ public class FastBboxInPolygon extends FastInPolygon implements Predicate<OSHDBB
       return false; // at least one of the bbox'es edges crosses the polygon
     }
     for (Envelope innerBbox : innerBboxes) {
-      if (boundingBox.getMinLat() <= innerBbox.getMinY()
-          && boundingBox.getMaxLat() >= innerBbox.getMaxY()
-          && boundingBox.getMinLon() <= innerBbox.getMinX()
-          && boundingBox.getMaxLon() >= innerBbox.getMaxX()) {
+      if (boundingBox.getMinLatitude() <= innerBbox.getMinY()
+          && boundingBox.getMaxLatitude() >= innerBbox.getMaxY()
+          && boundingBox.getMinLongitude() <= innerBbox.getMinX()
+          && boundingBox.getMaxLongitude() >= innerBbox.getMaxX()) {
         // the bounding box fully covers at least one of the (multi)polygon's inner rings
         return false;
       }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygon.java
@@ -55,13 +55,17 @@ public class FastBboxOutsidePolygon extends FastInPolygon implements Predicate<O
   @Override
   public boolean test(OSHDBBoundable boundingBox) {
     GeometryFactory gf = new GeometryFactory();
-    Point p1 = gf.createPoint(new Coordinate(boundingBox.getMinLon(), boundingBox.getMinLat()));
+    Point p1 =
+        gf.createPoint(new Coordinate(boundingBox.getMinLongitude(), boundingBox.getMinLatitude()));
     if (crossingNumber(p1, true) % 2 == 1) {
       return false;
     }
-    Point p2 = gf.createPoint(new Coordinate(boundingBox.getMaxLon(), boundingBox.getMinLat()));
-    Point p3 = gf.createPoint(new Coordinate(boundingBox.getMaxLon(), boundingBox.getMaxLat()));
-    Point p4 = gf.createPoint(new Coordinate(boundingBox.getMinLon(), boundingBox.getMaxLat()));
+    Point p2 =
+        gf.createPoint(new Coordinate(boundingBox.getMaxLongitude(), boundingBox.getMinLatitude()));
+    Point p3 =
+        gf.createPoint(new Coordinate(boundingBox.getMaxLongitude(), boundingBox.getMaxLatitude()));
+    Point p4 =
+        gf.createPoint(new Coordinate(boundingBox.getMinLongitude(), boundingBox.getMaxLatitude()));
     if (crossingNumber(p1, true) != crossingNumber(p2, true)
         || crossingNumber(p3, true) != crossingNumber(p4, true)
         || crossingNumber(p2, false) != crossingNumber(p3, false)
@@ -69,10 +73,10 @@ public class FastBboxOutsidePolygon extends FastInPolygon implements Predicate<O
       return false; // at least one of the bbox'es edges crosses the polygon
     }
     for (Envelope innerBbox : outerBboxes) {
-      if (boundingBox.getMinLat() <= innerBbox.getMinY()
-          && boundingBox.getMaxLat() >= innerBbox.getMaxY()
-          && boundingBox.getMinLon() <= innerBbox.getMinX()
-          && boundingBox.getMaxLon() >= innerBbox.getMaxX()) {
+      if (boundingBox.getMinLatitude() <= innerBbox.getMinY()
+          && boundingBox.getMaxLatitude() >= innerBbox.getMaxY()
+          && boundingBox.getMinLongitude() <= innerBbox.getMinX()
+          && boundingBox.getMaxLongitude() >= innerBbox.getMaxX()) {
         // the bounding box fully covers at least one of the (multi)polygon's outer rings
         return false;
       }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygon.java
@@ -74,10 +74,10 @@ public class FastBboxOutsidePolygon extends FastInPolygon implements Predicate<O
       return false; // at least one of the bbox'es edges crosses the polygon
     }
     for (Envelope innerBbox : outerBboxes) {
-      if (OSMCoordinates.toDouble(boundingBox.getMinLatitude()) <= innerBbox.getMinY()
-          && OSMCoordinates.toDouble(boundingBox.getMaxLatitude()) >= innerBbox.getMaxY()
-          && OSMCoordinates.toDouble(boundingBox.getMinLongitude()) <= innerBbox.getMinX()
-          && OSMCoordinates.toDouble(boundingBox.getMaxLongitude()) >= innerBbox.getMaxX()) {
+      if (OSMCoordinates.toWgs84(boundingBox.getMinLatitude()) <= innerBbox.getMinY()
+          && OSMCoordinates.toWgs84(boundingBox.getMaxLatitude()) >= innerBbox.getMaxY()
+          && OSMCoordinates.toWgs84(boundingBox.getMinLongitude()) <= innerBbox.getMinX()
+          && OSMCoordinates.toWgs84(boundingBox.getMaxLongitude()) >= innerBbox.getMaxX()) {
         // the bounding box fully covers at least one of the (multi)polygon's outer rings
         return false;
       }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygon.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygon.java
@@ -1,5 +1,7 @@
 package org.heigit.ohsome.oshdb.util.geometry.fip;
 
+import static org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder.getCoordinate;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -7,7 +9,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.function.Predicate;
 import org.heigit.ohsome.oshdb.OSHDBBoundable;
-import org.locationtech.jts.geom.Coordinate;
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -24,7 +26,6 @@ import org.locationtech.jts.geom.Polygonal;
 public class FastBboxOutsidePolygon extends FastInPolygon implements Predicate<OSHDBBoundable>,
     Serializable {
   private Collection<Envelope> outerBboxes = new ArrayList<>();
-
 
   /**
    * Constructor using a given geometry {@code geom} and geometry type {@code P}.
@@ -56,16 +57,16 @@ public class FastBboxOutsidePolygon extends FastInPolygon implements Predicate<O
   public boolean test(OSHDBBoundable boundingBox) {
     GeometryFactory gf = new GeometryFactory();
     Point p1 =
-        gf.createPoint(new Coordinate(boundingBox.getMinLongitude(), boundingBox.getMinLatitude()));
+        gf.createPoint(getCoordinate(boundingBox.getMinLongitude(), boundingBox.getMinLatitude()));
     if (crossingNumber(p1, true) % 2 == 1) {
       return false;
     }
     Point p2 =
-        gf.createPoint(new Coordinate(boundingBox.getMaxLongitude(), boundingBox.getMinLatitude()));
+        gf.createPoint(getCoordinate(boundingBox.getMaxLongitude(), boundingBox.getMinLatitude()));
     Point p3 =
-        gf.createPoint(new Coordinate(boundingBox.getMaxLongitude(), boundingBox.getMaxLatitude()));
+        gf.createPoint(getCoordinate(boundingBox.getMaxLongitude(), boundingBox.getMaxLatitude()));
     Point p4 =
-        gf.createPoint(new Coordinate(boundingBox.getMinLongitude(), boundingBox.getMaxLatitude()));
+        gf.createPoint(getCoordinate(boundingBox.getMinLongitude(), boundingBox.getMaxLatitude()));
     if (crossingNumber(p1, true) != crossingNumber(p2, true)
         || crossingNumber(p3, true) != crossingNumber(p4, true)
         || crossingNumber(p2, false) != crossingNumber(p3, false)
@@ -73,10 +74,10 @@ public class FastBboxOutsidePolygon extends FastInPolygon implements Predicate<O
       return false; // at least one of the bbox'es edges crosses the polygon
     }
     for (Envelope innerBbox : outerBboxes) {
-      if (boundingBox.getMinLatitude() <= innerBbox.getMinY()
-          && boundingBox.getMaxLatitude() >= innerBbox.getMaxY()
-          && boundingBox.getMinLongitude() <= innerBbox.getMinX()
-          && boundingBox.getMaxLongitude() >= innerBbox.getMaxX()) {
+      if (OSMCoordinates.toDouble(boundingBox.getMinLatitude()) <= innerBbox.getMinY()
+          && OSMCoordinates.toDouble(boundingBox.getMaxLatitude()) >= innerBbox.getMaxY()
+          && OSMCoordinates.toDouble(boundingBox.getMinLongitude()) <= innerBbox.getMinX()
+          && OSMCoordinates.toDouble(boundingBox.getMaxLongitude()) >= innerBbox.getMaxX()) {
         // the bounding box fully covers at least one of the (multi)polygon's outer rings
         return false;
       }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/osh/OSHEntityTimeUtils.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/osh/OSHEntityTimeUtils.java
@@ -3,8 +3,6 @@ package org.heigit.ohsome.oshdb.util.osh;
 import static java.lang.String.format;
 
 import com.google.common.collect.Lists;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -68,11 +66,7 @@ public class OSHEntityTimeUtils {
     Map<OSHDBTimestamp, Long> result = new TreeMap<>();
     putChangesetTimestamps(osh, result);
     // recurse way nodes
-    try {
-      putChangesetTimestamps(osh.getNodes(), result);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    putChangesetTimestamps(osh.getNodes(), result);
     return result;
   }
 
@@ -80,12 +74,8 @@ public class OSHEntityTimeUtils {
     Map<OSHDBTimestamp, Long> result = new TreeMap<>();
     putChangesetTimestamps(osh, result);
     // recurse rel members
-    try {
-      putChangesetTimestamps(osh.getNodes(), result);
-      putChangesetTimestampsRecurse(osh.getWays(), result);
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
-    }
+    putChangesetTimestamps(osh.getNodes(), result);
+    putChangesetTimestampsRecurse(osh.getWays(), result);
     return result;
   }
 
@@ -274,7 +264,7 @@ public class OSHEntityTimeUtils {
     for (OSMEntity osm : osh.getVersions()) {
       OSHDBTimestamp thisT = new OSHDBTimestamp(osm);
       // skip versions which are deleted or don't match the given filter
-      if (!osm.isVisible() || (osmEntityFilter != null && !osmEntityFilter.test(osm))) {
+      if (!osm.isVisible() || osmEntityFilter != null && !osmEntityFilter.test(osm)) {
         // remember "valid-to" time
         nextT = thisT;
         continue;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -53,7 +53,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -93,7 +93,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 2,
         osmEntity -> true,
@@ -129,7 +129,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 3,
         osmEntity -> true,
@@ -176,7 +176,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 4,
         osmEntity -> true,
@@ -226,7 +226,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(8, 9, 49, 50),
+        OSHDBBoundingBox.bboxLonLatCoordinates(8.0, 9.0, 49.0, 50.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -246,7 +246,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(1.42, 1.22, 1.3, 1.1),
+        OSHDBBoundingBox.bboxLonLatCoordinates(1.42, 1.22, 1.3, 1.1),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -266,7 +266,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(3.2, 3.3, 1.425, 1.23),
+        OSHDBBoundingBox.bboxLonLatCoordinates(3.2, 3.3, 1.425, 1.23),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -286,7 +286,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(1.42, 1.22, 1.425, 1.23),
+        OSHDBBoundingBox.bboxLonLatCoordinates(1.42, 1.22, 1.425, 1.23),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -306,7 +306,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -342,7 +342,7 @@ public class IterateByContributionNodesTest {
             "2007-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 7,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("disused:shop")),
@@ -374,7 +374,7 @@ public class IterateByContributionNodesTest {
             "2007-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(0, 0, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 0.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 8,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -407,7 +407,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -53,7 +53,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -93,7 +93,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 2,
         osmEntity -> true,
@@ -129,7 +129,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 3,
         osmEntity -> true,
@@ -176,7 +176,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 4,
         osmEntity -> true,
@@ -226,7 +226,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(8.0, 9.0, 49.0, 50.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(8.0, 9.0, 49.0, 50.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -246,7 +246,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(1.42, 1.22, 1.3, 1.1),
+        OSHDBBoundingBox.bboxWgs84Coordinates(1.42, 1.22, 1.3, 1.1),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -266,7 +266,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(3.2, 3.3, 1.425, 1.23),
+        OSHDBBoundingBox.bboxWgs84Coordinates(3.2, 3.3, 1.425, 1.23),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -286,7 +286,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(1.42, 1.22, 1.425, 1.23),
+        OSHDBBoundingBox.bboxWgs84Coordinates(1.42, 1.22, 1.425, 1.23),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -306,7 +306,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -342,7 +342,7 @@ public class IterateByContributionNodesTest {
             "2007-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 7,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("disused:shop")),
@@ -374,7 +374,7 @@ public class IterateByContributionNodesTest {
             "2007-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 0.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 0.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 8,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -407,7 +407,7 @@ public class IterateByContributionNodesTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -60,7 +60,7 @@ public class IterateByContributionRelationsTest {
             "2020-01-01T00:00:00Z"
         ).get(),
         // look at dat in this bbox
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         // needed to create actual geometries from OSM data
         areaDecider,
         // oshEntityPreFilter: get data of relation with id 500
@@ -105,7 +105,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -139,7 +139,7 @@ public class IterateByContributionRelationsTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          new OSHDBBoundingBox(-180, -90, 180, 90),
+          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -161,7 +161,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -195,7 +195,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -235,7 +235,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -274,7 +274,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -313,7 +313,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -347,7 +347,7 @@ public class IterateByContributionRelationsTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          new OSHDBBoundingBox(-180, -90, 180, 90),
+          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -369,7 +369,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -426,7 +426,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -453,7 +453,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -490,7 +490,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -524,7 +524,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -554,7 +554,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -589,7 +589,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -744,7 +744,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -800,7 +800,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 52.7, 52.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -821,7 +821,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(50, 50, 52, 52),
+        OSHDBBoundingBox.bboxLonLatCoordinates(50.0, 50.0, 52.0, 52.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -844,7 +844,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -906,7 +906,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -931,7 +931,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,
@@ -955,7 +955,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 523,
         osmEntity -> true,
@@ -979,7 +979,7 @@ public class IterateByContributionRelationsTest {
             "2012-01-01T00:00:00Z",
             "2014-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> !(osmEntity.getVersion() == 2),

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -60,7 +60,7 @@ public class IterateByContributionRelationsTest {
             "2020-01-01T00:00:00Z"
         ).get(),
         // look at dat in this bbox
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         // needed to create actual geometries from OSM data
         areaDecider,
         // oshEntityPreFilter: get data of relation with id 500
@@ -105,7 +105,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -139,7 +139,7 @@ public class IterateByContributionRelationsTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+          OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -161,7 +161,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -195,7 +195,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -235,7 +235,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -274,7 +274,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -313,7 +313,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -347,7 +347,7 @@ public class IterateByContributionRelationsTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+          OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -369,7 +369,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -426,7 +426,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -453,7 +453,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -490,7 +490,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -524,7 +524,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -554,7 +554,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -589,7 +589,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -744,7 +744,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -800,7 +800,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 52.7, 52.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -821,7 +821,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(50.0, 50.0, 52.0, 52.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(50.0, 50.0, 52.0, 52.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -844,7 +844,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -906,7 +906,7 @@ public class IterateByContributionRelationsTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -931,7 +931,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,
@@ -955,7 +955,7 @@ public class IterateByContributionRelationsTest {
             "2016-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 523,
         osmEntity -> true,
@@ -979,7 +979,7 @@ public class IterateByContributionRelationsTest {
             "2012-01-01T00:00:00Z",
             "2014-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> !(osmEntity.getVersion() == 2),

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
@@ -78,7 +78,7 @@ public class IterateByContributionTest {
 
         List<IterateAllEntry> result = (new CellIterator(
             timestamps,
-            new OSHDBBoundingBox(8, 9, 49, 50),
+            OSHDBBoundingBox.bboxLonLatCoordinates(8.0, 9.0, 49.0, 50.0),
             new DefaultTagInterpreter(tt),
             oshEntity -> oshEntity.getId() == 617308093,
             osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
@@ -78,7 +78,7 @@ public class IterateByContributionTest {
 
         List<IterateAllEntry> result = (new CellIterator(
             timestamps,
-            OSHDBBoundingBox.bboxLonLatCoordinates(8.0, 9.0, 49.0, 50.0),
+            OSHDBBoundingBox.bboxWgs84Coordinates(8.0, 9.0, 49.0, 50.0),
             new DefaultTagInterpreter(tt),
             oshEntity -> oshEntity.getId() == 617308093,
             osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
@@ -53,7 +53,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> true,
@@ -93,7 +93,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -127,7 +127,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+          OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -149,7 +149,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -183,7 +183,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -223,7 +223,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -263,7 +263,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -302,7 +302,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -336,7 +336,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+          OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -358,7 +358,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -415,7 +415,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -442,7 +442,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -470,7 +470,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -504,7 +504,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -534,7 +534,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -569,7 +569,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -696,7 +696,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -753,7 +753,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2016-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 52.7, 52.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -774,7 +774,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(50.0, 50.0, 52.0, 52.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(50.0, 50.0, 52.0, 52.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -824,7 +824,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -849,7 +849,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2012-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
@@ -53,7 +53,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> true,
@@ -93,7 +93,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -127,7 +127,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          new OSHDBBoundingBox(-180, -90, 180, 90),
+          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -149,7 +149,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -183,7 +183,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -223,7 +223,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -263,7 +263,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -302,7 +302,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -336,7 +336,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
               "2000-01-01T00:00:00Z",
               "2020-01-01T00:00:00Z"
           ).get(),
-          new OSHDBBoundingBox(-180, -90, 180, 90),
+          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -358,7 +358,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -415,7 +415,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -442,7 +442,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -470,7 +470,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -504,7 +504,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -534,7 +534,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -569,7 +569,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -696,7 +696,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2019-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -753,7 +753,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2016-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 52.7, 52.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -774,7 +774,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(50, 50, 52, 52),
+        OSHDBBoundingBox.bboxLonLatCoordinates(50.0, 50.0, 52.0, 52.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -824,7 +824,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -849,7 +849,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
             "2012-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
@@ -49,7 +49,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 100,
         osmEntity -> true,
@@ -98,7 +98,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 101,
         osmEntity -> true,
@@ -149,7 +149,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 102,
         osmEntity -> true,
@@ -182,7 +182,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 103,
         osmEntity -> true,
@@ -233,7 +233,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 104,
         osmEntity -> true,
@@ -277,7 +277,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 105,
         osmEntity -> true,
@@ -324,7 +324,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 106,
         osmEntity -> true,
@@ -364,7 +364,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 107,
         osmEntity -> true,
@@ -405,7 +405,7 @@ public class IterateByContributionWaysTest {
             "2009-02-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 108,
         osmEntity -> true,
@@ -427,7 +427,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 109,
         osmEntity -> true,
@@ -458,7 +458,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2009-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(1.8, 1.3, 2.7, 2.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -486,7 +486,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2012-08-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(1.8, 1.3, 2.7, 2.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -517,7 +517,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 111,
         osmEntity -> true,
@@ -543,7 +543,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 112,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
@@ -49,7 +49,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 100,
         osmEntity -> true,
@@ -98,7 +98,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 101,
         osmEntity -> true,
@@ -149,7 +149,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 102,
         osmEntity -> true,
@@ -182,7 +182,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2020-01-01T00:00:01Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 103,
         osmEntity -> true,
@@ -233,7 +233,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 104,
         osmEntity -> true,
@@ -277,7 +277,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 105,
         osmEntity -> true,
@@ -324,7 +324,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 106,
         osmEntity -> true,
@@ -364,7 +364,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:01Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 107,
         osmEntity -> true,
@@ -405,7 +405,7 @@ public class IterateByContributionWaysTest {
             "2009-02-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 108,
         osmEntity -> true,
@@ -427,7 +427,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 109,
         osmEntity -> true,
@@ -458,7 +458,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2009-08-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(1.8, 1.3, 2.7, 2.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -486,7 +486,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2012-08-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(1.8, 1.3, 2.7, 2.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -517,7 +517,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 111,
         osmEntity -> true,
@@ -543,7 +543,7 @@ public class IterateByContributionWaysTest {
             "2000-01-01T00:00:00Z",
             "2018-01-01T00:00:00Z"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 112,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -52,7 +52,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -78,7 +78,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 2,
         osmEntity -> true,
@@ -110,7 +110,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 3,
         osmEntity -> true,
@@ -136,7 +136,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 4,
         osmEntity -> true,
@@ -179,7 +179,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -199,7 +199,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -52,7 +52,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 1,
         osmEntity -> true,
@@ -78,7 +78,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 2,
         osmEntity -> true,
@@ -110,7 +110,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 3,
         osmEntity -> true,
@@ -136,7 +136,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 4,
         osmEntity -> true,
@@ -179,7 +179,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
@@ -199,7 +199,7 @@ public class IterateByTimestampsNodesTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
         osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -53,7 +53,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> true,
@@ -83,7 +83,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -107,7 +107,7 @@ public class IterateByTimestampsRelationsTest {
               "2020-01-01T00:00:00Z",
               "P1Y"
           ).get(),
-          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+          OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -130,7 +130,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -153,7 +153,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -185,7 +185,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -216,7 +216,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -241,7 +241,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -270,7 +270,7 @@ public class IterateByTimestampsRelationsTest {
               "2020-01-01T00:00:00Z",
               "P1Y"
           ).get(),
-          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+          OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -293,7 +293,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -329,7 +329,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -351,7 +351,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -376,7 +376,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -402,7 +402,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -428,7 +428,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -455,7 +455,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -493,7 +493,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 22.7, 22.7),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -552,7 +552,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 52.7, 52.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 52.7, 52.7),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -582,7 +582,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(50.0, 51.0, 51.0, 52.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(50.0, 51.0, 51.0, 52.0),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -605,7 +605,7 @@ public class IterateByTimestampsRelationsTest {
             "2019-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -656,7 +656,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 52.7, 52.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -676,7 +676,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(50.0, 50.0, 52.0, 52.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(50.0, 50.0, 52.0, 52.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -699,7 +699,7 @@ public class IterateByTimestampsRelationsTest {
             "2019-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -759,7 +759,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -780,7 +780,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,
@@ -801,7 +801,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 523,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -53,7 +53,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 500,
         osmEntity -> true,
@@ -83,7 +83,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 501,
         osmEntity -> true,
@@ -107,7 +107,7 @@ public class IterateByTimestampsRelationsTest {
               "2020-01-01T00:00:00Z",
               "P1Y"
           ).get(),
-          new OSHDBBoundingBox(-180, -90, 180, 90),
+          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 502,
           osmEntity -> true,
@@ -130,7 +130,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 503,
         osmEntity -> true,
@@ -153,7 +153,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 504,
         osmEntity -> true,
@@ -185,7 +185,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 505,
         osmEntity -> true,
@@ -216,7 +216,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 506,
         osmEntity -> true,
@@ -241,7 +241,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 507,
         osmEntity -> true,
@@ -270,7 +270,7 @@ public class IterateByTimestampsRelationsTest {
               "2020-01-01T00:00:00Z",
               "P1Y"
           ).get(),
-          new OSHDBBoundingBox(-180, -90, 180, 90),
+          OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
           areaDecider,
           oshEntity -> oshEntity.getId() == 508,
           osmEntity -> true,
@@ -293,7 +293,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 509,
         osmEntity -> true,
@@ -329,7 +329,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 510,
         osmEntity -> true,
@@ -351,7 +351,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 511,
         osmEntity -> true,
@@ -376,7 +376,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 512,
         osmEntity -> true,
@@ -402,7 +402,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 513,
         osmEntity -> true,
@@ -428,7 +428,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 514,
         osmEntity -> true,
@@ -455,7 +455,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 515,
         osmEntity -> true,
@@ -493,7 +493,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -552,7 +552,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 52.7, 52.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 52.7, 52.7),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -582,7 +582,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(50, 51, 51, 52),
+        OSHDBBoundingBox.bboxLonLatCoordinates(50.0, 51.0, 51.0, 52.0),
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
@@ -605,7 +605,7 @@ public class IterateByTimestampsRelationsTest {
             "2019-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -656,7 +656,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 52.7, 52.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 52.7, 52.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 517,
         osmEntity -> true,
@@ -676,7 +676,7 @@ public class IterateByTimestampsRelationsTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(50, 50, 52, 52),
+        OSHDBBoundingBox.bboxLonLatCoordinates(50.0, 50.0, 52.0, 52.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -699,7 +699,7 @@ public class IterateByTimestampsRelationsTest {
             "2019-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(10.8, 10.3, 22.7, 22.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(10.8, 10.3, 22.7, 22.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 516,
         osmEntity -> true,
@@ -759,7 +759,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 521,
         osmEntity -> true,
@@ -780,7 +780,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 522,
         osmEntity -> true,
@@ -801,7 +801,7 @@ public class IterateByTimestampsRelationsTest {
             "2020-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 523,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -51,7 +51,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 100,
         osmEntity -> true,
@@ -86,7 +86,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 101,
         osmEntity -> true,
@@ -117,7 +117,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 102,
         osmEntity -> true,
@@ -141,7 +141,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 103,
         osmEntity -> true,
@@ -179,7 +179,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 104,
         osmEntity -> true,
@@ -207,7 +207,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 105,
         osmEntity -> true,
@@ -233,7 +233,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 106,
         osmEntity -> true,
@@ -263,7 +263,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 107,
         osmEntity -> true,
@@ -293,7 +293,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 108,
         osmEntity -> true,
@@ -314,7 +314,7 @@ public class IterateByTimestampsWaysTest {
             "2010-02-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(1.8, 1.3, 2.7, 2.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -339,7 +339,7 @@ public class IterateByTimestampsWaysTest {
             "2012-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(1.8, 1.3, 2.7, 2.7),
+        OSHDBBoundingBox.bboxWgs84Coordinates(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -363,7 +363,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 112,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -51,7 +51,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 100,
         osmEntity -> true,
@@ -86,7 +86,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 101,
         osmEntity -> true,
@@ -117,7 +117,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 102,
         osmEntity -> true,
@@ -141,7 +141,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 103,
         osmEntity -> true,
@@ -179,7 +179,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 104,
         osmEntity -> true,
@@ -207,7 +207,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 105,
         osmEntity -> true,
@@ -233,7 +233,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 106,
         osmEntity -> true,
@@ -263,7 +263,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 107,
         osmEntity -> true,
@@ -293,7 +293,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 108,
         osmEntity -> true,
@@ -314,7 +314,7 @@ public class IterateByTimestampsWaysTest {
             "2010-02-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(1.8, 1.3, 2.7, 2.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -339,7 +339,7 @@ public class IterateByTimestampsWaysTest {
             "2012-08-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(1.8, 1.3, 2.7, 2.7),
+        OSHDBBoundingBox.bboxLonLatCoordinates(1.8, 1.3, 2.7, 2.7),
         areaDecider,
         oshEntity -> oshEntity.getId() == 110,
         osmEntity -> true,
@@ -363,7 +363,7 @@ public class IterateByTimestampsWaysTest {
             "2018-01-01T00:00:00Z",
             "P1Y"
         ).get(),
-        new OSHDBBoundingBox(-180, -90, 180, 90),
+        OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 112,
         osmEntity -> true,

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.util.geometry;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -51,18 +51,18 @@ public class OSHDBGeometryBuilderTest {
     OSMEntity entity = testData.nodes().get(1L).get(1);
     OSHDBTimestamp timestamp = TimestampParser.toOSHDBTimestamp("2001-01-01");
     // by bbox
-    OSHDBBoundingBox clipBbox = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
+    OSHDBBoundingBox clipBbox = bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0);
     Geometry result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipBbox);
     assertFalse(result.isEmpty());
-    clipBbox = bboxLonLatCoordinates(-180.0, -90.0, 0.0, 0.0);
+    clipBbox = bboxWgs84Coordinates(-180.0, -90.0, 0.0, 0.0);
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipBbox);
     assertTrue(result.isEmpty());
     // by poly
     Polygon clipPoly =
-        OSHDBGeometryBuilder.getGeometry(bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0));
+        OSHDBGeometryBuilder.getGeometry(bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0));
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipPoly);
     assertFalse(result.isEmpty());
-    clipPoly = OSHDBGeometryBuilder.getGeometry(bboxLonLatCoordinates(-1.0, -1.0, 1.0, 1.0));
+    clipPoly = OSHDBGeometryBuilder.getGeometry(bboxWgs84Coordinates(-1.0, -1.0, 1.0, 1.0));
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipPoly);
     assertTrue(result.isEmpty());
   }
@@ -164,7 +164,7 @@ public class OSHDBGeometryBuilderTest {
   @Test
   public void testBoundingGetGeometry() throws ParseException {
     Polygon clipPoly =
-        OSHDBGeometryBuilder.getGeometry(bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0));
+        OSHDBGeometryBuilder.getGeometry(bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0));
     Geometry expectedPolygon = new WKTReader().read(
         "POLYGON((-180.0 -90.0, 180.0 -90.0, 180.0 90.0, -180.0 90.0, -180.0 -90.0))"
     );
@@ -180,7 +180,7 @@ public class OSHDBGeometryBuilderTest {
   @Test
   public void testBoundingBoxGetGeometry() {
     // regular bbox
-    OSHDBBoundingBox bbox = bboxLonLatCoordinates(0.0, 0.0, 1.0, 1.0);
+    OSHDBBoundingBox bbox = bboxWgs84Coordinates(0.0, 0.0, 1.0, 1.0);
     Polygon geometry = OSHDBGeometryBuilder.getGeometry(bbox);
     Coordinate[] test = {
       new Coordinate(0, 0),
@@ -191,7 +191,7 @@ public class OSHDBGeometryBuilderTest {
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
     // degenerate bbox: point
-    bbox = bboxLonLatCoordinates(0.0, 0.0, 0.0, 0.0);
+    bbox = bboxWgs84Coordinates(0.0, 0.0, 0.0, 0.0);
     geometry = OSHDBGeometryBuilder.getGeometry(bbox);
     test = new Coordinate[]{
       new Coordinate(0, 0),
@@ -202,7 +202,7 @@ public class OSHDBGeometryBuilderTest {
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
     // degenerate bbox: line
-    bbox = bboxLonLatCoordinates(0.0, 0.0, 0.0, 1.0);
+    bbox = bboxWgs84Coordinates(0.0, 0.0, 0.0, 1.0);
     geometry = OSHDBGeometryBuilder.getGeometry(bbox);
     test = new Coordinate[]{
       new Coordinate(0, 0),

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.util.geometry;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -50,17 +51,18 @@ public class OSHDBGeometryBuilderTest {
     OSMEntity entity = testData.nodes().get(1L).get(1);
     OSHDBTimestamp timestamp = TimestampParser.toOSHDBTimestamp("2001-01-01");
     // by bbox
-    OSHDBBoundingBox clipBbox = new OSHDBBoundingBox(-180.0, -90.0, 180.0, 90.0);
+    OSHDBBoundingBox clipBbox = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
     Geometry result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipBbox);
     assertFalse(result.isEmpty());
-    clipBbox = new OSHDBBoundingBox(-180.0, -90.0, 0.0, 0.0);
+    clipBbox = bboxLonLatCoordinates(-180.0, -90.0, 0.0, 0.0);
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipBbox);
     assertTrue(result.isEmpty());
     // by poly
-    Polygon clipPoly = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-180, -90, 180, 90));
+    Polygon clipPoly =
+        OSHDBGeometryBuilder.getGeometry(bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0));
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipPoly);
     assertFalse(result.isEmpty());
-    clipPoly = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-1, -1, 1, 1));
+    clipPoly = OSHDBGeometryBuilder.getGeometry(bboxLonLatCoordinates(-1.0, -1.0, 1.0, 1.0));
     result = OSHDBGeometryBuilder.getGeometryClipped(entity, timestamp, null, clipPoly);
     assertTrue(result.isEmpty());
   }
@@ -161,8 +163,9 @@ public class OSHDBGeometryBuilderTest {
 
   @Test
   public void testBoundingGetGeometry() throws ParseException {
-    Polygon clipPoly = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-180, -90, 180, 90));
-    Geometry expectedPolygon = (new WKTReader()).read(
+    Polygon clipPoly =
+        OSHDBGeometryBuilder.getGeometry(bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0));
+    Geometry expectedPolygon = new WKTReader().read(
         "POLYGON((-180.0 -90.0, 180.0 -90.0, 180.0 90.0, -180.0 90.0, -180.0 -90.0))"
     );
     assertEquals(expectedPolygon, clipPoly);
@@ -177,7 +180,7 @@ public class OSHDBGeometryBuilderTest {
   @Test
   public void testBoundingBoxGetGeometry() {
     // regular bbox
-    OSHDBBoundingBox bbox = new OSHDBBoundingBox(0, 0, 1, 1);
+    OSHDBBoundingBox bbox = bboxLonLatCoordinates(0.0, 0.0, 1.0, 1.0);
     Polygon geometry = OSHDBGeometryBuilder.getGeometry(bbox);
     Coordinate[] test = {
       new Coordinate(0, 0),
@@ -188,7 +191,7 @@ public class OSHDBGeometryBuilderTest {
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
     // degenerate bbox: point
-    bbox = new OSHDBBoundingBox(0, 0, 0, 0);
+    bbox = bboxLonLatCoordinates(0.0, 0.0, 0.0, 0.0);
     geometry = OSHDBGeometryBuilder.getGeometry(bbox);
     test = new Coordinate[]{
       new Coordinate(0, 0),
@@ -199,7 +202,7 @@ public class OSHDBGeometryBuilderTest {
     Assert.assertArrayEquals(test, geometry.getCoordinates());
 
     // degenerate bbox: line
-    bbox = new OSHDBBoundingBox(0, 0, 0, 1);
+    bbox = bboxLonLatCoordinates(0.0, 0.0, 0.0, 1.0);
     geometry = OSHDBGeometryBuilder.getGeometry(bbox);
     test = new Coordinate[]{
       new Coordinate(0, 0),

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.util.geometry.fip;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder.getGeometry;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -19,10 +19,10 @@ public class FastBboxInPolygonTest {
    */
   public static MultiPolygon createSquareSquareMultiPolygon() {
     GeometryFactory gf = new GeometryFactory();
-    Polygon poly1 = getGeometry(bboxLonLatCoordinates(-1.5, -1.5, -0.5, -0.5));
-    Polygon poly2 = getGeometry(bboxLonLatCoordinates(0.5, -1.5, 1.5, -0.5));
-    Polygon poly3 = getGeometry(bboxLonLatCoordinates(-1.5, 0.5, -0.5, 1.5));
-    Polygon poly4 = getGeometry(bboxLonLatCoordinates(0.5, 0.5, 1.5, 1.5));
+    Polygon poly1 = getGeometry(bboxWgs84Coordinates(-1.5, -1.5, -0.5, -0.5));
+    Polygon poly2 = getGeometry(bboxWgs84Coordinates(0.5, -1.5, 1.5, -0.5));
+    Polygon poly3 = getGeometry(bboxWgs84Coordinates(-1.5, 0.5, -0.5, 1.5));
+    Polygon poly4 = getGeometry(bboxWgs84Coordinates(0.5, 0.5, 1.5, 1.5));
     return new MultiPolygon(new Polygon[] { poly1, poly2, poly3, poly4 }, gf);
   }
 
@@ -32,22 +32,22 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // inside
-    assertTrue(bip.test(bboxLonLatCoordinates(-0.6, -0.1, -0.4, 0.1)));
+    assertTrue(bip.test(bboxWgs84Coordinates(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertFalse(bip.test(bboxLonLatCoordinates(-1.5, -0.1, -0.4, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -0.1, 1.4, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -1.1, -0.4, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -0.1, -0.4, 1.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertFalse(bip.test(bboxLonLatCoordinates(0.4, -0.1, 0.6, 0.1)));
-    assertTrue(bip.test(bboxLonLatCoordinates(0.4, -0.9, 0.6, -0.8)));
-    assertTrue(bip.test(bboxLonLatCoordinates(0.4, 0.8, 0.6, 0.9)));
+    assertFalse(bip.test(bboxWgs84Coordinates(0.4, -0.1, 0.6, 0.1)));
+    assertTrue(bip.test(bboxWgs84Coordinates(0.4, -0.9, 0.6, -0.8)));
+    assertTrue(bip.test(bboxWgs84Coordinates(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertFalse(bip.test(bboxLonLatCoordinates(0.4, -0.9, 0.6, 0.9)));
+    assertFalse(bip.test(bboxWgs84Coordinates(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertFalse(bip.test(bboxLonLatCoordinates(1.4, -0.1, 1.6, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertFalse(bip.test(bboxLonLatCoordinates(-11.0, -10.0, 10.0, 10.0)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-11.0, -10.0, 10.0, 10.0)));
   }
 
   @Test
@@ -57,31 +57,31 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // inside
-    assertTrue(bip.test(bboxLonLatCoordinates(2.1, -0.1, 2.2, 0.1)));
-    assertTrue(bip.test(bboxLonLatCoordinates(3.1, -0.9, 3.2, -0.8)));
-    assertTrue(bip.test(bboxLonLatCoordinates(3.1, 0.8, 3.2, 0.9)));
-    assertTrue(bip.test(bboxLonLatCoordinates(3.8, -0.1, 3.9, .1)));
+    assertTrue(bip.test(bboxWgs84Coordinates(2.1, -0.1, 2.2, 0.1)));
+    assertTrue(bip.test(bboxWgs84Coordinates(3.1, -0.9, 3.2, -0.8)));
+    assertTrue(bip.test(bboxWgs84Coordinates(3.1, 0.8, 3.2, 0.9)));
+    assertTrue(bip.test(bboxWgs84Coordinates(3.8, -0.1, 3.9, .1)));
     // partially inside
-    assertFalse(bip.test(bboxLonLatCoordinates(1.8, -0.1, 2.2, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -1.1, 3.2, -0.8)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 0.8, 3.2, 1.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.8, -0.1, 4.1, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertFalse(bip.test(bboxLonLatCoordinates(2.9, -0.1, 3.1, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertFalse(bip.test(bboxLonLatCoordinates(2.4, -0.1, 2.6, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -0.6, 3.2, -0.4)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 0.4, 3.2, 0.6)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.4, -0.1, 3.6, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertFalse(bip.test(bboxLonLatCoordinates(2.1, -0.1, 3.9, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertFalse(bip.test(bboxLonLatCoordinates(4.1, -0.1, 4.2, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(1.8, -0.1, 1.9, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -1.2, 3.2, -1.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 1.1, 3.2, 1.2)));
+    assertFalse(bip.test(bboxWgs84Coordinates(4.1, -0.1, 4.2, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(1.8, -0.1, 1.9, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, -1.2, 3.2, -1.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertFalse(bip.test(bboxLonLatCoordinates(2.2, -0.8, 3.8, 0.8)));
+    assertFalse(bip.test(bboxWgs84Coordinates(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -92,50 +92,50 @@ public class FastBboxInPolygonTest {
 
     // left polygon
     // inside
-    assertTrue(bip.test(bboxLonLatCoordinates(-0.6, -0.1, -0.4, 0.1)));
+    assertTrue(bip.test(bboxWgs84Coordinates(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertFalse(bip.test(bboxLonLatCoordinates(-1.5, -0.1, -0.4, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -0.1, 1.4, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -1.1, -0.4, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -0.1, -0.4, 1.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertFalse(bip.test(bboxLonLatCoordinates(0.4, -0.1, 0.6, 0.1)));
-    assertTrue(bip.test(bboxLonLatCoordinates(0.4, -0.9, 0.6, -0.8)));
-    assertTrue(bip.test(bboxLonLatCoordinates(0.4, 0.8, 0.6, 0.9)));
+    assertFalse(bip.test(bboxWgs84Coordinates(0.4, -0.1, 0.6, 0.1)));
+    assertTrue(bip.test(bboxWgs84Coordinates(0.4, -0.9, 0.6, -0.8)));
+    assertTrue(bip.test(bboxWgs84Coordinates(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertFalse(bip.test(bboxLonLatCoordinates(0.4, -0.9, 0.6, 0.9)));
+    assertFalse(bip.test(bboxWgs84Coordinates(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertFalse(bip.test(bboxLonLatCoordinates(1.4, -0.1, 1.6, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertFalse(bip.test(bboxLonLatCoordinates(-11.0, -10.0, 10.0, 10.0)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-11.0, -10.0, 10.0, 10.0)));
 
     // right polygon
     // inside
-    assertTrue(bip.test(bboxLonLatCoordinates(2.1, -0.1, 2.2, 0.1)));
-    assertTrue(bip.test(bboxLonLatCoordinates(3.1, -0.9, 3.2, -0.8)));
-    assertTrue(bip.test(bboxLonLatCoordinates(3.1, 0.8, 3.2, 0.9)));
-    assertTrue(bip.test(bboxLonLatCoordinates(3.8, -0.1, 3.9, 0.1)));
+    assertTrue(bip.test(bboxWgs84Coordinates(2.1, -0.1, 2.2, 0.1)));
+    assertTrue(bip.test(bboxWgs84Coordinates(3.1, -0.9, 3.2, -0.8)));
+    assertTrue(bip.test(bboxWgs84Coordinates(3.1, 0.8, 3.2, 0.9)));
+    assertTrue(bip.test(bboxWgs84Coordinates(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertFalse(bip.test(bboxLonLatCoordinates(1.8, -0.1, 2.2, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -1.1, 3.2, -0.8)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 0.8, 3.2, 1.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.8, -0.1, 4.1, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertFalse(bip.test(bboxLonLatCoordinates(2.9, -0.1, 3.1, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertFalse(bip.test(bboxLonLatCoordinates(2.4, -0.1, 2.6, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -0.6, 3.2, -0.4)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 0.4, 3.2, 0.6)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.4, -0.1, 3.6, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertFalse(bip.test(bboxLonLatCoordinates(2.1, -0.1, 3.9, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertFalse(bip.test(bboxLonLatCoordinates(4.1, -0.1, 4.2, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(1.8, -0.1, 1.9, 0.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -1.2, 3.2, -1.1)));
-    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 1.1, 3.2, 1.2)));
+    assertFalse(bip.test(bboxWgs84Coordinates(4.1, -0.1, 4.2, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(1.8, -0.1, 1.9, 0.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, -1.2, 3.2, -1.1)));
+    assertFalse(bip.test(bboxWgs84Coordinates(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertFalse(bip.test(bboxLonLatCoordinates(2.2, -0.8, 3.8, 0.8)));
+    assertFalse(bip.test(bboxWgs84Coordinates(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -144,6 +144,6 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // not inside
-    assertFalse(bip.test(bboxLonLatCoordinates(-1.0, -1.0, 1.0, 1.0)));
+    assertFalse(bip.test(bboxWgs84Coordinates(-1.0, -1.0, 1.0, 1.0)));
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
@@ -1,10 +1,10 @@
 package org.heigit.ohsome.oshdb.util.geometry.fip;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder.getGeometry;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.junit.Test;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
@@ -19,10 +19,10 @@ public class FastBboxInPolygonTest {
    */
   public static MultiPolygon createSquareSquareMultiPolygon() {
     GeometryFactory gf = new GeometryFactory();
-    Polygon poly1 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-1.5, -1.5, -0.5, -0.5));
-    Polygon poly2 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0.5, -1.5, 1.5, -0.5));
-    Polygon poly3 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(-1.5, 0.5, -0.5, 1.5));
-    Polygon poly4 = OSHDBGeometryBuilder.getGeometry(new OSHDBBoundingBox(0.5, 0.5, 1.5, 1.5));
+    Polygon poly1 = getGeometry(bboxLonLatCoordinates(-1.5, -1.5, -0.5, -0.5));
+    Polygon poly2 = getGeometry(bboxLonLatCoordinates(0.5, -1.5, 1.5, -0.5));
+    Polygon poly3 = getGeometry(bboxLonLatCoordinates(-1.5, 0.5, -0.5, 1.5));
+    Polygon poly4 = getGeometry(bboxLonLatCoordinates(0.5, 0.5, 1.5, 1.5));
     return new MultiPolygon(new Polygon[] { poly1, poly2, poly3, poly4 }, gf);
   }
 
@@ -32,22 +32,22 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // inside
-    assertTrue(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)));
+    assertTrue(bip.test(bboxLonLatCoordinates(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertFalse(bip.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertFalse(bip.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)));
-    assertTrue(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)));
-    assertTrue(bip.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)));
+    assertFalse(bip.test(bboxLonLatCoordinates(0.4, -0.1, 0.6, 0.1)));
+    assertTrue(bip.test(bboxLonLatCoordinates(0.4, -0.9, 0.6, -0.8)));
+    assertTrue(bip.test(bboxLonLatCoordinates(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertFalse(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)));
+    assertFalse(bip.test(bboxLonLatCoordinates(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertFalse(bip.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertFalse(bip.test(new OSHDBBoundingBox(-11, -10, 10, 10)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-11.0, -10.0, 10.0, 10.0)));
   }
 
   @Test
@@ -57,31 +57,31 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // inside
-    assertTrue(bip.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)));
-    assertTrue(bip.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)));
-    assertTrue(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)));
-    assertTrue(bip.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, .1)));
+    assertTrue(bip.test(bboxLonLatCoordinates(2.1, -0.1, 2.2, 0.1)));
+    assertTrue(bip.test(bboxLonLatCoordinates(3.1, -0.9, 3.2, -0.8)));
+    assertTrue(bip.test(bboxLonLatCoordinates(3.1, 0.8, 3.2, 0.9)));
+    assertTrue(bip.test(bboxLonLatCoordinates(3.8, -0.1, 3.9, .1)));
     // partially inside
-    assertFalse(bip.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertFalse(bip.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertFalse(bip.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertFalse(bip.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertFalse(bip.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)));
+    assertFalse(bip.test(bboxLonLatCoordinates(4.1, -0.1, 4.2, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(1.8, -0.1, 1.9, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -1.2, 3.2, -1.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertFalse(bip.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)));
+    assertFalse(bip.test(bboxLonLatCoordinates(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -92,50 +92,50 @@ public class FastBboxInPolygonTest {
 
     // left polygon
     // inside
-    assertTrue(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)));
+    assertTrue(bip.test(bboxLonLatCoordinates(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertFalse(bip.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertFalse(bip.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)));
-    assertTrue(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)));
-    assertTrue(bip.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)));
+    assertFalse(bip.test(bboxLonLatCoordinates(0.4, -0.1, 0.6, 0.1)));
+    assertTrue(bip.test(bboxLonLatCoordinates(0.4, -0.9, 0.6, -0.8)));
+    assertTrue(bip.test(bboxLonLatCoordinates(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertFalse(bip.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)));
+    assertFalse(bip.test(bboxLonLatCoordinates(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertFalse(bip.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertFalse(bip.test(new OSHDBBoundingBox(-11, -10, 10, 10)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-11.0, -10.0, 10.0, 10.0)));
 
     // right polygon
     // inside
-    assertTrue(bip.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)));
-    assertTrue(bip.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)));
-    assertTrue(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)));
-    assertTrue(bip.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)));
+    assertTrue(bip.test(bboxLonLatCoordinates(2.1, -0.1, 2.2, 0.1)));
+    assertTrue(bip.test(bboxLonLatCoordinates(3.1, -0.9, 3.2, -0.8)));
+    assertTrue(bip.test(bboxLonLatCoordinates(3.1, 0.8, 3.2, 0.9)));
+    assertTrue(bip.test(bboxLonLatCoordinates(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertFalse(bip.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertFalse(bip.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertFalse(bip.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertFalse(bip.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertFalse(bip.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)));
-    assertFalse(bip.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)));
+    assertFalse(bip.test(bboxLonLatCoordinates(4.1, -0.1, 4.2, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(1.8, -0.1, 1.9, 0.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, -1.2, 3.2, -1.1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertFalse(bip.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)));
+    assertFalse(bip.test(bboxLonLatCoordinates(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -144,6 +144,6 @@ public class FastBboxInPolygonTest {
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
     // not inside
-    assertFalse(bip.test(new OSHDBBoundingBox(-1, -1, 1, 1)));
+    assertFalse(bip.test(bboxLonLatCoordinates(-1.0, -1.0, 1.0, 1.0)));
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
@@ -18,22 +18,22 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // inside
-    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertFalse(bop.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertTrue(bop.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)));
-    assertFalse(bop.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.1, 0.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.9, 0.6, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertFalse(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertTrue(bop.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertFalse(bop.test(new OSHDBBoundingBox(-11, -10, 10, 10)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-11.0, -10.0, 10.0, 10.0)));
   }
 
   @Test
@@ -43,31 +43,31 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // inside
-    assertFalse(bop.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.1, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -0.9, 3.2, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.8, 3.2, 0.9)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertFalse(bop.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertTrue(bop.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertFalse(bop.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertFalse(bop.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertTrue(bop.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)));
-    assertTrue(bop.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)));
-    assertTrue(bop.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)));
-    assertTrue(bop.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(4.1, -0.1, 4.2, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.8, -0.1, 1.9, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -1.2, 3.2, -1.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertFalse(bop.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -78,50 +78,50 @@ public class FastBboxOutsidePolygonTest {
 
     // left polygon
     // inside
-    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertFalse(bop.test(new OSHDBBoundingBox(-1.5, -0.1, -0.4, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, 1.4, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -1.1, -0.4, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(-0.6, -0.1, -0.4, 1.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertTrue(bop.test(new OSHDBBoundingBox(0.4, -0.1, 0.6, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, -0.8)));
-    assertFalse(bop.test(new OSHDBBoundingBox(0.4, 0.8, 0.6, 0.9)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.1, 0.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.9, 0.6, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertFalse(bop.test(new OSHDBBoundingBox(0.4, -0.9, 0.6, 0.9)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertTrue(bop.test(new OSHDBBoundingBox(1.4, -0.1, 1.6, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertFalse(bop.test(new OSHDBBoundingBox(-11, -10, 10, 10)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-11.0, -10.0, 10.0, 10.0)));
 
     // right polygon
     // inside
-    assertFalse(bop.test(new OSHDBBoundingBox(2.1, -0.1, 2.2, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -0.9, 3.2, -0.8)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 0.9)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.8, -0.1, 3.9, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.1, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -0.9, 3.2, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.8, 3.2, 0.9)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertFalse(bop.test(new OSHDBBoundingBox(1.8, -0.1, 2.2, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -1.1, 3.2, -0.8)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.8, 3.2, 1.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.8, -0.1, 4.1, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertTrue(bop.test(new OSHDBBoundingBox(2.9, -0.1, 3.1, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertFalse(bop.test(new OSHDBBoundingBox(2.4, -0.1, 2.6, 0.1)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, -0.6, 3.2, -0.4)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.1, 0.4, 3.2, 0.6)));
-    assertFalse(bop.test(new OSHDBBoundingBox(3.4, -0.1, 3.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertFalse(bop.test(new OSHDBBoundingBox(2.1, -0.1, 3.9, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertTrue(bop.test(new OSHDBBoundingBox(4.1, -0.1, 4.2, 0.1)));
-    assertTrue(bop.test(new OSHDBBoundingBox(1.8, -0.1, 1.9, 0.1)));
-    assertTrue(bop.test(new OSHDBBoundingBox(3.1, -1.2, 3.2, -1.1)));
-    assertTrue(bop.test(new OSHDBBoundingBox(3.1, 1.1, 3.2, 1.2)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(4.1, -0.1, 4.2, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.8, -0.1, 1.9, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -1.2, 3.2, -1.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertFalse(bop.test(new OSHDBBoundingBox(2.2, -0.8, 3.8, 0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -130,6 +130,6 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // not inside
-    assertFalse(bop.test(new OSHDBBoundingBox(-1, -1, 1, 1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-1.0, -1.0, 1.0, 1.0)));
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
@@ -18,22 +18,22 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-1.5, -0.1, -0.4, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, 1.4, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -1.1, -0.4, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, -0.4, 1.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.1, 0.6, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.9, 0.6, -0.8)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, 0.8, 0.6, 0.9)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(0.4, -0.1, 0.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(0.4, -0.9, 0.6, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.9, 0.6, 0.9)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.4, -0.1, 1.6, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-11.0, -10.0, 10.0, 10.0)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-11.0, -10.0, 10.0, 10.0)));
   }
 
   @Test
@@ -43,31 +43,31 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.1, -0.1, 2.2, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -0.9, 3.2, -0.8)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.8, 3.2, 0.9)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.8, -0.1, 3.9, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.1, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, -0.9, 3.2, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, 0.8, 3.2, 0.9)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.8, -0.1, 2.2, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -1.1, 3.2, -0.8)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.8, 3.2, 1.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.8, -0.1, 4.1, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.9, -0.1, 3.1, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.4, -0.1, 2.6, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -0.6, 3.2, -0.4)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.4, 3.2, 0.6)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.4, -0.1, 3.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.1, -0.1, 3.9, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(4.1, -0.1, 4.2, 0.1)));
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.8, -0.1, 1.9, 0.1)));
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -1.2, 3.2, -1.1)));
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 1.1, 3.2, 1.2)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(4.1, -0.1, 4.2, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(1.8, -0.1, 1.9, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, -1.2, 3.2, -1.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.2, -0.8, 3.8, 0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -78,50 +78,50 @@ public class FastBboxOutsidePolygonTest {
 
     // left polygon
     // inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-0.6, -0.1, -0.4, 0.1)));
     // partially inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-1.5, -0.1, -0.4, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, 1.4, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -1.1, -0.4, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-0.6, -0.1, -0.4, 1.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-1.5, -0.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-0.6, -0.1, 1.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-0.6, -1.1, -0.4, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-0.6, -0.1, -0.4, 1.1)));
     // in concave part
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.1, 0.6, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.9, 0.6, -0.8)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, 0.8, 0.6, 0.9)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(0.4, -0.1, 0.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(0.4, -0.9, 0.6, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(0.4, 0.8, 0.6, 0.9)));
     // in concave part, coordinates all inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(0.4, -0.9, 0.6, 0.9)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(0.4, -0.9, 0.6, 0.9)));
     // outside poly's bbox
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.4, -0.1, 1.6, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(1.4, -0.1, 1.6, 0.1)));
     // bbox covering
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-11.0, -10.0, 10.0, 10.0)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-11.0, -10.0, 10.0, 10.0)));
 
     // right polygon
     // inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.1, -0.1, 2.2, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -0.9, 3.2, -0.8)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.8, 3.2, 0.9)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.8, -0.1, 3.9, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.1, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, -0.9, 3.2, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, 0.8, 3.2, 0.9)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.8, -0.1, 3.9, 0.1)));
     // partially inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.8, -0.1, 2.2, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -1.1, 3.2, -0.8)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.8, 3.2, 1.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.8, -0.1, 4.1, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(1.8, -0.1, 2.2, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, -1.1, 3.2, -0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, 0.8, 3.2, 1.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.8, -0.1, 4.1, 0.1)));
     // in hole
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.9, -0.1, 3.1, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.9, -0.1, 3.1, 0.1)));
     // partially in hole
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.4, -0.1, 2.6, 0.1)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -0.6, 3.2, -0.4)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 0.4, 3.2, 0.6)));
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.4, -0.1, 3.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.4, -0.1, 2.6, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, -0.6, 3.2, -0.4)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, 0.4, 3.2, 0.6)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.4, -0.1, 3.6, 0.1)));
     // intersecting hole
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.1, -0.1, 3.9, 0.1)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.1, -0.1, 3.9, 0.1)));
     // outside poly's bbox
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(4.1, -0.1, 4.2, 0.1)));
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(1.8, -0.1, 1.9, 0.1)));
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, -1.2, 3.2, -1.1)));
-    assertTrue(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(3.1, 1.1, 3.2, 1.2)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(4.1, -0.1, 4.2, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(1.8, -0.1, 1.9, 0.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, -1.2, 3.2, -1.1)));
+    assertTrue(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(3.1, 1.1, 3.2, 1.2)));
     // covering hole, but all vertices inside polygon
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(2.2, -0.8, 3.8, 0.8)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(2.2, -0.8, 3.8, 0.8)));
   }
 
   @Test
@@ -130,6 +130,6 @@ public class FastBboxOutsidePolygonTest {
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
     // not inside
-    assertFalse(bop.test(OSHDBBoundingBox.bboxLonLatCoordinates(-1.0, -1.0, 1.0, 1.0)));
+    assertFalse(bop.test(OSHDBBoundingBox.bboxWgs84Coordinates(-1.0, -1.0, 1.0, 1.0)));
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/osh/TestOSHEntityTimeUtils.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/osh/TestOSHEntityTimeUtils.java
@@ -30,9 +30,9 @@ public class TestOSHEntityTimeUtils {
   public void testGetModificationTimestampsNode() throws IOException {
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(123L, 2, 2L, 0L, 1, new int[] {1, 1},
-            86756350L, 494186210L),
+            86756350, 494186210),
         new OSMNode(123L, 1, 1L, 0L, 1, new int[] {1, 1},
-            86756350L, 494186210L)
+            86756350, 494186210)
     ));
 
     List<OSHDBTimestamp> tss = OSHEntityTimeUtils.getModificationTimestamps(hnode);
@@ -51,11 +51,11 @@ public class TestOSHEntityTimeUtils {
   public void testGetModificationTimestampsNodeWithFilter() throws IOException {
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(123L, 3, 3L, 3L, 1, new int[] {1, 2},
-            86756350L, 494186210L),
+            86756350, 494186210),
         new OSMNode(123L, 2, 2L, 2L, 1, new int[] {1, 2},
-            86756350L, 494186210L),
+            86756350, 494186210),
         new OSMNode(123L, 1, 1L, 1L, 1, new int[] {1, 1},
-            86756350L, 494186210L)
+            86756350, 494186210)
     ));
 
     List<OSHDBTimestamp> tss =
@@ -334,9 +334,9 @@ public class TestOSHEntityTimeUtils {
   public void testGetChangesetTimestampsNode() throws IOException {
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(123L, 2, 2L, 8L, 1, new int[] {1, 1},
-            86756350L, 494186210L),
+            86756350, 494186210),
         new OSMNode(123L, 1, 1L, 1L, 1, new int[] {1, 2},
-            86756350L, 494186210L)
+            86756350, 494186210)
     ));
 
     var tss = OSHEntityTimeUtils.getChangesetTimestamps(hnode);
@@ -350,19 +350,19 @@ public class TestOSHEntityTimeUtils {
   public void testGetChangesetTimestampsWay() throws IOException {
     OSHNode hnode1 = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(1L, 3, 5L, 5L, 1, new int[] {},
-            86756340L, 494186210L),
+            86756340, 494186210),
         new OSMNode(1L, 2, 3L, 3L, 1, new int[] {},
-            86756340L, 494186210L),
+            86756340, 494186210),
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {},
-            86756340L, 494186200L)
+            86756340, 494186200)
     ));
     OSHNode hnode2 = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(2L, 1, 1L, 1L, 1, new int[] {},
-            86756380L, 494186210L)
+            86756380, 494186210)
     ));
     OSHNode hnode3 = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(3L, 1, 4L, 4L, 1, new int[] {},
-            86756390L, 494186210L)
+            86756390, 494186210)
     ));
 
     OSHWay hway = OSHWayImpl.build(Lists.newArrayList(
@@ -401,25 +401,25 @@ public class TestOSHEntityTimeUtils {
   public void testGetChangesetTimestampsRelation() throws IOException {
     OSHNode hnode1 = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(1L, 2, 3L, 3L, 1, new int[] {},
-            86756340L, 494186210L),
+            86756340, 494186210),
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {},
-            86756340L, 494186200L)
+            86756340, 494186200)
     ));
     OSHNode hnode2 = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(2L, 1, 1L, 1L, 1, new int[] {},
-            86756380L, 494186210L)
+            86756380, 494186210)
     ));
     OSHNode hnode3 = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(3L, 1, 4L, 4L, 1, new int[] {},
-            86756390L, 494186210L)
+            86756390, 494186210)
     ));
     OSHNode hnode4 = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(4L, 3, 8L, 8L, 1, new int[] {1, 1},
-            86756340L, 494186210L),
+            86756340, 494186210),
         new OSMNode(4L, 2, 6L, 6L, 1, new int[] {2, 2},
-            86756340L, 494186210L),
+            86756340, 494186210),
         new OSMNode(4L, 1, 1L, 1L, 1, new int[] {1, 1},
-            86756390L, 494186210L)
+            86756390, 494186210)
     ));
 
     OSHWay hway = OSHWayImpl.build(Lists.newArrayList(
@@ -479,7 +479,7 @@ public class TestOSHEntityTimeUtils {
     // missing way node reference
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {},
-            86756380L, 494186210L)
+            86756380, 494186210)
     ));
 
     OSHWay hway = OSHWayImpl.build(Lists.newArrayList(
@@ -510,7 +510,7 @@ public class TestOSHEntityTimeUtils {
     // broken reference (potentially due to data redaction)
     hnode = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {},
-            86756380L, 494186210L)
+            86756380, 494186210)
     ));
   }
 
@@ -519,7 +519,7 @@ public class TestOSHEntityTimeUtils {
     // missing way node reference
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {},
-            86756380L, 494186210L)
+            86756380, 494186210)
     ));
 
     OSHWay hway = OSHWayImpl.build(Lists.newArrayList(
@@ -552,7 +552,7 @@ public class TestOSHEntityTimeUtils {
   public void testGetModificationTimestampsNestedRelations() throws IOException {
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {},
-            86756380L, 494186210L)
+            86756380, 494186210)
     ));
     OSHRelation hrel = OSHRelationImpl.build(Lists.newArrayList(
         new OSMRelation(1L, 1, 1L, 1L, 1, new int[] {1, 1}, new OSMMember[] {

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/xmlreader/MutableOSMNode.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/xmlreader/MutableOSMNode.java
@@ -4,26 +4,26 @@ package org.heigit.ohsome.oshdb.util.xmlreader;
  * A mutable OSM node, specifically for use in {@link OSMXmlReader}.
  */
 public class MutableOSMNode extends MutableOSMEntity  {
-  private long longitude;
-  private long latitude;
+  private int longitude;
+  private int latitude;
 
-  public long getLon() {
+  public int getLon() {
     return longitude;
   }
 
-  public void setLon(long longitude) {
+  public void setLon(int longitude) {
     this.longitude = longitude;
   }
 
-  public long getLat() {
+  public int getLat() {
     return latitude;
   }
 
-  public void setLat(long latitude) {
+  public void setLat(int latitude) {
     this.latitude = latitude;
   }
 
-  public void setExtension(long longitude, long latitude) {
+  public void setExtension(int longitude, int latitude) {
     this.longitude = longitude;
     this.latitude = latitude;
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/xmlreader/OSMXmlReader.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/xmlreader/OSMXmlReader.java
@@ -1,5 +1,7 @@
 package org.heigit.ohsome.oshdb.util.xmlreader;
 
+import static org.heigit.ohsome.oshdb.osm.OSMCoordinates.GEOM_PRECISION_TO_LONG;
+
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.ListMultimap;
@@ -10,7 +12,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -24,7 +25,6 @@ import java.util.zip.GZIPInputStream;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import org.heigit.ohsome.oshdb.OSHDB;
 import org.heigit.ohsome.oshdb.impl.osh.OSHNodeImpl;
 import org.heigit.ohsome.oshdb.impl.osh.OSHWayImpl;
 import org.heigit.ohsome.oshdb.osh.OSHEntity;
@@ -95,8 +95,8 @@ public class OSMXmlReader {
         double lon = osm.isVisible() ? attrAsDouble(e, "lon") : 0.0;
         double lat = osm.isVisible() ? attrAsDouble(e, "lat") : 0.0;
 
-        long longitude = Math.round(lon * OSHDB.GEOM_PRECISION_TO_LONG);
-        long latitude = Math.round(lat * OSHDB.GEOM_PRECISION_TO_LONG);
+        int longitude = Math.toIntExact(Math.round(lon * GEOM_PRECISION_TO_LONG));
+        int latitude = Math.toIntExact(Math.round(lat * GEOM_PRECISION_TO_LONG));
 
         osm.setExtension(longitude, latitude);
 
@@ -370,7 +370,6 @@ public class OSMXmlReader {
   /**
    * Get attribute {@code name} from {@link Element} {@code e} as {@code boolean}.
    */
-  @SuppressWarnings("unused")
   public static boolean attrAsBoolean(Element e, String name) {
     Attr attr = e.getAttributeNode(name);
     if (attr != null) {

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDB.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDB.java
@@ -4,10 +4,6 @@ public abstract class OSHDB {
 
   public static final int MAXZOOM = 14;
 
-  // osm only stores 7 decimals for each coordinate
-  public static final long GEOM_PRECISION_TO_LONG = 10000000L;
-  public static final double GEOM_PRECISION = 1.0 / GEOM_PRECISION_TO_LONG;
-
   /**
    * Returns various metadata properties of this OSHDB instance.
    *

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundable.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundable.java
@@ -1,32 +1,34 @@
 package org.heigit.ohsome.oshdb;
 
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
+
 /**
  * Interface for spatially boundable objects, i.e. objects which have a bounding box.
  */
 public interface OSHDBBoundable {
 
-  long getMinLonLong();
+  int getMinLon();
 
-  long getMinLatLong();
+  int getMinLat();
 
-  long getMaxLonLong();
+  int getMaxLon();
 
-  long getMaxLatLong();
+  int getMaxLat();
 
-  default double getMinLon() {
-    return getMinLonLong() * OSHDB.GEOM_PRECISION;
+  default double getMinLongitude() {
+    return OSMCoordinates.toDouble(getMinLon());
   }
 
-  default double getMinLat() {
-    return getMinLatLong() * OSHDB.GEOM_PRECISION;
+  default double getMinLatitude() {
+    return OSMCoordinates.toDouble(getMinLat());
   }
 
-  default double getMaxLon() {
-    return getMaxLonLong() * OSHDB.GEOM_PRECISION;
+  default double getMaxLongitude() {
+    return OSMCoordinates.toDouble(getMaxLon());
   }
 
-  default double getMaxLat() {
-    return getMaxLatLong() * OSHDB.GEOM_PRECISION;
+  default double getMaxLatitude() {
+    return OSMCoordinates.toDouble(getMaxLat());
   }
 
   /**
@@ -37,10 +39,10 @@ public interface OSHDBBoundable {
    */
   default boolean intersects(OSHDBBoundable other) {
     return other != null
-        && getMaxLatLong() >= other.getMinLatLong()
-        && getMinLatLong() <= other.getMaxLatLong()
-        && getMaxLonLong() >= other.getMinLonLong()
-        && getMinLonLong() <= other.getMaxLonLong();
+        && getMaxLat() >= other.getMinLat()
+        && getMinLat() <= other.getMaxLat()
+        && getMaxLon() >= other.getMinLon()
+        && getMinLon() <= other.getMaxLon();
   }
 
   /**
@@ -52,18 +54,18 @@ public interface OSHDBBoundable {
    */
   default boolean coveredBy(OSHDBBoundable other) {
     return other != null
-        && getMinLatLong() >= other.getMinLatLong()
-        && getMaxLatLong() <= other.getMaxLatLong()
-        && getMinLonLong() >= other.getMinLonLong()
-        && getMaxLonLong() <= other.getMaxLonLong();
+        && getMinLat() >= other.getMinLat()
+        && getMaxLat() <= other.getMaxLat()
+        && getMinLon() >= other.getMinLon()
+        && getMaxLon() <= other.getMaxLon();
   }
 
   default boolean isPoint() {
-    return getMinLonLong() == getMaxLonLong() && getMinLatLong() == getMaxLatLong();
+    return getMinLon() == getMaxLon() && getMinLat() == getMaxLat();
   }
 
   default boolean isValid() {
-    return getMinLonLong() <= getMaxLonLong() && getMinLatLong() <= getMaxLatLong();
+    return getMinLon() <= getMaxLon() && getMinLat() <= getMaxLat();
   }
 
   /**
@@ -73,10 +75,10 @@ public interface OSHDBBoundable {
    * @return the intersection of the two bboxes
    */
   default OSHDBBoundingBox intersection(OSHDBBoundable other) {
-    return new OSHDBBoundingBox(
-        Math.max(getMinLonLong(), other.getMinLonLong()),
-        Math.max(getMinLatLong(), other.getMinLatLong()),
-        Math.min(getMaxLonLong(), other.getMaxLonLong()),
-        Math.min(getMaxLatLong(), other.getMaxLatLong()));
+    return OSHDBBoundingBox.bboxOSMCoordinates(
+        Math.max(getMinLon(), other.getMinLon()),
+        Math.max(getMinLat(), other.getMinLat()),
+        Math.min(getMaxLon(), other.getMaxLon()),
+        Math.min(getMaxLat(), other.getMaxLat()));
   }
 }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundable.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundable.java
@@ -1,35 +1,37 @@
 package org.heigit.ohsome.oshdb;
 
-import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
-
 /**
  * Interface for spatially boundable objects, i.e. objects which have a bounding box.
  */
 public interface OSHDBBoundable {
 
-  int getMinLon();
+  /**
+   * Returns the minimum longitude in osm-coordinate-system.
+   *
+   * @return minimum longitude
+   */
+  int getMinLongitude();
 
-  int getMinLat();
+  /**
+   * Returns the minimum latitude in osm-coordinate-system.
+   *
+   * @return minimum latitude
+   */
+  int getMinLatitude();
 
-  int getMaxLon();
+  /**
+   * Returns the maximum longitude in osm-coordinate-system.
+   *
+   * @return maximum longitude
+   */
+  int getMaxLongitude();
 
-  int getMaxLat();
-
-  default double getMinLongitude() {
-    return OSMCoordinates.toDouble(getMinLon());
-  }
-
-  default double getMinLatitude() {
-    return OSMCoordinates.toDouble(getMinLat());
-  }
-
-  default double getMaxLongitude() {
-    return OSMCoordinates.toDouble(getMaxLon());
-  }
-
-  default double getMaxLatitude() {
-    return OSMCoordinates.toDouble(getMaxLat());
-  }
+  /**
+   * Returns the maximum latitude in osm-coordinate-system.
+   *
+   * @return maximum latitude
+   */
+  int getMaxLatitude();
 
   /**
    * Calculates the intersection between this and {@code other} {@code OSHDBBoundable}.
@@ -39,33 +41,43 @@ public interface OSHDBBoundable {
    */
   default boolean intersects(OSHDBBoundable other) {
     return other != null
-        && getMaxLat() >= other.getMinLat()
-        && getMinLat() <= other.getMaxLat()
-        && getMaxLon() >= other.getMinLon()
-        && getMinLon() <= other.getMaxLon();
+        && getMaxLatitude() >= other.getMinLatitude()
+        && getMinLatitude() <= other.getMaxLatitude()
+        && getMaxLongitude() >= other.getMinLongitude()
+        && getMinLongitude() <= other.getMaxLongitude();
   }
 
   /**
    * Returns true if this {@code OSHDBBoundable} is inside/coveredBy the {@code other} object.
    *
-   * @param other the {@code OSHDBBoundable} which is being checked for inside/coveredBy
-   *          this {@code OSHDBBoundable}
+   * @param other the {@code OSHDBBoundable} which is being checked for inside/coveredBy this
+   *        {@code OSHDBBoundable}
    * @return {@code true} if the {@code OSHDBBoundable} is inside
    */
   default boolean coveredBy(OSHDBBoundable other) {
     return other != null
-        && getMinLat() >= other.getMinLat()
-        && getMaxLat() <= other.getMaxLat()
-        && getMinLon() >= other.getMinLon()
-        && getMaxLon() <= other.getMaxLon();
+        && getMinLatitude() >= other.getMinLatitude()
+        && getMaxLatitude() <= other.getMaxLatitude()
+        && getMinLongitude() >= other.getMinLongitude()
+        && getMaxLongitude() <= other.getMaxLongitude();
   }
 
+  /**
+   * Checks if this {@link OSHDBBoundable} collapsed to a single point.
+   *
+   * @return true if collapsed to a single point
+   */
   default boolean isPoint() {
-    return getMinLon() == getMaxLon() && getMinLat() == getMaxLat();
+    return getMinLongitude() == getMaxLongitude() && getMinLatitude() == getMaxLatitude();
   }
 
+  /**
+   * Checks if this {@link OSHDBBoundable} describes a valid boundable.
+   *
+   * @return true, if this {@link OSHDBBoundable} is valid
+   */
   default boolean isValid() {
-    return getMinLon() <= getMaxLon() && getMinLat() <= getMaxLat();
+    return getMinLongitude() <= getMaxLongitude() && getMinLatitude() <= getMaxLatitude();
   }
 
   /**
@@ -76,9 +88,9 @@ public interface OSHDBBoundable {
    */
   default OSHDBBoundingBox intersection(OSHDBBoundable other) {
     return OSHDBBoundingBox.bboxOSMCoordinates(
-        Math.max(getMinLon(), other.getMinLon()),
-        Math.max(getMinLat(), other.getMinLat()),
-        Math.min(getMaxLon(), other.getMaxLon()),
-        Math.min(getMaxLat(), other.getMaxLat()));
+        Math.max(getMinLongitude(), other.getMinLongitude()),
+        Math.max(getMinLatitude(), other.getMinLatitude()),
+        Math.min(getMaxLongitude(), other.getMaxLongitude()),
+        Math.min(getMaxLatitude(), other.getMaxLatitude()));
   }
 }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundingBox.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundingBox.java
@@ -53,10 +53,29 @@ public class OSHDBBoundingBox implements OSHDBBoundable, Serializable {
    * @param maxLat maximum latitude in wgs84 coordinate system
    * @return new instance of {@link OSHDBBoundingBox}
    */
-  public static OSHDBBoundingBox bboxLonLatCoordinates(double minLon, double minLat, double maxLon,
+  public static OSHDBBoundingBox bboxWgs84Coordinates(double minLon, double minLat, double maxLon,
       double maxLat) {
     return bboxOSMCoordinates(
         Math.toIntExact(Math.round(minLon * GEOM_PRECISION_TO_LONG)),
+        Math.toIntExact(Math.round(minLat * GEOM_PRECISION_TO_LONG)),
+        Math.toIntExact(Math.round(maxLon * GEOM_PRECISION_TO_LONG)),
+        Math.toIntExact(Math.round(maxLat * GEOM_PRECISION_TO_LONG)));
+  }
+
+  /**
+   * Creates an {@code OSHDBBoundingBox} with wgs84 coordinates.
+   *
+   * @param minLon minimum longitude in wgs84 coordinate system
+   * @param minLat minimum latitude in wgs84 coordinate system
+   * @param maxLon maximum longitude in wgs84 coordinate system
+   * @param maxLat maximum latitude in wgs84 coordinate system
+   *
+   * @deprecated use {@link #bboxWgs84Coordinates(double, double, double, double)
+   *             bboxWgs84Coordinates} instead
+   */
+  @Deprecated(forRemoval = true, since = "0.7")
+  public OSHDBBoundingBox(double minLon, double minLat, double maxLon, double maxLat) {
+    this(Math.toIntExact(Math.round(minLon * GEOM_PRECISION_TO_LONG)),
         Math.toIntExact(Math.round(minLat * GEOM_PRECISION_TO_LONG)),
         Math.toIntExact(Math.round(maxLon * GEOM_PRECISION_TO_LONG)),
         Math.toIntExact(Math.round(maxLat * GEOM_PRECISION_TO_LONG)));

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundingBox.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundingBox.java
@@ -86,10 +86,10 @@ public class OSHDBBoundingBox implements OSHDBBoundable, Serializable {
   public String toString() {
     return String.format(Locale.ENGLISH,
         "(%3.7f,%3.7f,%3.7f,%3.7f)",
-        OSMCoordinates.toDouble(minLon),
-        OSMCoordinates.toDouble(minLat),
-        OSMCoordinates.toDouble(maxLon),
-        OSMCoordinates.toDouble(maxLat));
+        OSMCoordinates.toWgs84(minLon),
+        OSMCoordinates.toWgs84(minLat),
+        OSMCoordinates.toWgs84(maxLon),
+        OSMCoordinates.toWgs84(maxLat));
   }
 
   @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundingBox.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundingBox.java
@@ -5,9 +5,17 @@ import static org.heigit.ohsome.oshdb.osm.OSMCoordinates.GEOM_PRECISION_TO_LONG;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Objects;
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
 
+/**
+ * This class describes a BoundingBox with min/max longitude/latitude.
+ */
 public class OSHDBBoundingBox implements OSHDBBoundable, Serializable {
   private static final long serialVersionUID = 1L;
+
+  /**
+   * Singleton invalid bounding box.
+   */
   public static final OSHDBBoundingBox INVALID = bboxOSMCoordinates(1, 1, -1, -1);
 
   private final int minLon;
@@ -16,7 +24,13 @@ public class OSHDBBoundingBox implements OSHDBBoundable, Serializable {
   private final int maxLat;
 
   /**
-   * Creates an {@code OSHDBBoundingBox} instance from osm long coordinates.
+   * Creates an {@code OSHDBBoundingBox} instance from osm int coordinates.
+   *
+   * @param minLon minimum longitude in osm-coordinate system
+   * @param minLat minimum latitude in osm-coordinate system
+   * @param maxLon maximum longitude in osm-coordinate system
+   * @param maxLat maximum latitude in osm-coordinate system
+   * @return new instance of {@link OSHDBBoundingBox}
    */
   public static OSHDBBoundingBox bboxOSMCoordinates(int minLon, int minLat,
       int maxLon, int maxLat) {
@@ -31,7 +45,13 @@ public class OSHDBBoundingBox implements OSHDBBoundable, Serializable {
   }
 
   /**
-   * Create an {@code OSHDBBoudingBox} with standard double longitude/latitude coordinates.
+   * Creates an {@code OSHDBBoundingBox} with wgs84 coordinates.
+   *
+   * @param minLon minimum longitude in wgs84 coordinate system
+   * @param minLat minimum latitude in wgs84 coordinate system
+   * @param maxLon maximum longitude in wgs84 coordinate system
+   * @param maxLat maximum latitude in wgs84 coordinate system
+   * @return new instance of {@link OSHDBBoundingBox}
    */
   public static OSHDBBoundingBox bboxLonLatCoordinates(double minLon, double minLat, double maxLon,
       double maxLat) {
@@ -43,41 +63,33 @@ public class OSHDBBoundingBox implements OSHDBBoundable, Serializable {
   }
 
   @Override
-  public int getMinLon() {
+  public int getMinLongitude() {
     return minLon;
   }
 
   @Override
-  public int getMaxLon() {
+  public int getMaxLongitude() {
     return maxLon;
   }
 
   @Override
-  public int getMinLat() {
+  public int getMinLatitude() {
     return minLat;
   }
 
   @Override
-  public int getMaxLat() {
+  public int getMaxLatitude() {
     return maxLat;
-  }
-
-  public int[] getLon() {
-    return new int[] {minLon, maxLon};
-  }
-
-  public int[] getLat() {
-    return new int[] {minLat, maxLat};
   }
 
   @Override
   public String toString() {
     return String.format(Locale.ENGLISH,
         "(%3.7f,%3.7f,%3.7f,%3.7f)",
-        this.getMinLongitude(),
-        this.getMinLatitude(),
-        this.getMaxLongitude(),
-        this.getMaxLatitude());
+        OSMCoordinates.toDouble(minLon),
+        OSMCoordinates.toDouble(minLat),
+        OSMCoordinates.toDouble(maxLon),
+        OSMCoordinates.toDouble(maxLat));
   }
 
   @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundingBox.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBBoundingBox.java
@@ -1,87 +1,88 @@
 package org.heigit.ohsome.oshdb;
 
+import static org.heigit.ohsome.oshdb.osm.OSMCoordinates.GEOM_PRECISION_TO_LONG;
+
 import java.io.Serializable;
 import java.util.Locale;
+import java.util.Objects;
 
 public class OSHDBBoundingBox implements OSHDBBoundable, Serializable {
   private static final long serialVersionUID = 1L;
-  public static final OSHDBBoundingBox INVALID = new OSHDBBoundingBox(1L, 1L, -1L, -1L);
+  public static final OSHDBBoundingBox INVALID = bboxOSMCoordinates(1, 1, -1, -1);
 
-  private final long minLon;
-  private final long maxLon;
-  private final long minLat;
-  private final long maxLat;
+  private final int minLon;
+  private final int maxLon;
+  private final int minLat;
+  private final int maxLat;
 
   /**
    * Creates an {@code OSHDBBoundingBox} instance from osm long coordinates.
    */
-  public OSHDBBoundingBox(long minLon, long minLat, long maxLon, long maxLat) {
+  public static OSHDBBoundingBox bboxOSMCoordinates(int minLon, int minLat,
+      int maxLon, int maxLat) {
+    return new OSHDBBoundingBox(minLon, minLat, maxLon, maxLat);
+  }
+
+  private OSHDBBoundingBox(int minLon, int minLat, int maxLon, int maxLat) {
     this.minLon = minLon;
-    this.maxLon = maxLon;
     this.minLat = minLat;
+    this.maxLon = maxLon;
     this.maxLat = maxLat;
   }
 
   /**
    * Create an {@code OSHDBBoudingBox} with standard double longitude/latitude coordinates.
    */
-  public OSHDBBoundingBox(double minLon, double minLat, double maxLon, double maxLat) {
-    this.minLon = Math.round(minLon * OSHDB.GEOM_PRECISION_TO_LONG);
-    this.maxLon = Math.round(maxLon * OSHDB.GEOM_PRECISION_TO_LONG);
-    this.minLat = Math.round(minLat * OSHDB.GEOM_PRECISION_TO_LONG);
-    this.maxLat = Math.round(maxLat * OSHDB.GEOM_PRECISION_TO_LONG);
-  }
-
-  public OSHDBBoundingBox(int minLon, int minLat, int maxLon, int maxLat) {
-    this((double) minLon, (double) minLat, (double) maxLon, (double) maxLat);
+  public static OSHDBBoundingBox bboxLonLatCoordinates(double minLon, double minLat, double maxLon,
+      double maxLat) {
+    return bboxOSMCoordinates(
+        Math.toIntExact(Math.round(minLon * GEOM_PRECISION_TO_LONG)),
+        Math.toIntExact(Math.round(minLat * GEOM_PRECISION_TO_LONG)),
+        Math.toIntExact(Math.round(maxLon * GEOM_PRECISION_TO_LONG)),
+        Math.toIntExact(Math.round(maxLat * GEOM_PRECISION_TO_LONG)));
   }
 
   @Override
-  public long getMinLonLong() {
+  public int getMinLon() {
     return minLon;
   }
 
   @Override
-  public long getMaxLonLong() {
+  public int getMaxLon() {
     return maxLon;
   }
 
   @Override
-  public long getMinLatLong() {
+  public int getMinLat() {
     return minLat;
   }
 
   @Override
-  public long getMaxLatLong() {
+  public int getMaxLat() {
     return maxLat;
   }
 
-  public long[] getLon() {
-    return new long[] {minLon, maxLon};
+  public int[] getLon() {
+    return new int[] {minLon, maxLon};
   }
 
-  public long[] getLat() {
-    return new long[] {minLat, maxLat};
+  public int[] getLat() {
+    return new int[] {minLat, maxLat};
   }
 
   @Override
   public String toString() {
     return String.format(Locale.ENGLISH,
         "(%3.7f,%3.7f,%3.7f,%3.7f)",
-        this.getMinLon(),
-        this.getMinLat(),
-        this.getMaxLon(),
-        this.getMaxLat());
+        this.getMinLongitude(),
+        this.getMinLatitude(),
+        this.getMaxLongitude(),
+        this.getMaxLatitude());
   }
 
   @Override
   public int hashCode() {
-    int hash = 7;
-    hash = 79 * hash + (int) (this.minLon ^ this.minLon >>> 32);
-    hash = 79 * hash + (int) (this.maxLon ^ this.maxLon >>> 32);
-    hash = 79 * hash + (int) (this.minLat ^ this.minLat >>> 32);
-    hash = 79 * hash + (int) (this.maxLat ^ this.maxLat >>> 32);
-    return hash;
+    return Objects.hash(maxLat, maxLon, minLat, minLon);
   }
 
   @Override
@@ -89,22 +90,11 @@ public class OSHDBBoundingBox implements OSHDBBoundable, Serializable {
     if (this == obj) {
       return true;
     }
-    if (obj == null) {
+    if (!(obj instanceof OSHDBBoundingBox)) {
       return false;
     }
-    if (getClass() != obj.getClass()) {
-      return false;
-    }
-    final OSHDBBoundingBox other = (OSHDBBoundingBox) obj;
-    if (this.minLon != other.minLon) {
-      return false;
-    }
-    if (this.maxLon != other.maxLon) {
-      return false;
-    }
-    if (this.minLat != other.minLat) {
-      return false;
-    }
-    return this.maxLat == other.maxLat;
+    OSHDBBoundingBox other = (OSHDBBoundingBox) obj;
+    return maxLat == other.maxLat && maxLon == other.maxLon && minLat == other.minLat
+        && minLon == other.minLon;
   }
 }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
@@ -16,8 +16,8 @@ public abstract class GridOSHEntity
 
   protected final long baseTimestamp;
 
-  protected final long baseLongitude;
-  protected final long baseLatitude;
+  protected final int baseLongitude;
+  protected final int baseLatitude;
 
   protected final long baseId;
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
@@ -56,9 +56,7 @@ public abstract class GridOSHEntity
   public String toString() {
     if (id >= 0) {
       OSHDBBoundingBox bbox = XYGrid.getBoundingBox(new CellId((int) id, level));
-      return String.format(Locale.ENGLISH, "ID:%d Level:%d BBox:(%f,%f),(%f,%f)", id, level,
-          bbox.getMinLatitude(), bbox.getMinLongitude(), bbox.getMaxLatitude(),
-          bbox.getMaxLongitude());
+      return String.format(Locale.ENGLISH, "ID:%d Level:%d %s", id, level, bbox);
     } else {
       return String.format(Locale.ENGLISH, "ID:%d Level:%d", id, level);
     }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
@@ -16,8 +16,8 @@ public abstract class GridOSHEntity
 
   protected final long baseTimestamp;
 
-  protected final int baseLongitude;
-  protected final int baseLatitude;
+  protected final long baseLongitude;
+  protected final long baseLatitude;
 
   protected final long baseId;
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
@@ -27,8 +27,9 @@ public abstract class GridOSHEntity
   /**
    * Base constructor {@code GridOSHEntity}.
    */
-  public GridOSHEntity(final long id, final int level, final long baseId, final long baseTimestamp,
-      final long baseLongitude, final long baseLatitude, final int[] index, final byte[] data) {
+  protected GridOSHEntity(final long id, final int level, final long baseId,
+      final long baseTimestamp, final int baseLongitude, final int baseLatitude, final int[] index,
+      final byte[] data) {
 
     this.id = id;
     this.level = level;
@@ -56,7 +57,8 @@ public abstract class GridOSHEntity
     if (id >= 0) {
       OSHDBBoundingBox bbox = XYGrid.getBoundingBox(new CellId((int) id, level));
       return String.format(Locale.ENGLISH, "ID:%d Level:%d BBox:(%f,%f),(%f,%f)", id, level,
-          bbox.getMinLat(), bbox.getMinLon(), bbox.getMaxLat(), bbox.getMaxLon());
+          bbox.getMinLatitude(), bbox.getMinLongitude(), bbox.getMaxLatitude(),
+          bbox.getMaxLongitude());
     } else {
       return String.format(Locale.ENGLISH, "ID:%d Level:%d", id, level);
     }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHNodes.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHNodes.java
@@ -69,8 +69,8 @@ public class GridOSHNodes extends GridOSHEntity implements Iterable<OSHNode> {
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHNodeImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
-            baseLatitude);
+        return OSHNodeImpl.instance(data, offset, length, baseId, baseTimestamp,
+            (int) baseLongitude, (int) baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHNodes.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHNodes.java
@@ -1,7 +1,6 @@
 package org.heigit.ohsome.oshdb.grid;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
@@ -17,10 +16,19 @@ public class GridOSHNodes extends GridOSHEntity implements Iterable<OSHNode> {
 
   /**
    * Create a new {@code GridOSHNode} while rebasing the input nodes.
+   *
+   * @param id the grid id
+   * @param level zoom level
+   * @param baseId base of id for compact entities
+   * @param baseTimestamp base of timemstamps for compact entities
+   * @param baseLongitude base of longitude for compact entities
+   * @param baseLatitude base of latitued for compact entities
+   * @param list list of entities
+   * @return new instance of this grid
    */
   public static GridOSHNodes rebase(final long id, final int level, final long baseId,
-      final long baseTimestamp, final long baseLongitude, final long baseLatitude,
-      final List<OSHNode> list) throws IOException {
+      final long baseTimestamp, final int baseLongitude, final int baseLatitude,
+      final List<OSHNode> list) {
 
     int offset = 0;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
@@ -39,7 +47,7 @@ public class GridOSHNodes extends GridOSHEntity implements Iterable<OSHNode> {
   }
 
   private GridOSHNodes(final long id, final int level, final long baseId, final long baseTimestamp,
-      final long baseLongitude, final long baseLatitude, final int[] index, final byte[] data) {
+      final int baseLongitude, final int baseLatitude, final int[] index, final byte[] data) {
     super(id, level, baseId, baseTimestamp, baseLongitude, baseLatitude, index, data);
   }
 
@@ -61,8 +69,8 @@ public class GridOSHNodes extends GridOSHEntity implements Iterable<OSHNode> {
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHNodeImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
-            baseLatitude);
+        return OSHNodeImpl.instance(data, offset, length, baseId, baseTimestamp,
+            (int) baseLongitude, (int) baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHNodes.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHNodes.java
@@ -69,8 +69,8 @@ public class GridOSHNodes extends GridOSHEntity implements Iterable<OSHNode> {
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHNodeImpl.instance(data, offset, length, baseId, baseTimestamp,
-            (int) baseLongitude, (int) baseLatitude);
+        return OSHNodeImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
+            baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHRelations.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHRelations.java
@@ -70,8 +70,8 @@ public class GridOSHRelations extends GridOSHEntity implements Iterable<OSHRelat
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHRelationImpl.instance(data, offset, length, baseId, baseTimestamp,
-            (int) baseLongitude, (int) baseLatitude);
+        return OSHRelationImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
+            baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHRelations.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHRelations.java
@@ -70,8 +70,8 @@ public class GridOSHRelations extends GridOSHEntity implements Iterable<OSHRelat
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHRelationImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
-            baseLatitude);
+        return OSHRelationImpl.instance(data, offset, length, baseId, baseTimestamp,
+            (int) baseLongitude, (int) baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHRelations.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHRelations.java
@@ -1,7 +1,6 @@
 package org.heigit.ohsome.oshdb.grid;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
@@ -17,15 +16,23 @@ public class GridOSHRelations extends GridOSHEntity implements Iterable<OSHRelat
 
   /**
    * Creates a new {@code GridOSHRelations} while rebase/compacting the input relations.
+   *
+   * @param id the grid id
+   * @param level zoom level
+   * @param baseId base of id for compact entities
+   * @param baseTimestamp base of timemstamps for compact entities
+   * @param baseLongitude base of longitude for compact entities
+   * @param baseLatitude base of latitued for compact entities
+   * @param list list of entities
+   * @return new instance of this grid
    */
   public static GridOSHRelations compact(final long id, final int level, final long baseId,
-          final long baseTimestamp, final long baseLongitude, final long baseLatitude,
-          final List<OSHRelation> list) throws IOException {
+          final long baseTimestamp, final int baseLongitude, final int baseLatitude,
+          final List<OSHRelation> list) {
 
     int offset = 0;
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final int[] index = new int[list.size()];
-    // TODO user iterator!!
     for (int i = 0; i < index.length; i++) {
       final OSHRelation osh = list.get(i);
       final ByteBuffer buffer = OSHRelationImpl.buildRecord(OSHEntities.toList(osh.getVersions()),
@@ -40,7 +47,7 @@ public class GridOSHRelations extends GridOSHEntity implements Iterable<OSHRelat
   }
 
   private GridOSHRelations(final long id, final int level, final long baseId,
-      final long baseTimestamp, final long baseLongitude, final long baseLatitude,
+      final long baseTimestamp, final int baseLongitude, final int baseLatitude,
       final int[] index, final byte[] data) {
     super(id, level, baseId, baseTimestamp, baseLongitude, baseLatitude, index, data);
   }
@@ -63,8 +70,8 @@ public class GridOSHRelations extends GridOSHEntity implements Iterable<OSHRelat
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHRelationImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
-            baseLatitude);
+        return OSHRelationImpl.instance(data, offset, length, baseId, baseTimestamp,
+            (int) baseLongitude, (int) baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHWays.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHWays.java
@@ -68,8 +68,8 @@ public class GridOSHWays extends GridOSHEntity implements Iterable<OSHWay> {
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHWayImpl.instance(data, offset, length, baseId, baseTimestamp,
-            (int) baseLongitude, (int) baseLatitude);
+        return OSHWayImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
+            baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHWays.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHWays.java
@@ -68,8 +68,8 @@ public class GridOSHWays extends GridOSHEntity implements Iterable<OSHWay> {
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHWayImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
-            baseLatitude);
+        return OSHWayImpl.instance(data, offset, length, baseId, baseTimestamp, (int) baseLongitude,
+            (int) baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHWays.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHWays.java
@@ -1,7 +1,6 @@
 package org.heigit.ohsome.oshdb.grid;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.List;
@@ -17,10 +16,19 @@ public class GridOSHWays extends GridOSHEntity implements Iterable<OSHWay> {
 
   /**
    * Creates a new {@code GridOSHWays} while rebase/compacting the input ways.
+   *
+   * @param id the grid id
+   * @param level zoom level
+   * @param baseId base of id for compact entities
+   * @param baseTimestamp base of timemstamps for compact entities
+   * @param baseLongitude base of longitude for compact entities
+   * @param baseLatitude base of latitued for compact entities
+   * @param list list of entities
+   * @return new instance of this grid
    */
   public static GridOSHWays compact(final long id, final int level, final long baseId,
-      final long baseTimestamp, final long baseLongitude, final long baseLatitude,
-      final List<OSHWay> list) throws IOException {
+      final long baseTimestamp, final int baseLongitude, final int baseLatitude,
+      final List<OSHWay> list) {
     final ByteArrayOutputStream out = new ByteArrayOutputStream();
     final int[] index = new int[list.size()];
     int offset = 0;
@@ -38,7 +46,7 @@ public class GridOSHWays extends GridOSHEntity implements Iterable<OSHWay> {
   }
 
   public GridOSHWays(final long id, final int level, final long baseId, final long baseTimestamp,
-      final long baseLongitude, final long baseLatitude, final int[] index, final byte[] data) {
+      final int baseLongitude, final int baseLatitude, final int[] index, final byte[] data) {
     super(id, level, baseId, baseTimestamp, baseLongitude, baseLatitude, index, data);
   }
 
@@ -60,8 +68,8 @@ public class GridOSHWays extends GridOSHEntity implements Iterable<OSHWay> {
         int offset = index[pos];
         int length = (pos < index.length - 1 ? index[pos + 1] : data.length) - offset;
         pos++;
-        return OSHWayImpl.instance(data, offset, length, baseId, baseTimestamp, baseLongitude,
-            baseLatitude);
+        return OSHWayImpl.instance(data, offset, length, baseId, baseTimestamp,
+            (int) baseLongitude, (int) baseLatitude);
       }
 
       @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
@@ -321,6 +321,32 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
     this.dataOffset = p.getDataOffset();
     this.dataLength = p.getDataLength();
   }
+  
+  @Deprecated
+  protected OSHEntityImpl(final byte[] data, final int offset, final int length,
+      final long baseTimestamp, final long baseLongitude, final long baseLatitude,
+      final byte header, final long id, long minLon, long minLat, long maxLon, long maxLat,
+      final int[] keys, final int dataOffset, final int dataLength) {
+    this.data = data;
+    this.offset = offset;
+    this.length = length;
+
+    this.baseId = 0;
+    this.baseTimestamp = baseTimestamp;
+    this.baseLongitude = Math.toIntExact(baseLongitude);
+    this.baseLatitude = Math.toIntExact(baseLatitude);
+
+    this.header = header;
+    this.id = id;
+    this.minLon = Math.toIntExact(minLon);
+    this.minLat = Math.toIntExact(minLat);
+    this.maxLon = Math.toIntExact(maxLon);
+    this.maxLat = Math.toIntExact(maxLat);
+
+    this.keys = keys;
+    this.dataOffset = dataOffset;
+    this.dataLength = dataLength;
+  }
 
   /**
    * Return the underlying data/byte array and creates a copy if necessary.

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
@@ -321,7 +321,6 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
     this.dataOffset = p.getDataOffset();
     this.dataLength = p.getDataLength();
   }
-  
   @Deprecated
   protected OSHEntityImpl(final byte[] data, final int offset, final int length,
       final long baseTimestamp, final long baseLongitude, final long baseLatitude,

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
@@ -13,6 +13,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.Nonnull;
 import org.heigit.ohsome.oshdb.osh.OSHEntity;
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
 import org.heigit.ohsome.oshdb.util.bytearray.ByteArrayOutputWrapper;
@@ -343,22 +344,22 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
   }
 
   @Override
-  public int getMinLon() {
+  public int getMinLongitude() {
     return minLon;
   }
 
   @Override
-  public int getMinLat() {
+  public int getMinLatitude() {
     return minLat;
   }
 
   @Override
-  public int getMaxLon() {
+  public int getMaxLongitude() {
     return maxLon;
   }
 
   @Override
-  public int getMaxLat() {
+  public int getMaxLatitude() {
     return maxLat;
   }
 
@@ -436,8 +437,11 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
     }
 
     return String.format(Locale.ENGLISH, "ID:%d Vmax:+%d+ Creation:%d BBox:(%f,%f),(%f,%f)", id,
-        last.getVersion(), first.getEpochSecond(), getMinLatitude(), getMinLongitude(),
-        getMaxLatitude(), getMaxLongitude());
+        last.getVersion(), first.getEpochSecond(),
+        OSMCoordinates.toDouble(minLat),
+        OSMCoordinates.toDouble(minLon),
+        OSMCoordinates.toDouble(maxLat),
+        OSMCoordinates.toDouble(maxLon));
   }
 
   protected static void readBbox(ByteArrayWrapper wrapper, CommonEntityProps p, int baseLongitude,

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
@@ -28,7 +28,7 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
   protected static final int HEADER_TIMESTAMPS_NOT_IN_ORDER = 1 << 1;
   protected static final int HEADER_HAS_TAGS = 1 << 2;
 
-  public static class Builder {
+  protected static class Builder {
 
     private final ByteArrayOutputWrapper output;
     private final long baseTimestamp;
@@ -103,7 +103,7 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
       firstVersion = false;
     }
 
-    public byte getHeader(boolean multiVersion) {
+    protected byte getHeader(boolean multiVersion) {
       byte header = 0;
       if (multiVersion) {
         header |= HEADER_MULTIVERSION;
@@ -117,7 +117,7 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
       return header;
     }
 
-    public ByteArrayOutputWrapper writeCommon(byte header, long id, boolean bbox, int minLon,
+    protected ByteArrayOutputWrapper writeCommon(byte header, long id, boolean bbox, int minLon,
         int minLat, int maxLon, int maxLat) {
       var buffer = new ByteArrayOutputWrapper();
       buffer.writeByte(header);
@@ -321,6 +321,7 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
     this.dataOffset = p.getDataOffset();
     this.dataLength = p.getDataLength();
   }
+
   @Deprecated
   protected OSHEntityImpl(final byte[] data, final int offset, final int length,
       final long baseTimestamp, final long baseLongitude, final long baseLatitude,
@@ -463,10 +464,10 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
 
     return String.format(Locale.ENGLISH, "ID:%d Vmax:+%d+ Creation:%d BBox:(%f,%f),(%f,%f)", id,
         last.getVersion(), first.getEpochSecond(),
-        OSMCoordinates.toDouble(minLat),
-        OSMCoordinates.toDouble(minLon),
-        OSMCoordinates.toDouble(maxLat),
-        OSMCoordinates.toDouble(maxLon));
+        OSMCoordinates.toWgs84(minLat),
+        OSMCoordinates.toWgs84(minLon),
+        OSMCoordinates.toWgs84(maxLat),
+        OSMCoordinates.toWgs84(maxLon));
   }
 
   protected static void readBbox(ByteArrayWrapper wrapper, CommonEntityProps p, int baseLongitude,

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHNodeImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHNodeImpl.java
@@ -1,15 +1,10 @@
 package org.heigit.ohsome.oshdb.impl.osh;
 
-import java.io.Externalizable;
-import java.io.IOException;
-import java.io.ObjectInput;
-import java.io.ObjectOutput;
 import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import org.heigit.ohsome.oshdb.osh.OSHNode;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.osm.OSMNode;
@@ -24,13 +19,7 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
 
   private static final long serialVersionUID = 1L;
 
-  private static final int CHANGED_USER_ID = 1 << 0;
-  private static final int CHANGED_TAGS = 1 << 1;
   private static final int CHANGED_LOCATION = 1 << 2;
-
-  private static final int HEADER_MULTIVERSION = 1 << 0;
-  private static final int HEADER_TIMESTAMPS_NOT_IN_ORDER = 1 << 1;
-  private static final int HEADER_HAS_TAGS = 1 << 2;
   private static final int HEADER_HAS_BOUNDINGBOX = 1 << 3;
 
   public static OSHNodeImpl instance(final byte[] data, final int offset, final int length) {
@@ -41,62 +30,38 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
    * Creates an instances of {@code OSHNodeImpl} from the given byte array.
    */
   public static OSHNodeImpl instance(final byte[] data, final int offset, final int length,
-      final long baseNodeId, final long baseTimestamp, final long baseLongitude,
-      final long baseLatitude) {
-
-    ByteArrayWrapper wrapper = ByteArrayWrapper.newInstance(data, offset, length);
-    // header holds data on bitlevel and can then be compared to stereotypical
-    // bitcombinations (e.g. this.HEADER_HAS_TAGS)
-    final byte header = wrapper.readRawByte();
-    final long minLon;
-    final long minLat;
-    final long maxLon;
-    final long maxLat;
-    if ((header & HEADER_HAS_BOUNDINGBOX) != 0) {
-      minLon = baseLongitude + wrapper.readS64();
-      maxLon = minLon + wrapper.readU64();
-      minLat = baseLatitude + wrapper.readS64();
-      maxLat = minLat + wrapper.readU64();
+      final long baseNodeId, final long baseTimestamp, final int baseLongitude,
+      final int baseLatitude) {
+    var wrapper = ByteArrayWrapper.newInstance(data, offset, length);
+    var commonProps = new CommonEntityProps(data, offset, length);
+    commonProps.setHeader(wrapper.readRawByte());
+    if ((commonProps.getHeader() & HEADER_HAS_BOUNDINGBOX) != 0) {
+      readBbox(wrapper, commonProps, baseLongitude, baseLatitude);
     } else {
-      minLon = 1;
-      minLat = 1;
-      maxLon = -1;
-      maxLat = -1;
+      commonProps.setMinLon(1);
+      commonProps.setMinLat(1);
+      commonProps.setMaxLon(-1);
+      commonProps.setMaxLat(-1);
     }
-    final int[] keys;
-    if ((header & HEADER_HAS_TAGS) != 0) {
-      final int size = wrapper.readU32();
-      keys = new int[size];
-      for (int i = 0; i < size; i++) {
-        keys[i] = wrapper.readU32();
-      }
-    } else {
-      keys = new int[0];
-    }
-    final long id = wrapper.readU64() + baseNodeId;
-    final int dataOffset = wrapper.getPos();
-
-    // TODO do we need dataLength?
-    // TODO maybe better to store number of versions instead
-    final int dataLength = length - (dataOffset - offset);
-
-    return new OSHNodeImpl(data, offset, length, baseTimestamp, baseLongitude,
-        baseLatitude, header, id, minLon, minLat, maxLon, maxLat, keys, dataOffset, dataLength);
+    readBaseAndKeys(wrapper, commonProps, baseNodeId, baseTimestamp, baseLongitude, baseLatitude);
+    commonProps.setDataOffset(wrapper.getPos());
+    commonProps.setDataLength(length - (commonProps.getDataOffset() - offset));
+    return new OSHNodeImpl(commonProps);
   }
 
-  private OSHNodeImpl(final byte[] data, final int offset, final int length,
-      final long baseTimestamp, final long baseLongitude, final long baseLatitude,
-      final byte header, final long id, long minLon, long minLat, long maxLon, long maxLat,
-      final int[] keys, final int dataOffset, final int dataLength) {
-    super(data, offset, length, baseTimestamp, baseLongitude, baseLatitude, header, id,
-        minLon, minLat, maxLon, maxLat, keys, dataOffset, dataLength);
+  private OSHNodeImpl(final CommonEntityProps p) {
+    super(p);
 
+    this.minLon = p.getMinLon();
+    this.minLat = p.getMinLat();
+    this.maxLon = p.getMaxLon();
+    this.maxLat = p.getMaxLat();
     // correct bbox!
     if (!(minLon <= maxLon && minLat <= maxLat)) {
-      minLon = Long.MAX_VALUE;
-      maxLon = Long.MIN_VALUE;
-      minLat = Long.MAX_VALUE;
-      maxLat = Long.MIN_VALUE;
+      minLon = Integer.MAX_VALUE;
+      maxLon = Integer.MIN_VALUE;
+      minLat = Integer.MAX_VALUE;
+      maxLat = Integer.MIN_VALUE;
       for (OSMNode osm : this) {
         if (osm.isVisible()) {
           minLon = Math.min(minLon, osm.getLon());
@@ -106,11 +71,6 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
           maxLat = Math.max(maxLat, osm.getLat());
         }
       }
-
-      this.minLon = minLon;
-      this.minLat = minLat;
-      this.maxLon = maxLon;
-      this.maxLat = maxLat;
     }
   }
 
@@ -126,59 +86,11 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
 
   @Override
   public Iterator<OSMNode> iterator() {
-    return new Iterator<>() {
-      ByteArrayWrapper wrapper = ByteArrayWrapper.newInstance(data, dataOffset, dataLength);
-
-      int version = 0;
-      long timestamp = 0;
-      long changeset = 0;
-      int userId = 0;
-      int[] keyValues = new int[0];
-
-      private long longitude = 0;
-      private long latitude = 0;
-
-      @Override
-      public boolean hasNext() {
-        return wrapper.hasLeft() > 0;
-      }
-
-      @Override
-      public OSMNode next() {
-        if (!hasNext()) {
-          throw new NoSuchElementException();
-        }
-
-        version = wrapper.readS32() + version;
-        timestamp = wrapper.readS64() + timestamp;
-        changeset = wrapper.readS64() + changeset;
-
-        var changed = wrapper.readRawByte();
-
-        if ((changed & CHANGED_USER_ID) != 0) {
-          userId = wrapper.readS32() + userId;
-        }
-
-        if ((changed & CHANGED_TAGS) != 0) {
-          int size = wrapper.readU32();
-          keyValues = new int[size];
-          for (int i = 0; i < size; i++) {
-            keyValues[i] = wrapper.readU32();
-          }
-        }
-
-        if ((changed & CHANGED_LOCATION) != 0) {
-          longitude = wrapper.readS64() + longitude;
-          latitude = wrapper.readS64() + latitude;
-        }
-
-        return new OSMNode(id, version, baseTimestamp + timestamp, changeset, userId, keyValues,
-            version > 0 ? baseLongitude + longitude : 0, version > 0 ? baseLatitude + latitude : 0);
-      }
-    };
+    var wrapper = ByteArrayWrapper.newInstance(data, dataOffset, dataLength);
+    return new VersionIterator(wrapper, id, baseTimestamp, baseLongitude, baseLatitude);
   }
 
-  public static OSHNodeImpl build(List<OSMNode> versions) throws IOException {
+  public static OSHNodeImpl build(List<OSMNode> versions) {
     return build(versions, 0, 0, 0, 0);
   }
 
@@ -186,8 +98,7 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
    * Creates a {@code OSHNode} bases on the given list of node versions.
    */
   public static OSHNodeImpl build(List<OSMNode> versions, final long baseId,
-      final long baseTimestamp, final long baseLongitude, final long baseLatitude)
-      throws IOException {
+      final long baseTimestamp, final int baseLongitude, final int baseLatitude) {
     ByteBuffer bb = buildRecord(versions, baseId, baseTimestamp, baseLongitude, baseLatitude);
 
     return OSHNodeImpl.instance(bb.array(), 0, bb.remaining(), baseId, baseTimestamp, baseLongitude,
@@ -199,17 +110,16 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
    * ByteBuffer instead of an instance of {@code OSHNode}.
    */
   public static ByteBuffer buildRecord(List<OSMNode> versions, final long baseId,
-      final long baseTimestamp, final long baseLongitude, final long baseLatitude)
-      throws IOException {
+      final long baseTimestamp, final int baseLongitude, final int baseLatitude) {
     Collections.sort(versions, Collections.reverseOrder());
 
-    long lastLongitude = baseLongitude;
-    long lastLatitude = baseLatitude;
+    int lastLongitude = baseLongitude;
+    int lastLatitude = baseLatitude;
 
-    long minLon = Long.MAX_VALUE;
-    long maxLon = Long.MIN_VALUE;
-    long minLat = Long.MAX_VALUE;
-    long maxLat = Long.MIN_VALUE;
+    int minLon = Integer.MAX_VALUE;
+    int maxLon = Integer.MIN_VALUE;
+    int minLat = Integer.MAX_VALUE;
+    int maxLat = Integer.MIN_VALUE;
 
     ByteArrayOutputWrapper output = new ByteArrayOutputWrapper();
     Builder builder = new Builder(output, baseTimestamp);
@@ -225,9 +135,9 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
       }
       builder.build(version, changed);
       if ((changed & CHANGED_LOCATION) != 0) {
-        output.writeS64(node.getLon() - baseLongitude - (lastLongitude - baseLongitude));
+        output.writeS32(node.getLon() - baseLongitude - (lastLongitude - baseLongitude));
         lastLongitude = node.getLon();
-        output.writeS64(node.getLat() - baseLatitude - (lastLatitude - baseLatitude));
+        output.writeS32(node.getLat() - baseLatitude - (lastLatitude - baseLatitude));
         lastLatitude = node.getLat();
 
         minLon = Math.min(minLon, lastLongitude);
@@ -238,42 +148,19 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
       }
     } // for versions
 
-    byte header = 0;
-    if (versions.size() > 1) {
-      header |= HEADER_MULTIVERSION;
-    }
-    if (builder.getTimestampsNotInOrder()) {
-      header |= HEADER_TIMESTAMPS_NOT_IN_ORDER;
-    }
-    if (builder.getKeySet().size() > 0) {
-      header |= HEADER_HAS_TAGS;
-    }
-
+    byte header = builder.getHeader(versions.size() > 1);
     if (minLon != maxLon || minLat != maxLat) {
       header |= HEADER_HAS_BOUNDINGBOX;
     }
 
-    ByteArrayOutputWrapper record = new ByteArrayOutputWrapper();
-    record.writeByte(header);
-    if ((header & HEADER_HAS_BOUNDINGBOX) != 0) {
-      record.writeS64(minLon - baseLongitude);
-      record.writeU64(maxLon - minLon);
-      record.writeS64(minLat - baseLatitude);
-      record.writeU64(maxLat - minLat);
-    }
+    var buffer = builder.writeCommon(header, versions.get(0).getId() - baseId,
+        (header & HEADER_HAS_BOUNDINGBOX) != 0,
+        minLon - baseLongitude,
+        minLat  - baseLatitude,
+        maxLon, maxLat);
 
-    if ((header & HEADER_HAS_TAGS) != 0) {
-      record.writeU32(builder.getKeySet().size());
-      for (Integer key : builder.getKeySet()) {
-        record.writeU32(key.intValue());
-      }
-    }
-
-    long id = versions.get(0).getId();
-    record.writeU64(id - baseId);
-    record.writeByteArray(output.array(), 0, output.length());
-
-    return ByteBuffer.wrap(record.array(), 0, record.length());
+    buffer.writeByteArray(output.array(), 0, output.length());
+    return ByteBuffer.wrap(buffer.array(), 0, buffer.length());
   }
 
   public boolean hasTags() {
@@ -284,34 +171,45 @@ public class OSHNodeImpl extends OSHEntityImpl implements OSHNode, Iterable<OSMN
     return new SerializationProxy(this);
   }
 
-  private static class SerializationProxy implements Externalizable {
+  private static class VersionIterator extends EntityVersionIterator<OSMNode> {
+    private final int baseLongitude;
+    private final int baseLatitude;
+    private int longitude = 0;
+    private int latitude = 0;
 
-    private final OSHNodeImpl node;
-    private byte[] data;
+    private VersionIterator(ByteArrayWrapper wrapper, long id, long baseTimestamp,
+        int baseLongitude, int baseLatitude) {
+      super(wrapper, id, baseTimestamp);
+      this.baseLongitude = baseLongitude;
+      this.baseLatitude = baseLatitude;
+    }
 
-    public SerializationProxy(OSHNodeImpl node) {
-      this.node = node;
+    @Override
+    protected OSMNode extension(byte changed) {
+      if ((changed & CHANGED_LOCATION) != 0) {
+        longitude = wrapper.readS32() + longitude;
+        latitude = wrapper.readS32() + latitude;
+      }
+
+      return new OSMNode(id, version, baseTimestamp + timestamp, changeset, userId, keyValues,
+          version > 0 ? baseLongitude + longitude : 0, version > 0 ? baseLatitude + latitude : 0);
+    }
+  }
+
+  private static class SerializationProxy extends OSHEntitySerializationProxy {
+    public SerializationProxy(OSHNodeImpl osh) {
+      super(osh);
     }
 
     public SerializationProxy() {
-      this.node = null;
+      super(null);
     }
 
     @Override
-    public void writeExternal(ObjectOutput out) throws IOException {
-      out.writeInt(node.getLength());
-      node.writeTo(out);
-    }
-
-    @Override
-    public void readExternal(ObjectInput in) throws IOException, ClassNotFoundException {
-      int length = in.readInt();
-      data = new byte[length];
-      in.readFully(data);
-    }
-
-    private Object readResolve() {
-      return OSHNodeImpl.instance(data, 0, data.length);
+    protected Object newInstance(byte[] data, long id, long baseTimestamp, int baseLongitude,
+        int baseLatitude) {
+      return OSHNodeImpl.instance(data, 0, data.length, id, baseTimestamp, baseLongitude,
+          baseLatitude);
     }
   }
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHRelationImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHRelationImpl.java
@@ -207,10 +207,10 @@ public class OSHRelationImpl extends OSHEntityImpl
     for (OSHNode node : nodes) {
       OSHDBBoundable bbox = node;
       if (bbox.isValid()) {
-        minLon = Math.min(minLon, bbox.getMinLon());
-        maxLon = Math.max(maxLon, bbox.getMaxLon());
-        minLat = Math.min(minLat, bbox.getMinLat());
-        maxLat = Math.max(maxLat, bbox.getMaxLat());
+        minLon = Math.min(minLon, bbox.getMinLongitude());
+        maxLon = Math.max(maxLon, bbox.getMaxLongitude());
+        minLat = Math.min(minLat, bbox.getMinLatitude());
+        maxLat = Math.max(maxLat, bbox.getMaxLatitude());
       } else {
         Iterator<OSMNode> osmItr = node.getVersions().iterator();
         while (osmItr.hasNext()) {
@@ -241,10 +241,10 @@ public class OSHRelationImpl extends OSHEntityImpl
     offset = 0;
     for (OSHWay way : ways) {
       OSHDBBoundable bbox = way;
-      minLon = Math.min(minLon, bbox.getMinLon());
-      maxLon = Math.max(maxLon, bbox.getMaxLon());
-      minLat = Math.min(minLat, bbox.getMinLat());
-      maxLat = Math.max(maxLat, bbox.getMaxLat());
+      minLon = Math.min(minLon, bbox.getMinLongitude());
+      maxLon = Math.max(maxLon, bbox.getMaxLongitude());
+      minLat = Math.min(minLat, bbox.getMinLatitude());
+      maxLat = Math.max(maxLat, bbox.getMaxLatitude());
 
       ByteBuffer buffer = OSHWayImpl.buildRecord(OSHEntities.toList(way.getVersions()),
           way.getNodes(), 0, 0, baseLongitude, baseLatitude);

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGrid.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGrid.java
@@ -184,7 +184,7 @@ public class XYGrid implements Serializable {
    * @return length in degree of borders of cells
    */
   public double getCellWidth() {
-    return OSMCoordinates.toDouble(cellWidth);
+    return cellWidth * OSMCoordinates.GEOM_PRECISION;
   }
 
   /**

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGrid.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGrid.java
@@ -1,11 +1,15 @@
 package org.heigit.ohsome.oshdb.index;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxOSMCoordinates;
+import static org.heigit.ohsome.oshdb.osm.OSMCoordinates.GEOM_PRECISION_TO_LONG;
+
 import java.io.Serializable;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
-import org.heigit.ohsome.oshdb.OSHDB;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
 import org.heigit.ohsome.oshdb.util.CellId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,10 +83,10 @@ public class XYGrid implements Serializable {
     }
     OSHDBBoundingBox bbox = grid.getCellDimensions(id);
     OSHDBBoundingBox topRight = grid.getCellDimensions(topRightId);
-    return new OSHDBBoundingBox(Math.min(bbox.getMinLonLong(), topRight.getMinLonLong()),
-        Math.min(bbox.getMinLatLong(), topRight.getMinLatLong()),
-        Math.max(bbox.getMaxLonLong(), topRight.getMaxLonLong()),
-        Math.max(bbox.getMaxLatLong(), topRight.getMaxLatLong()));
+    return bboxOSMCoordinates(Math.min(bbox.getMinLon(), topRight.getMinLon()),
+        Math.min(bbox.getMinLat(), topRight.getMinLat()),
+        Math.max(bbox.getMaxLon(), topRight.getMaxLon()),
+        Math.max(bbox.getMaxLat(), topRight.getMaxLat()));
   }
 
   private final int zoom;
@@ -108,7 +112,7 @@ public class XYGrid implements Serializable {
     }
 
     zoompow = (long) Math.pow(2, this.zoom);
-    cellWidth = 360.0 / zoompow * OSHDB.GEOM_PRECISION_TO_LONG;
+    cellWidth = 360.0 / zoompow * GEOM_PRECISION_TO_LONG;
   }
 
   /**
@@ -121,8 +125,8 @@ public class XYGrid implements Serializable {
    * @return Returns the ID of the tile as shown above
    */
   public long getId(double longitude, double latitude) {
-    return this.getId((long) (longitude * OSHDB.GEOM_PRECISION_TO_LONG),
-        (long) (latitude * OSHDB.GEOM_PRECISION_TO_LONG));
+    return this.getId(OSMCoordinates.toOSM(longitude),
+        OSMCoordinates.toOSM(latitude));
   }
 
   /**
@@ -135,23 +139,23 @@ public class XYGrid implements Serializable {
    */
   public long getId(long longitude, long latitude) {
     // return -1 if point is outside geographical coordinate range
-    if (longitude > (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG)
-        || longitude < (long) (-180.0 * OSHDB.GEOM_PRECISION_TO_LONG)
-        || latitude > (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG)
-        || latitude < (long) (-90.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
+    if (longitude > OSMCoordinates.toOSM(180.0)
+        || longitude < OSMCoordinates.toOSM(-180.0)
+        || latitude > OSMCoordinates.toOSM(90.0)
+        || latitude < OSMCoordinates.toOSM(-90.0)) {
       return -1L;
     }
 
-    longitude += (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG);
-    latitude += (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+    longitude += OSMCoordinates.toOSM(180.0);
+    latitude += OSMCoordinates.toOSM(90.0);
 
     // if it reaches the eastern most border it is placed on the western most tile
-    if (longitude == (long) (360.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
+    if (longitude == (long) (360.0 * GEOM_PRECISION_TO_LONG)) {
       // wrap arround
       longitude = 0L;
     }
     // if it reaches the northpole it is placed in the northern most tile
-    if (latitude == (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
+    if (latitude == (long) (180.0 * GEOM_PRECISION_TO_LONG)) {
       // fix latitude to clostest value under 180
       latitude -= 1L;
     }
@@ -171,7 +175,7 @@ public class XYGrid implements Serializable {
    * @return south-western cellId of given BBOX
    */
   public long getId(OSHDBBoundingBox bbox) {
-    return getId(bbox.getMinLonLong(), bbox.getMinLatLong());
+    return getId(bbox.getMinLon(), bbox.getMinLat());
   }
 
   /**
@@ -180,7 +184,7 @@ public class XYGrid implements Serializable {
    * @return length in degree of borders of cells
    */
   public double getCellWidth() {
-    return cellWidth * OSHDB.GEOM_PRECISION;
+    return OSMCoordinates.toDouble(cellWidth);
   }
 
   /**
@@ -195,25 +199,25 @@ public class XYGrid implements Serializable {
     int x = (int) (cellId % zoompow);
     int y = (int) ((cellId - x) / zoompow);
     // calculate the values of the south-western most corner
-    long lon = (long) (x * cellWidth - 180.0 * OSHDB.GEOM_PRECISION_TO_LONG);
-    long lat = (long) (y * cellWidth - 90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+    int lon = (int) (x * cellWidth - OSMCoordinates.toOSM(180.0));
+    int lat = (int) (y * cellWidth - OSMCoordinates.toOSM(90.0));
 
-    final long minlong = lon;
-    final long maxlong = (long) (lon + cellWidth) - 1L;
+    final int minlong = lon;
+    final int maxlong = (int) (lon + cellWidth) - 1;
 
-    final long minlat;
-    final long maxlat;
+    final int minlat;
+    final int maxlat;
     if (zoom == 0) {
-      minlat = (long) (-90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
-      maxlat = (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
-    } else if (lat == (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG) - cellWidth) {
+      minlat = OSMCoordinates.toOSM(-90.0);
+      maxlat = OSMCoordinates.toOSM(90.0);
+    } else if (lat == OSMCoordinates.toOSM(90.0) - cellWidth) {
       minlat = lat;
-      maxlat = (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+      maxlat = OSMCoordinates.toOSM(90.0);
     } else {
       minlat = lat;
-      maxlat = (long) (lat + cellWidth) - 1L;
+      maxlat = (int) (lat + cellWidth) - 1;
     }
-    return new OSHDBBoundingBox(minlong, minlat, maxlong, maxlat);
+    return bboxOSMCoordinates(minlong, minlat, maxlong, maxlat);
   }
 
   /**
@@ -225,10 +229,10 @@ public class XYGrid implements Serializable {
   public long getEstimatedIdCount(final OSHDBBoundingBox data) {
     // number of Cells in x * number of cells in y
     return Math.max(
-        (long) Math.ceil(data.getMaxLonLong() / cellWidth)
-            - (long) Math.floor(data.getMinLonLong() / cellWidth),
-        (long) Math.ceil(data.getMaxLatLong() / cellWidth)
-            - (long) Math.floor(data.getMinLatLong() / cellWidth));
+        (long) Math.ceil(data.getMaxLon() / cellWidth)
+            - (long) Math.floor(data.getMinLon() / cellWidth),
+        (long) Math.ceil(data.getMaxLat() / cellWidth)
+            - (long) Math.floor(data.getMinLat() / cellWidth));
   }
 
   /**
@@ -313,70 +317,70 @@ public class XYGrid implements Serializable {
     // initialise basic variables
     Set<IdRange> result = new TreeSet<>();
 
-    long minlat = bbox.getMinLatLong();
-    long maxlat = bbox.getMaxLatLong();
+    int minlat = bbox.getMinLat();
+    int maxlat = bbox.getMaxLat();
 
     if (minlat > maxlat) {
       LOG.warn("The minimum values are not smaller than the maximum values. "
           + "This might throw an exeption one day?");
-      return null;
+      return Collections.emptySet();
     }
 
-    long minlong = bbox.getMinLonLong();
-    long maxlong = bbox.getMaxLonLong();
+    int minlong = bbox.getMinLon();
+    int maxlong = bbox.getMaxLon();
 
     IdRange outofboundsCell = IdRange.INVALID;
     // test if bbox is on earth or extends further
-    if (minlong < (long) (-180.0 * OSHDB.GEOM_PRECISION_TO_LONG)
-        || minlong > (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
+    if (minlong < OSMCoordinates.toOSM(-180.0)
+        || minlong > OSMCoordinates.toOSM(180.0)) {
       result.add(outofboundsCell);
-      minlong = (long) (-180.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+      minlong = OSMCoordinates.toOSM(-180.0);
     }
-    if (minlat < (long) (-90.0 * OSHDB.GEOM_PRECISION_TO_LONG)
-        || minlat > (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
+    if (minlat < OSMCoordinates.toOSM(-90.0)
+        || minlat > OSMCoordinates.toOSM(90.0)) {
       result.add(outofboundsCell);
-      minlat = (long) (-90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+      minlat = OSMCoordinates.toOSM(-90.0);
     }
-    if (maxlong > (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG)
-        || maxlong < (long) (-180.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
+    if (maxlong > OSMCoordinates.toOSM(180.0)
+        || maxlong < OSMCoordinates.toOSM(-180.0)) {
       result.add(outofboundsCell);
-      maxlong = (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+      maxlong = OSMCoordinates.toOSM(180.0);
     }
-    if (maxlat > (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG)
-        || maxlat < (long) (-90.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
+    if (maxlat > OSMCoordinates.toOSM(90.0)
+        || maxlat < OSMCoordinates.toOSM(-90.0)) {
       result.add(outofboundsCell);
-      maxlat = (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+      maxlat = OSMCoordinates.toOSM(90.0);
     }
 
-    if (minlong == (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
-      minlong = (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG) - 1L;
+    if (minlong == OSMCoordinates.toOSM(180.0)) {
+      minlong = OSMCoordinates.toOSM(180.0) - 1;
     }
-    if (maxlong == (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
-      maxlong = (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG) - 1L;
+    if (maxlong == OSMCoordinates.toOSM(180.0)) {
+      maxlong = OSMCoordinates.toOSM(180.0) - 1;
     }
-    if (minlat == (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
-      minlat = (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG) - 1L;
+    if (minlat == OSMCoordinates.toOSM(90.0)) {
+      minlat = OSMCoordinates.toOSM(90.0) - 1;
     }
-    if (maxlat == (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG)) {
-      maxlat = (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG) - 1L;
+    if (maxlat == OSMCoordinates.toOSM(90.0)) {
+      maxlat = OSMCoordinates.toOSM(90.0) - 1;
     }
 
     // cope with BBOX extending over the date-line
     if (minlong > maxlong) {
-      result.addAll(bbox2CellIdRanges(new OSHDBBoundingBox(minlong, minlat,
-          (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG) - 1L, maxlat), enlarge));
+      result.addAll(bbox2CellIdRanges(bboxOSMCoordinates(minlong, minlat,
+          OSMCoordinates.toOSM(180.0) - 1, maxlat), enlarge));
 
-      minlong = (long) (-180.0 * OSHDB.GEOM_PRECISION_TO_LONG);
+      minlong = OSMCoordinates.toOSM(-180.0);
     }
 
     // At this point the following should be true
     // minlong[-180.0:179.999999]<=maxlong[-180.0:179.9999]
     // minlat[0:89.99999999999]<=maxlat[0:89.99999999999]
     // calculate column and row range
-    int columnmin = (int) ((minlong + (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG)) / cellWidth);
-    int columnmax = (int) ((maxlong + (long) (180.0 * OSHDB.GEOM_PRECISION_TO_LONG)) / cellWidth);
-    int rowmin = (int) ((minlat + (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG)) / cellWidth);
-    int rowmax = (int) ((maxlat + (long) (90.0 * OSHDB.GEOM_PRECISION_TO_LONG)) / cellWidth);
+    int columnmin = (int) ((minlong + (long) OSMCoordinates.toOSM(180.0)) / cellWidth);
+    int columnmax = (int) ((maxlong + (long) OSMCoordinates.toOSM(180.0)) / cellWidth);
+    int rowmin = (int) ((minlat + (long) OSMCoordinates.toOSM(90.0)) / cellWidth);
+    int rowmax = (int) ((maxlat + (long) OSMCoordinates.toOSM(90.0)) / cellWidth);
 
     if (enlarge) {
       // it is impossible for features to span over the datelimit, so the enlargement stops at
@@ -405,15 +409,15 @@ public class XYGrid implements Serializable {
   public Set<IdRange> getNeighbours(CellId center) {
     if (center.getZoomLevel() != this.zoom) {
       // might return neighbours in current zoomlevel given the bbox of the provided CellId one day
-      return null;
+      return Collections.emptySet();
     }
 
     OSHDBBoundingBox bbox = this.getCellDimensions(center.getId());
-    long minlong = bbox.getMinLonLong() - 1L;
-    long minlat = bbox.getMinLatLong() - 1L;
-    long maxlong = bbox.getMaxLonLong() + 1L;
-    long maxlat = bbox.getMaxLatLong() + 1L;
-    OSHDBBoundingBox newbbox = new OSHDBBoundingBox(minlong, minlat, maxlong, maxlat);
+    int minlong = bbox.getMinLon() - 1;
+    int minlat = bbox.getMinLat() - 1;
+    int maxlong = bbox.getMaxLon() + 1;
+    int maxlat = bbox.getMaxLat() + 1;
+    OSHDBBoundingBox newbbox = bboxOSMCoordinates(minlong, minlat, maxlong, maxlat);
 
     return this.bbox2CellIdRanges(newbbox, false);
   }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGrid.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGrid.java
@@ -83,10 +83,10 @@ public class XYGrid implements Serializable {
     }
     OSHDBBoundingBox bbox = grid.getCellDimensions(id);
     OSHDBBoundingBox topRight = grid.getCellDimensions(topRightId);
-    return bboxOSMCoordinates(Math.min(bbox.getMinLon(), topRight.getMinLon()),
-        Math.min(bbox.getMinLat(), topRight.getMinLat()),
-        Math.max(bbox.getMaxLon(), topRight.getMaxLon()),
-        Math.max(bbox.getMaxLat(), topRight.getMaxLat()));
+    return bboxOSMCoordinates(Math.min(bbox.getMinLongitude(), topRight.getMinLongitude()),
+        Math.min(bbox.getMinLatitude(), topRight.getMinLatitude()),
+        Math.max(bbox.getMaxLongitude(), topRight.getMaxLongitude()),
+        Math.max(bbox.getMaxLatitude(), topRight.getMaxLatitude()));
   }
 
   private final int zoom;
@@ -175,7 +175,7 @@ public class XYGrid implements Serializable {
    * @return south-western cellId of given BBOX
    */
   public long getId(OSHDBBoundingBox bbox) {
-    return getId(bbox.getMinLon(), bbox.getMinLat());
+    return getId(bbox.getMinLongitude(), bbox.getMinLatitude());
   }
 
   /**
@@ -229,10 +229,10 @@ public class XYGrid implements Serializable {
   public long getEstimatedIdCount(final OSHDBBoundingBox data) {
     // number of Cells in x * number of cells in y
     return Math.max(
-        (long) Math.ceil(data.getMaxLon() / cellWidth)
-            - (long) Math.floor(data.getMinLon() / cellWidth),
-        (long) Math.ceil(data.getMaxLat() / cellWidth)
-            - (long) Math.floor(data.getMinLat() / cellWidth));
+        (long) Math.ceil(data.getMaxLongitude() / cellWidth)
+            - (long) Math.floor(data.getMinLongitude() / cellWidth),
+        (long) Math.ceil(data.getMaxLatitude() / cellWidth)
+            - (long) Math.floor(data.getMinLatitude() / cellWidth));
   }
 
   /**
@@ -317,8 +317,8 @@ public class XYGrid implements Serializable {
     // initialise basic variables
     Set<IdRange> result = new TreeSet<>();
 
-    int minlat = bbox.getMinLat();
-    int maxlat = bbox.getMaxLat();
+    int minlat = bbox.getMinLatitude();
+    int maxlat = bbox.getMaxLatitude();
 
     if (minlat > maxlat) {
       LOG.warn("The minimum values are not smaller than the maximum values. "
@@ -326,8 +326,8 @@ public class XYGrid implements Serializable {
       return Collections.emptySet();
     }
 
-    int minlong = bbox.getMinLon();
-    int maxlong = bbox.getMaxLon();
+    int minlong = bbox.getMinLongitude();
+    int maxlong = bbox.getMaxLongitude();
 
     IdRange outofboundsCell = IdRange.INVALID;
     // test if bbox is on earth or extends further
@@ -413,10 +413,10 @@ public class XYGrid implements Serializable {
     }
 
     OSHDBBoundingBox bbox = this.getCellDimensions(center.getId());
-    int minlong = bbox.getMinLon() - 1;
-    int minlat = bbox.getMinLat() - 1;
-    int maxlong = bbox.getMaxLon() + 1;
-    int maxlat = bbox.getMaxLat() + 1;
+    int minlong = bbox.getMinLongitude() - 1;
+    int minlat = bbox.getMinLatitude() - 1;
+    int maxlong = bbox.getMaxLongitude() + 1;
+    int maxlat = bbox.getMaxLatitude() + 1;
     OSHDBBoundingBox newbbox = bboxOSMCoordinates(minlong, minlat, maxlong, maxlat);
 
     return this.bbox2CellIdRanges(newbbox, false);

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGridTree.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGridTree.java
@@ -87,7 +87,7 @@ public class XYGridTree implements Serializable {
   public CellId getInsertId(OSHDBBoundingBox bbox) {
     for (int i = maxLevel; i >= 0; i--) {
       if (gridMap.get(i).getEstimatedIdCount(bbox) <= 2) {
-        return new CellId(i, gridMap.get(i).getId(bbox.getMinLon(), bbox.getMinLat()));
+        return new CellId(i, gridMap.get(i).getId(bbox.getMinLongitude(), bbox.getMinLatitude()));
       }
     }
     return null;

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGridTree.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/index/XYGridTree.java
@@ -9,6 +9,7 @@ import java.util.TreeMap;
 import org.heigit.ohsome.oshdb.OSHDB;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.index.XYGrid.IdRange;
+import org.heigit.ohsome.oshdb.osm.OSMCoordinates;
 import org.heigit.ohsome.oshdb.util.CellId;
 
 /**
@@ -43,13 +44,8 @@ public class XYGridTree implements Serializable {
    * @param latitude Latitude for the given point
    * @return An iterator over the cellIds in all zoomlevel
    */
-  @SuppressWarnings("Convert2Lambda")
   public Iterable<CellId> getIds(long longitude, long latitude) {
-    return new Iterable<>() {
-
-      @Override
-      public Iterator<CellId> iterator() {
-        Iterator<CellId> result = new Iterator<>() {
+    return () -> new Iterator<>() {
           private int level = -1;
 
           @Override
@@ -66,10 +62,6 @@ public class XYGridTree implements Serializable {
             return new CellId(gridMap.get(level).getLevel(),
                 gridMap.get(level).getId(longitude, latitude));
           }
-        };
-
-        return result;
-      }
     };
   }
 
@@ -81,8 +73,8 @@ public class XYGridTree implements Serializable {
    * @return An iterator over the cellIds in all zoomlevel
    */
   public Iterable<CellId> getIds(double longitude, double latitude) {
-    return this.getIds((long) longitude * OSHDB.GEOM_PRECISION_TO_LONG,
-        (long) latitude * OSHDB.GEOM_PRECISION_TO_LONG);
+    return this.getIds(OSMCoordinates.toOSM(longitude),
+        OSMCoordinates.toOSM(latitude));
 
   }
 
@@ -95,7 +87,7 @@ public class XYGridTree implements Serializable {
   public CellId getInsertId(OSHDBBoundingBox bbox) {
     for (int i = maxLevel; i >= 0; i--) {
       if (gridMap.get(i).getEstimatedIdCount(bbox) <= 2) {
-        return new CellId(i, gridMap.get(i).getId(bbox.getMinLonLong(), bbox.getMinLatLong()));
+        return new CellId(i, gridMap.get(i).getId(bbox.getMinLon(), bbox.getMinLat()));
       }
     }
     return null;
@@ -117,12 +109,8 @@ public class XYGridTree implements Serializable {
    * @param bbox {@code OSHDBBoundingBox} for the query
    * @param enlarge {@code true} if the query should include enlarged bboxes
    */
-  @SuppressWarnings("Convert2Lambda")
   public Iterable<CellId> bbox2CellIds(final OSHDBBoundingBox bbox, final boolean enlarge) {
-    return new Iterable<>() {
-      @Override
-      public Iterator<CellId> iterator() {
-        return new Iterator<>() {
+    return () -> new Iterator<>() {
           private int level = 0;
           private Iterator<IdRange> rows =
               gridMap.get(level).bbox2CellIdRanges(bbox, enlarge).iterator();
@@ -160,8 +148,6 @@ public class XYGridTree implements Serializable {
             maxId = row.getEnd();
             return new CellId(level, currId);
           }
-        };
-      }
     };
   }
 
@@ -217,13 +203,9 @@ public class XYGridTree implements Serializable {
    * @param enlarge {@code true} to include enlarged bboxes
    * @return List of {@code CellIdRanges} which are covered by the given bbox
    */
-  @SuppressWarnings("Convert2Lambda")
   public Iterable<CellIdRange> bbox2CellIdRanges(final OSHDBBoundingBox bbox,
       final boolean enlarge) {
-    return new Iterable<>() {
-      @Override
-      public Iterator<CellIdRange> iterator() {
-        return new Iterator<>() {
+    return () -> new Iterator<>() {
           private int level = 0;
           private Iterator<IdRange> rows =
               gridMap.get(level).bbox2CellIdRanges(bbox, enlarge).iterator();
@@ -243,8 +225,6 @@ public class XYGridTree implements Serializable {
             return CellIdRange.of(new CellId(level, row.getStart()),
                 new CellId(level, row.getEnd()));
           }
-        };
-      }
     };
   }
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osh/OSHEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osh/OSHEntity.java
@@ -1,6 +1,5 @@
 package org.heigit.ohsome.oshdb.osh;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import org.heigit.ohsome.oshdb.OSHDBBoundable;
@@ -25,11 +24,11 @@ public interface OSHEntity extends OSHDBBoundable {
 
   Iterable<? extends OSMEntity> getVersions();
 
-  default List<OSHNode> getNodes() throws IOException {
+  default List<OSHNode> getNodes() {
     return Collections.emptyList();
   }
 
-  default List<OSHWay> getWays() throws IOException {
+  default List<OSHWay> getWays() {
     return Collections.emptyList();
   }
 }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMCoordinates.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMCoordinates.java
@@ -1,0 +1,34 @@
+package org.heigit.ohsome.oshdb.osm;
+
+public class OSMCoordinates {
+
+  // osm only stores 7 decimals for each coordinate
+  public static final double GEOM_PRECISION_TO_LONG = 1E7;
+  public static final double GEOM_PRECISION = 1.0 / GEOM_PRECISION_TO_LONG;
+
+  public static int toOSM(double value) {
+    return (int) (value * GEOM_PRECISION_TO_LONG);
+  }
+
+  public static double toDouble(int value) {
+    return value * GEOM_PRECISION;
+  }
+
+  public static double toDouble(long value) {
+    return value * GEOM_PRECISION;
+  }
+
+  public static double toDouble(double value) {
+    return value * GEOM_PRECISION;
+  }
+
+  public static boolean validLon(int lon) {
+    return Math.abs(lon) < 180_0000000;
+  }
+
+  public static boolean validLat(int lat) {
+    return Math.abs(lat) < 90_0000000;
+  }
+
+  private OSMCoordinates() {}
+}

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMCoordinates.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMCoordinates.java
@@ -14,15 +14,7 @@ public class OSMCoordinates {
     return (int) (value * GEOM_PRECISION_TO_LONG);
   }
 
-  public static double toDouble(int value) {
-    return value * GEOM_PRECISION;
-  }
-
-  public static double toDouble(long value) {
-    return value * GEOM_PRECISION;
-  }
-
-  public static double toDouble(double value) {
+  public static double toWgs84(int value) {
     return value * GEOM_PRECISION;
   }
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMCoordinates.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMCoordinates.java
@@ -3,7 +3,6 @@ package org.heigit.ohsome.oshdb.osm;
 /**
  * Helper class for converting double precision floating point lon/lat to
  * osm-coordinate fix presision 7 decimal integer system.
- *
  */
 public class OSMCoordinates {
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMCoordinates.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMCoordinates.java
@@ -1,5 +1,10 @@
 package org.heigit.ohsome.oshdb.osm;
 
+/**
+ * Helper class for converting double precision floating point lon/lat to
+ * osm-coordinate fix presision 7 decimal integer system.
+ *
+ */
 public class OSMCoordinates {
 
   // osm only stores 7 decimals for each coordinate

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMEntity.java
@@ -31,7 +31,7 @@ public abstract class OSMEntity implements OSHDBTemporal, Serializable {
    * @param userId UserID
    * @param tags An array of OSHDB key-value ids. The format is [KID1,VID1,KID2,VID2...KIDn,VIDn].
    */
-  public OSMEntity(final long id, final int version, final long timestamp,
+  protected OSMEntity(final long id, final int version, final long timestamp,
       final long changesetId, final int userId, final int[] tags) {
     this.id = id;
     this.version = version;

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMNode.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMNode.java
@@ -3,20 +3,19 @@ package org.heigit.ohsome.oshdb.osm;
 import java.io.Serializable;
 import java.util.Locale;
 import java.util.Objects;
-import org.heigit.ohsome.oshdb.OSHDB;
 
 public class OSMNode extends OSMEntity implements Comparable<OSMNode>, Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private final long longitude;
-  private final long latitude;
+  private final int longitude;
+  private final int latitude;
 
   /**
    * Creates a new {@code OSMNode} instance.
    */
   public OSMNode(final long id, final int version, final long timestamp, final long changeset,
-      final int userId, final int[] tags, final long longitude, final long latitude) {
+      final int userId, final int[] tags, final int longitude, final int latitude) {
     super(id, version, timestamp, changeset, userId, tags);
     this.longitude = longitude;
     this.latitude = latitude;
@@ -28,18 +27,18 @@ public class OSMNode extends OSMEntity implements Comparable<OSMNode>, Serializa
   }
 
   public double getLongitude() {
-    return longitude * OSHDB.GEOM_PRECISION;
+    return OSMCoordinates.toDouble(longitude);
   }
 
   public double getLatitude() {
-    return latitude * OSHDB.GEOM_PRECISION;
+    return OSMCoordinates.toDouble(latitude);
   }
 
-  public long getLon() {
+  public int getLon() {
     return longitude;
   }
 
-  public long getLat() {
+  public int getLat() {
     return latitude;
   }
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMNode.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMNode.java
@@ -35,11 +35,11 @@ public class OSMNode extends OSMEntity implements Comparable<OSMNode>, Serializa
   }
 
   public double getLongitude() {
-    return OSMCoordinates.toDouble(longitude);
+    return OSMCoordinates.toWgs84(longitude);
   }
 
   public double getLatitude() {
-    return OSMCoordinates.toDouble(latitude);
+    return OSMCoordinates.toWgs84(latitude);
   }
 
   public int getLon() {

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMNode.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMNode.java
@@ -21,6 +21,14 @@ public class OSMNode extends OSMEntity implements Comparable<OSMNode>, Serializa
     this.latitude = latitude;
   }
 
+  @Deprecated
+  public OSMNode(final long id, final int version, final long timestamp, final long changeset,
+      final int userId, final int[] tags, final long longitude, final long latitude) {
+    super(id, version, timestamp, changeset, userId, tags);
+    this.longitude = Math.toIntExact(longitude);
+    this.latitude = Math.toIntExact(latitude);
+  }
+
   @Override
   public OSMType getType() {
     return OSMType.NODE;

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/util/bytearray/ByteArrayOutputWrapper.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/util/bytearray/ByteArrayOutputWrapper.java
@@ -63,12 +63,13 @@ public class ByteArrayOutputWrapper {
    * @param value current value
    * @param last last value or delta encoding
    */
-  public void writeU64Delta(long value, long last) {
+  public long writeU64Delta(long value, long last) {
     final long delta = value - last;
     if (delta < 0) {
       throw new IllegalArgumentException("writeUInt64Delta with negative delta(" + delta + ")");
     }
     writeU64(delta);
+    return value;
   }
 
   /**

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/util/bytearray/ByteArrayOutputWrapper.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/util/bytearray/ByteArrayOutputWrapper.java
@@ -58,10 +58,11 @@ public class ByteArrayOutputWrapper {
   }
 
   /**
-   * Write a delta encoded value to the stream.
+   * Write a delta encoded unsigned 64 bit value to the stream.
    *
    * @param value current value
    * @param last last value or delta encoding
+   * @return current value
    */
   public long writeU64Delta(long value, long last) {
     final long delta = value - last;
@@ -81,6 +82,13 @@ public class ByteArrayOutputWrapper {
     writeU64(encodeZigZag64(value));
   }
 
+  /**
+   * Write a delta encoded signed 64 bit value to the stream.
+   *
+   * @param value current value
+   * @param last last value or delta encoding
+   * @return current value
+   */
   public long writeS64Delta(long value, long last) {
     writeS64(value - last);
     return value;

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
@@ -14,7 +14,7 @@ import org.junit.Test;
 public class GridOSHNodesTest {
 
   @Test
-  public void testToString() throws IOException {
+  public void testRebaseEntities() throws IOException {
     List<OSHNode> hosmNodes = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       List<OSMNode> versions = new ArrayList<>();

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
@@ -2,6 +2,7 @@ package org.heigit.ohsome.oshdb.grid;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,10 +26,8 @@ public class GridOSHNodesTest {
     }
 
     GridOSHNodes instance = GridOSHNodes.rebase(2, 2, 100, 100000L, 86000000, 490000000, hosmNodes);
-    String expResult =
-        "Grid-Cell of OSHNodes ID:2 Level:2 BBox:(-90.000000,0.000000),(-0.000000,90.000000)";
-    String result = instance.toString();
-    assertEquals(expResult, result);
+    var entities = instance.getEntities();
+    assertEquals(hosmNodes.size(), Iterables.size(entities));
   }
 
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
@@ -18,9 +18,9 @@ public class GridOSHNodesTest {
     for (int i = 0; i < 3; i++) {
       List<OSMNode> versions = new ArrayList<>();
       versions.add(new OSMNode(123L + 10 * i, 1, 123001L + 10 * i, 0L, 123, new int[] {},
-          86809727L - 1000000 * i, 494094984L - 1000000 * i));
+          86809727 - 1000000 * i, 494094984 - 1000000 * i));
       versions.add(new OSMNode(123L + 10 * i, 2, 123002L + 10 * i, 0L, 123, new int[] {},
-          86809727L - 1000000 * i, 494094984L - 1000000 * i));
+          86809727 - 1000000 * i, 494094984 - 1000000 * i));
       hosmNodes.add(OSHNodeImpl.build(versions));
     }
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
@@ -27,9 +27,9 @@ public class GridOSHRelationsTest {
 
   @Test
   public void test() throws IOException {
-    var node100 = buildOSHNode(node(100L, 1, 1L, 0L, 123, tags(1, 2), 494094984L, 86809727L));
-    var node102 = buildOSHNode(node(102L, 1, 1L, 0L, 123, tags(2, 1), 494094984L, 86809727L));
-    var node104 = buildOSHNode(node(104L, 1, 1L, 0L, 123, tags(2, 4), 494094984L, 86809727L));
+    var node100 = buildOSHNode(node(100L, 1, 1L, 0L, 123, tags(1, 2), 494094984, 86809727));
+    var node102 = buildOSHNode(node(102L, 1, 1L, 0L, 123, tags(2, 1), 494094984, 86809727));
+    var node104 = buildOSHNode(node(104L, 1, 1L, 0L, 123, tags(2, 4), 494094984, 86809727));
 
     var way200 = buildOSHWay(asList(node100, node104),
             way(200, 1, 3333L, 4444L, 23, tags(1, 2), mn(100, 0), mn(104, 0)));
@@ -65,7 +65,7 @@ public class GridOSHRelationsTest {
   }
 
   private static OSMNode node(long id, int version, long timestamp, long changeset,
-      int userId, int[] tags, long longitude, long latitude) {
+      int userId, int[] tags, int longitude, int latitude) {
     return new OSMNode(id, version, timestamp, changeset, userId, tags, longitude, latitude);
   }
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
@@ -47,11 +47,7 @@ public class GridOSHRelationsTest {
     long cellId = 2;
     int cellLevel = 2;
     var grid = GridOSHRelations.compact(cellId, cellLevel, 0, 0, 0, 0,
-        asList(relation300, relation301));
-
-    var expResult =
-        "Grid-Cell of OSHRelations ID:2 Level:2 BBox:(-90.000000,0.000000),(-0.000000,90.000000)";
-    assertEquals(expResult, grid.toString());
+        asList(relation300, relation301));;
     assertEquals(cellId, grid.getId());
     assertEquals(cellLevel, grid.getLevel());
     assertEquals(2, Iterables.size(grid.getEntities()));

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHWaysTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHWaysTest.java
@@ -19,20 +19,15 @@ import org.junit.Test;
 public class GridOSHWaysTest {
 
   static OSHNode buildOSHNode(List<OSMNode> versions) {
-    try {
-      return OSHNodeImpl.build(versions);
-    } catch (IOException e) {
-      e.printStackTrace();
-    }
-    return null;
+    return OSHNodeImpl.build(versions);
   }
 
   OSHNode node100 = buildOSHNode(
-      Arrays.asList(new OSMNode(100L, 1, 1L, 0L, 123, new int[] {1, 2}, 494094984L, 86809727L)));
+      Arrays.asList(new OSMNode(100L, 1, 1L, 0L, 123, new int[] {1, 2}, 494094984, 86809727)));
   OSHNode node102 = buildOSHNode(
-      Arrays.asList(new OSMNode(102L, 1, 1L, 0L, 123, new int[] {2, 1}, 494094984L, 86809727L)));
+      Arrays.asList(new OSMNode(102L, 1, 1L, 0L, 123, new int[] {2, 1}, 494094984, 86809727)));
   OSHNode node104 = buildOSHNode(
-      Arrays.asList(new OSMNode(104L, 1, 1L, 0L, 123, new int[] {2, 4}, 494094984L, 86809727L)));
+      Arrays.asList(new OSMNode(104L, 1, 1L, 0L, 123, new int[] {2, 4}, 494094984, 86809727)));
 
   @Test
   public void testToString() throws IOException {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHWaysTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHWaysTest.java
@@ -2,6 +2,7 @@ package org.heigit.ohsome.oshdb.grid;
 
 import static org.junit.Assert.assertEquals;
 
+import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -30,7 +31,7 @@ public class GridOSHWaysTest {
       Arrays.asList(new OSMNode(104L, 1, 1L, 0L, 123, new int[] {2, 4}, 494094984, 86809727)));
 
   @Test
-  public void testToString() throws IOException {
+  public void testGrid() throws IOException {
     List<OSHWay> hosmWays = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       List<OSMWay> versions = new ArrayList<>();
@@ -42,9 +43,7 @@ public class GridOSHWaysTest {
     }
 
     GridOSHWays instance = GridOSHWays.compact(2, 2, 100, 100000L, 86000000, 490000000, hosmWays);
-    String expResult =
-        "Grid-Cell of OSHWays ID:2 Level:2 BBox:(-90.000000,0.000000),(-0.000000,90.000000)";
-    String result = instance.toString();
-    assertEquals(expResult, result);
+    var entities = instance.getEntities();
+    assertEquals(hosmWays.size(), Iterables.size(entities));
   }
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTest.java
@@ -1,5 +1,7 @@
 package org.heigit.ohsome.oshdb.index;
 
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.osm.OSMCoordinates.GEOM_PRECISION;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Set;
@@ -100,7 +102,7 @@ public class XYGridTest {
   @Test
   public void test179_90_2() {
     // Testing Coordinates: 179, 90, zoom 2
-    double longitude = 180.0 - OSHDB.GEOM_PRECISION;
+    double longitude = 180.0 - GEOM_PRECISION;
     double latitude = 90.0;
 
     Long expResult = (long) 7;
@@ -161,7 +163,7 @@ public class XYGridTest {
   @Test
   public void test179_90_30() {
     // Testing Coordinates: 179, 90, zoom 30
-    double longitude = 180.0 - OSHDB.GEOM_PRECISION;
+    double longitude = 180.0 - GEOM_PRECISION;
     double latitude = 90.0;
 
     Long expResult = 576460752303423487L;
@@ -171,13 +173,13 @@ public class XYGridTest {
 
   @Test
   public void testGetId_BoundingBox() {
-    OSHDBBoundingBox bbx = new OSHDBBoundingBox(-10.0, -10.0, 10.0, 10.0);
+    OSHDBBoundingBox bbx = bboxLonLatCoordinates(-10.0, -10.0, 10.0, 10.0);
     XYGrid instance = new XYGrid(2);
     long expResult = 1L;
     long result = instance.getId(bbx);
     assertEquals(expResult, result);
 
-    OSHDBBoundingBox bbx2 = new OSHDBBoundingBox(10.0, -10.0, -9.0, 10.0);
+    OSHDBBoundingBox bbx2 = bboxLonLatCoordinates(10.0, -10.0, -9.0, 10.0);
     instance = new XYGrid(2);
     expResult = 2L;
     result = instance.getId(bbx2);
@@ -195,28 +197,28 @@ public class XYGridTest {
   @Test
   public void testGetCellDimensions() {
     long cellId = 0L;
-    OSHDBBoundingBox expResult = new OSHDBBoundingBox(-180.0, -90.0, -90.0 - OSHDB.GEOM_PRECISION,
-        0.0 - OSHDB.GEOM_PRECISION);
+    OSHDBBoundingBox expResult = bboxLonLatCoordinates(-180.0, -90.0, -90.0 - GEOM_PRECISION,
+        0.0 - GEOM_PRECISION);
     OSHDBBoundingBox result = two.getCellDimensions(cellId);
     assertEquals(expResult, result);
 
     cellId = 6L;
-    expResult = new OSHDBBoundingBox(0.0, 0.0, 90.0 - OSHDB.GEOM_PRECISION, 90.0);
+    expResult = bboxLonLatCoordinates(0.0, 0.0, 90.0 - GEOM_PRECISION, 90.0);
     result = two.getCellDimensions(cellId);
     assertEquals(expResult, result);
 
     cellId = 7L;
-    expResult = new OSHDBBoundingBox(90.0, 0.0, 180.0 - OSHDB.GEOM_PRECISION, 90.0);
+    expResult = bboxLonLatCoordinates(90.0, 0.0, 180.0 - GEOM_PRECISION, 90.0);
     result = two.getCellDimensions(cellId);
     assertEquals(expResult, result);
 
     cellId = 0L;
-    expResult = new OSHDBBoundingBox(-180.0, -90.0, 180.0 - OSHDB.GEOM_PRECISION, 90.0);
+    expResult = bboxLonLatCoordinates(-180.0, -90.0, 180.0 - GEOM_PRECISION, 90.0);
     result = zero.getCellDimensions(cellId);
     assertEquals(expResult, result);
 
     cellId = 0L;
-    expResult = new OSHDBBoundingBox(-180.0, -90.0, 0.0 - OSHDB.GEOM_PRECISION, 90.0);
+    expResult = bboxLonLatCoordinates(-180.0, -90.0, 0.0 - GEOM_PRECISION, 90.0);
     XYGrid instance = new XYGrid(1);
     result = instance.getCellDimensions(cellId);
     assertEquals(expResult, result);
@@ -224,23 +226,23 @@ public class XYGridTest {
 
   @Test
   public void testGetEstimatedIdCount() {
-    OSHDBBoundingBox data = new OSHDBBoundingBox(0, 0, 89, 89);
+    OSHDBBoundingBox data = bboxLonLatCoordinates(0.0, 0.0, 89.0, 89.0);
     long expResult = 1L;
     long result = two.getEstimatedIdCount(data);
     assertEquals(expResult, result);
 
-    data = new OSHDBBoundingBox(-89.0, -90.0, 89.0, 90.0);
+    data = bboxLonLatCoordinates(-89.0, -90.0, 89.0, 90.0);
     expResult = 2L;
     result = two.getEstimatedIdCount(data);
     assertEquals(expResult, result);
 
-    data = new OSHDBBoundingBox(0.0, 0.0, 0.0000053, 0.0000053);
+    data = bboxLonLatCoordinates(0.0, 0.0, 0.0000053, 0.0000053);
     expResult = 16L;
     result = thirty.getEstimatedIdCount(data);
     assertEquals(expResult, result);
 
     // "just" touching three cells, see https://github.com/GIScience/oshdb/pull/183
-    data = new OSHDBBoundingBox(-0.1, 0, 90.1, 89);
+    data = bboxLonLatCoordinates(-0.1, 0, 90.1, 89);
     expResult = 3L;
     result = two.getEstimatedIdCount(data);
     assertEquals(expResult, result);
@@ -255,7 +257,7 @@ public class XYGridTest {
 
   @Test
   public void testBbox2Ids() {
-    OSHDBBoundingBox bbox = new OSHDBBoundingBox(-180, -90, 180, 90);
+    OSHDBBoundingBox bbox = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
     Set<IdRange> result = zero.bbox2CellIdRanges(bbox, false);
 
     assertEquals(1, result.size());
@@ -264,7 +266,7 @@ public class XYGridTest {
     assertEquals(0, interval.getStart());
     assertEquals(0, interval.getEnd());
 
-    bbox = new OSHDBBoundingBox(-180, -90, 180, 90);
+    bbox = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
     result = two.bbox2CellIdRanges(bbox, false);
 
     assertEquals(2, result.size());
@@ -273,7 +275,7 @@ public class XYGridTest {
     assertEquals(0, interval.getStart());
     assertEquals(3, interval.getEnd());
 
-    bbox = new OSHDBBoundingBox(-10, -10, 10, 10);
+    bbox = bboxLonLatCoordinates(-10.0, -10.0, 10.0, 10.0);
     result = zero.bbox2CellIdRanges(bbox, false);
 
     assertEquals(1, result.size());
@@ -282,7 +284,7 @@ public class XYGridTest {
     assertEquals(0, interval.getStart());
     assertEquals(0, interval.getEnd());
 
-    bbox = new OSHDBBoundingBox(179, 0, 89, 5);
+    bbox = bboxLonLatCoordinates(179.0, 0.0, 89.0, 5.0);
     result = zero.bbox2CellIdRanges(bbox, false);
 
     assertEquals(1, result.size());
@@ -291,7 +293,7 @@ public class XYGridTest {
     assertEquals(0, interval.getStart());
     assertEquals(0, interval.getEnd());
 
-    bbox = new OSHDBBoundingBox(-10, -10, 10, 10);
+    bbox = bboxLonLatCoordinates(-10.0, -10.0, 10.0, 10.0);
     TreeSet<Long> expectedCellIds = new TreeSet<>();
     expectedCellIds.add(1L);
     expectedCellIds.add(2L);
@@ -305,7 +307,7 @@ public class XYGridTest {
     }
     assertEquals(0, expectedCellIds.size());
 
-    bbox = new OSHDBBoundingBox(-180, 0, 89, 5);
+    bbox = bboxLonLatCoordinates(-180.0, 0.0, 89.0, 5.0);
     expectedCellIds = new TreeSet<>();
     expectedCellIds.add(4L);
     expectedCellIds.add(5L);
@@ -319,7 +321,7 @@ public class XYGridTest {
     }
     assertEquals(0, expectedCellIds.size());
 
-    bbox = new OSHDBBoundingBox(90, -90, 89, -1);
+    bbox = bboxLonLatCoordinates(90.0, -90.0, 89.0, -1.0);
     expectedCellIds = new TreeSet<>();
     expectedCellIds.add(0L);
     expectedCellIds.add(1L);
@@ -341,7 +343,7 @@ public class XYGridTest {
     assertEquals(0, interval.getEnd());
 
     // test performance for maximum sized BBOX
-    bbox = new OSHDBBoundingBox(-180, -90, 180, 90);
+    bbox = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
     int expResult = (int) Math.pow(2, MAXZOOM) / 2;
     LOG.info("If this throws a warning because of the maximum zoomlevel, "
         + "we have to change XYGrid-Code:");
@@ -367,7 +369,11 @@ public class XYGridTest {
   public void testGetBoundingBox() {
     OSHDBBoundingBox result = XYGrid.getBoundingBox(new CellId(2, 2));
     OSHDBBoundingBox expResult =
-        new OSHDBBoundingBox(0.0, -90.0, 90.0 - OSHDB.GEOM_PRECISION, 0.0 - OSHDB.GEOM_PRECISION);
+        bboxLonLatCoordinates(0.0, -90.0, 90.0 - GEOM_PRECISION, 0.0 - GEOM_PRECISION);
     assertEquals(expResult, result);
+
+    OSHDBBoundingBox enlarged = XYGrid.getBoundingBox(new CellId(2, 2), true);
+    expResult = bboxLonLatCoordinates(0.0, -90.0, 180.0 - GEOM_PRECISION, 90.0);
+    assertEquals(expResult, enlarged);
   }
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.index;
 
-import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxLonLatCoordinates;
+import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.heigit.ohsome.oshdb.osm.OSMCoordinates.GEOM_PRECISION;
 import static org.junit.Assert.assertEquals;
 
@@ -173,13 +173,13 @@ public class XYGridTest {
 
   @Test
   public void testGetId_BoundingBox() {
-    OSHDBBoundingBox bbx = bboxLonLatCoordinates(-10.0, -10.0, 10.0, 10.0);
+    OSHDBBoundingBox bbx = bboxWgs84Coordinates(-10.0, -10.0, 10.0, 10.0);
     XYGrid instance = new XYGrid(2);
     long expResult = 1L;
     long result = instance.getId(bbx);
     assertEquals(expResult, result);
 
-    OSHDBBoundingBox bbx2 = bboxLonLatCoordinates(10.0, -10.0, -9.0, 10.0);
+    OSHDBBoundingBox bbx2 = bboxWgs84Coordinates(10.0, -10.0, -9.0, 10.0);
     instance = new XYGrid(2);
     expResult = 2L;
     result = instance.getId(bbx2);
@@ -197,28 +197,28 @@ public class XYGridTest {
   @Test
   public void testGetCellDimensions() {
     long cellId = 0L;
-    OSHDBBoundingBox expResult = bboxLonLatCoordinates(-180.0, -90.0, -90.0 - GEOM_PRECISION,
+    OSHDBBoundingBox expResult = bboxWgs84Coordinates(-180.0, -90.0, -90.0 - GEOM_PRECISION,
         0.0 - GEOM_PRECISION);
     OSHDBBoundingBox result = two.getCellDimensions(cellId);
     assertEquals(expResult, result);
 
     cellId = 6L;
-    expResult = bboxLonLatCoordinates(0.0, 0.0, 90.0 - GEOM_PRECISION, 90.0);
+    expResult = bboxWgs84Coordinates(0.0, 0.0, 90.0 - GEOM_PRECISION, 90.0);
     result = two.getCellDimensions(cellId);
     assertEquals(expResult, result);
 
     cellId = 7L;
-    expResult = bboxLonLatCoordinates(90.0, 0.0, 180.0 - GEOM_PRECISION, 90.0);
+    expResult = bboxWgs84Coordinates(90.0, 0.0, 180.0 - GEOM_PRECISION, 90.0);
     result = two.getCellDimensions(cellId);
     assertEquals(expResult, result);
 
     cellId = 0L;
-    expResult = bboxLonLatCoordinates(-180.0, -90.0, 180.0 - GEOM_PRECISION, 90.0);
+    expResult = bboxWgs84Coordinates(-180.0, -90.0, 180.0 - GEOM_PRECISION, 90.0);
     result = zero.getCellDimensions(cellId);
     assertEquals(expResult, result);
 
     cellId = 0L;
-    expResult = bboxLonLatCoordinates(-180.0, -90.0, 0.0 - GEOM_PRECISION, 90.0);
+    expResult = bboxWgs84Coordinates(-180.0, -90.0, 0.0 - GEOM_PRECISION, 90.0);
     XYGrid instance = new XYGrid(1);
     result = instance.getCellDimensions(cellId);
     assertEquals(expResult, result);
@@ -226,23 +226,23 @@ public class XYGridTest {
 
   @Test
   public void testGetEstimatedIdCount() {
-    OSHDBBoundingBox data = bboxLonLatCoordinates(0.0, 0.0, 89.0, 89.0);
+    OSHDBBoundingBox data = bboxWgs84Coordinates(0.0, 0.0, 89.0, 89.0);
     long expResult = 1L;
     long result = two.getEstimatedIdCount(data);
     assertEquals(expResult, result);
 
-    data = bboxLonLatCoordinates(-89.0, -90.0, 89.0, 90.0);
+    data = bboxWgs84Coordinates(-89.0, -90.0, 89.0, 90.0);
     expResult = 2L;
     result = two.getEstimatedIdCount(data);
     assertEquals(expResult, result);
 
-    data = bboxLonLatCoordinates(0.0, 0.0, 0.0000053, 0.0000053);
+    data = bboxWgs84Coordinates(0.0, 0.0, 0.0000053, 0.0000053);
     expResult = 16L;
     result = thirty.getEstimatedIdCount(data);
     assertEquals(expResult, result);
 
     // "just" touching three cells, see https://github.com/GIScience/oshdb/pull/183
-    data = bboxLonLatCoordinates(-0.1, 0, 90.1, 89);
+    data = bboxWgs84Coordinates(-0.1, 0, 90.1, 89);
     expResult = 3L;
     result = two.getEstimatedIdCount(data);
     assertEquals(expResult, result);
@@ -257,7 +257,7 @@ public class XYGridTest {
 
   @Test
   public void testBbox2Ids() {
-    OSHDBBoundingBox bbox = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
+    OSHDBBoundingBox bbox = bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0);
     Set<IdRange> result = zero.bbox2CellIdRanges(bbox, false);
 
     assertEquals(1, result.size());
@@ -266,7 +266,7 @@ public class XYGridTest {
     assertEquals(0, interval.getStart());
     assertEquals(0, interval.getEnd());
 
-    bbox = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
+    bbox = bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0);
     result = two.bbox2CellIdRanges(bbox, false);
 
     assertEquals(2, result.size());
@@ -275,7 +275,7 @@ public class XYGridTest {
     assertEquals(0, interval.getStart());
     assertEquals(3, interval.getEnd());
 
-    bbox = bboxLonLatCoordinates(-10.0, -10.0, 10.0, 10.0);
+    bbox = bboxWgs84Coordinates(-10.0, -10.0, 10.0, 10.0);
     result = zero.bbox2CellIdRanges(bbox, false);
 
     assertEquals(1, result.size());
@@ -284,7 +284,7 @@ public class XYGridTest {
     assertEquals(0, interval.getStart());
     assertEquals(0, interval.getEnd());
 
-    bbox = bboxLonLatCoordinates(179.0, 0.0, 89.0, 5.0);
+    bbox = bboxWgs84Coordinates(179.0, 0.0, 89.0, 5.0);
     result = zero.bbox2CellIdRanges(bbox, false);
 
     assertEquals(1, result.size());
@@ -293,7 +293,7 @@ public class XYGridTest {
     assertEquals(0, interval.getStart());
     assertEquals(0, interval.getEnd());
 
-    bbox = bboxLonLatCoordinates(-10.0, -10.0, 10.0, 10.0);
+    bbox = bboxWgs84Coordinates(-10.0, -10.0, 10.0, 10.0);
     TreeSet<Long> expectedCellIds = new TreeSet<>();
     expectedCellIds.add(1L);
     expectedCellIds.add(2L);
@@ -307,7 +307,7 @@ public class XYGridTest {
     }
     assertEquals(0, expectedCellIds.size());
 
-    bbox = bboxLonLatCoordinates(-180.0, 0.0, 89.0, 5.0);
+    bbox = bboxWgs84Coordinates(-180.0, 0.0, 89.0, 5.0);
     expectedCellIds = new TreeSet<>();
     expectedCellIds.add(4L);
     expectedCellIds.add(5L);
@@ -321,7 +321,7 @@ public class XYGridTest {
     }
     assertEquals(0, expectedCellIds.size());
 
-    bbox = bboxLonLatCoordinates(90.0, -90.0, 89.0, -1.0);
+    bbox = bboxWgs84Coordinates(90.0, -90.0, 89.0, -1.0);
     expectedCellIds = new TreeSet<>();
     expectedCellIds.add(0L);
     expectedCellIds.add(1L);
@@ -343,7 +343,7 @@ public class XYGridTest {
     assertEquals(0, interval.getEnd());
 
     // test performance for maximum sized BBOX
-    bbox = bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0);
+    bbox = bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0);
     int expResult = (int) Math.pow(2, MAXZOOM) / 2;
     LOG.info("If this throws a warning because of the maximum zoomlevel, "
         + "we have to change XYGrid-Code:");
@@ -369,11 +369,11 @@ public class XYGridTest {
   public void testGetBoundingBox() {
     OSHDBBoundingBox result = XYGrid.getBoundingBox(new CellId(2, 2));
     OSHDBBoundingBox expResult =
-        bboxLonLatCoordinates(0.0, -90.0, 90.0 - GEOM_PRECISION, 0.0 - GEOM_PRECISION);
+        bboxWgs84Coordinates(0.0, -90.0, 90.0 - GEOM_PRECISION, 0.0 - GEOM_PRECISION);
     assertEquals(expResult, result);
 
     OSHDBBoundingBox enlarged = XYGrid.getBoundingBox(new CellId(2, 2), true);
-    expResult = bboxLonLatCoordinates(0.0, -90.0, 180.0 - GEOM_PRECISION, 90.0);
+    expResult = bboxWgs84Coordinates(0.0, -90.0, 180.0 - GEOM_PRECISION, 90.0);
     assertEquals(expResult, enlarged);
   }
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTreeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTreeTest.java
@@ -31,21 +31,21 @@ public class XYGridTreeTest {
 
   @Test
   public void testGetInsertId() {
-    OSHDBBoundingBox bbox = new OSHDBBoundingBox(0.0, -90.0, 179.0, 90.0);
+    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, -90.0, 179.0, 90.0);
     XYGridTree instance = new XYGridTree(4);
     CellId expResult = new CellId(2, 2L);
     CellId result = instance.getInsertId(bbox);
     assertEquals(expResult.getId(), result.getId());
     assertEquals(expResult.getZoomLevel(), result.getZoomLevel());
 
-    bbox = new OSHDBBoundingBox(0.0, -90.0, 0.1, 90.0);
+    bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, -90.0, 0.1, 90.0);
     instance = new XYGridTree(4);
     expResult = new CellId(2, 2L);
     result = instance.getInsertId(bbox);
     assertEquals(expResult.getId(), result.getId());
     assertEquals(expResult.getZoomLevel(), result.getZoomLevel());
 
-    bbox = new OSHDBBoundingBox(0.0, -90.0, 179.0, -89.9);
+    bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, -90.0, 179.0, -89.9);
     instance = new XYGridTree(4);
     expResult = new CellId(2, 2L);
     result = instance.getInsertId(bbox);
@@ -61,7 +61,7 @@ public class XYGridTreeTest {
     expectedCellIds.add(new CellId(1, 1L));
     expectedCellIds.add(new CellId(0, 0L));
 
-    OSHDBBoundingBox bbox = new OSHDBBoundingBox(0.0, 0.0, 44.9, 44.9);
+    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 0.0, 44.9, 44.9);
     boolean enlarge = false;
     XYGridTree instance = new XYGridTree(3);
     for (CellId now : instance.bbox2CellIds(bbox, enlarge)) {
@@ -90,7 +90,7 @@ public class XYGridTreeTest {
     expectedCellIds.add(new CellId(1, 0L));
     expectedCellIds.add(new CellId(0, 0L));
 
-    OSHDBBoundingBox bbox = new OSHDBBoundingBox(0.0, 0.0, 89, 89);
+    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 0.0, 89, 89);
     boolean enlarge = true;
     XYGridTree instance = new XYGridTree(3);
     for (CellId now : instance.bbox2CellIds(bbox, enlarge)) {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTreeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTreeTest.java
@@ -31,21 +31,21 @@ public class XYGridTreeTest {
 
   @Test
   public void testGetInsertId() {
-    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, -90.0, 179.0, 90.0);
+    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, -90.0, 179.0, 90.0);
     XYGridTree instance = new XYGridTree(4);
     CellId expResult = new CellId(2, 2L);
     CellId result = instance.getInsertId(bbox);
     assertEquals(expResult.getId(), result.getId());
     assertEquals(expResult.getZoomLevel(), result.getZoomLevel());
 
-    bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, -90.0, 0.1, 90.0);
+    bbox = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, -90.0, 0.1, 90.0);
     instance = new XYGridTree(4);
     expResult = new CellId(2, 2L);
     result = instance.getInsertId(bbox);
     assertEquals(expResult.getId(), result.getId());
     assertEquals(expResult.getZoomLevel(), result.getZoomLevel());
 
-    bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, -90.0, 179.0, -89.9);
+    bbox = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, -90.0, 179.0, -89.9);
     instance = new XYGridTree(4);
     expResult = new CellId(2, 2L);
     result = instance.getInsertId(bbox);
@@ -61,7 +61,7 @@ public class XYGridTreeTest {
     expectedCellIds.add(new CellId(1, 1L));
     expectedCellIds.add(new CellId(0, 0L));
 
-    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 0.0, 44.9, 44.9);
+    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 0.0, 44.9, 44.9);
     boolean enlarge = false;
     XYGridTree instance = new XYGridTree(3);
     for (CellId now : instance.bbox2CellIds(bbox, enlarge)) {
@@ -90,7 +90,7 @@ public class XYGridTreeTest {
     expectedCellIds.add(new CellId(1, 0L));
     expectedCellIds.add(new CellId(0, 0L));
 
-    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 0.0, 89, 89);
+    OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 0.0, 89, 89);
     boolean enlarge = true;
     XYGridTree instance = new XYGridTree(3);
     for (CellId now : instance.bbox2CellIds(bbox, enlarge)) {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
@@ -4,8 +4,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -19,16 +24,16 @@ import org.junit.Test;
 public class OSHWayTest {
 
   OSHNode node100 = OSHNodeTest.buildOSHNode(new OSMNode(
-      100L, 1, 1L, 0L, 123, new int[]{1, 2}, 494094984L, 86809727L));
+      100L, 1, 1L, 0L, 123, new int[]{1, 2}, 494094984, 86809727));
   OSHNode node102 = OSHNodeTest.buildOSHNode(new OSMNode(
-      102L, 1, 1L, 0L, 123, new int[]{2, 1}, 494094984L, 86809727L));
+      102L, 1, 1L, 0L, 123, new int[]{2, 1}, 494094984, 86809727));
   OSHNode node104 = OSHNodeTest.buildOSHNode(new OSMNode(
-      104L, 1, 1L, 0L, 123, new int[]{2, 4}, 494094984L, 86809727L));
+      104L, 1, 1L, 0L, 123, new int[]{2, 4}, 494094984, 86809727));
 
   public OSHWayTest() throws IOException {}
 
   @Test
-  public void testGetNodes() throws IOException {
+  public void testGetNodes() throws IOException, ClassNotFoundException {
     OSHWay hway = OSHWayImpl.build(Lists.newArrayList(
         new OSMWay(123, 1, 3333L, 4444L, 23, new int[]{1, 1, 2, 1},
             new OSMMember[]{
@@ -43,6 +48,19 @@ public class OSHWayTest {
 
     List<OSHNode> nodes = hway.getNodes();
     assertEquals(3, nodes.size());
+
+    var baos = new ByteArrayOutputStream();
+    try (var oos = new ObjectOutputStream(baos)) {
+      oos.writeObject(hway);
+    }
+    assertEquals(true, baos.size() > 0);
+    var bais = new ByteArrayInputStream(baos.toByteArray());
+    try (var ois = new ObjectInputStream(bais)) {
+      var newWay = (OSHWay) ois.readObject();
+
+      assertEquals(hway.getId(), newWay.getId());
+      assertEquals(Iterables.size(hway.getVersions()), Iterables.size(newWay.getVersions()));
+    }
   }
 
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
@@ -2,6 +2,7 @@ package org.heigit.ohsome.oshdb.osm;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
@@ -1,7 +1,6 @@
 package org.heigit.ohsome.oshdb.osm;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -12,7 +11,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetLongitude() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1);
     double expResult = 100.0;
     double result = instance.getLongitude();
     assertEquals(expResult, result, 0.0);
@@ -20,7 +19,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetLatitude() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     double expResult = 100.0;
     double result = instance.getLatitude();
     assertEquals(expResult, result, 0.0);
@@ -28,7 +27,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetLon() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1000000000L;
     long result = instance.getLon();
     assertEquals(expResult, result);
@@ -36,7 +35,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetLat() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1000000000L;
     long result = instance.getLat();
     assertEquals(expResult, result);
@@ -44,7 +43,7 @@ public class OSMNodeTest {
 
   @Test
   public void testToString() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1100000000L, 100000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1100000000, 100000000);
     String expResult = "NODE: ID:1 V:+1+ TS:1 CS:1 VIS:true UID:1 TAGS:[] 110.0000000:10.0000000";
     String result = instance.toString();
     assertEquals(expResult, result);
@@ -53,9 +52,9 @@ public class OSMNodeTest {
   @Test
   public void testEquals() {
     OSMNode o =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     OSMNode instance =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     boolean expResult = true;
     boolean result = instance.equals(o);
     assertEquals(expResult, result);
@@ -64,9 +63,9 @@ public class OSMNodeTest {
   @Test
   public void testEquals2() {
     OSMNode o =
-        new OSMNode(2L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+        new OSMNode(2L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     OSMNode instance =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     boolean expResult = false;
     boolean result = instance.equals(o);
     assertEquals(expResult, result);
@@ -75,31 +74,31 @@ public class OSMNodeTest {
   @Test
   public void testCompareTo() {
     OSMNode o =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     OSMNode instance =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
-    assertTrue(instance.compareTo(o) == 0);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
+    assertEquals(true, instance.compareTo(o) == 0);
 
-    o = new OSMNode(1L, 3, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+    o = new OSMNode(1L, 3, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     instance =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
-    assertTrue(instance.compareTo(o) < 0);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
+    assertEquals(true, instance.compareTo(o) < 0);
 
-    o = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+    o = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     instance =
-        new OSMNode(1L, 3, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
-    assertTrue(instance.compareTo(o) > 0);
+        new OSMNode(1L, 3, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
+    assertEquals(true, instance.compareTo(o) > 0);
 
-    o = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+    o = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     instance =
-        new OSMNode(1L, -6, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
-    assertTrue(instance.compareTo(o) > 0);
+        new OSMNode(1L, -6, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
+    assertEquals(true, instance.compareTo(o) > 0);
   }
 
   // -------------------
   @Test
   public void testGetId() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1L;
     long result = instance.getId();
     assertEquals(expResult, result);
@@ -107,7 +106,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetVersion() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     int expResult = 1;
     int result = instance.getVersion();
     assertEquals(expResult, result);
@@ -115,7 +114,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetTimestamp() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1L;
     long result = instance.getEpochSecond();
     assertEquals(expResult, result);
@@ -123,7 +122,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetChangeset() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1L;
     long result = instance.getChangesetId();
     assertEquals(expResult, result);
@@ -131,7 +130,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetUserId() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     int expResult = 1;
     int result = instance.getUserId();
     assertEquals(expResult, result);
@@ -139,7 +138,7 @@ public class OSMNodeTest {
 
   @Test
   public void testisVisible() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     boolean expResult = true;
     boolean result = instance.isVisible();
     assertEquals(expResult, result);
@@ -147,7 +146,7 @@ public class OSMNodeTest {
 
   @Test
   public void testisVisible2() {
-    OSMNode instance = new OSMNode(1L, -1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, -1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     boolean expResult = false;
     boolean result = instance.isVisible();
     assertEquals(expResult, result);
@@ -155,7 +154,7 @@ public class OSMNodeTest {
 
   @Test
   public void testGetTags() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     int[] expResult = new int[] {};
     int[] result = instance.getRawTags();
     Assert.assertArrayEquals(expResult, result);
@@ -163,30 +162,30 @@ public class OSMNodeTest {
 
   @Test
   public void testHasTagKey() {
-    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000L, 1000000000L);
+    OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     boolean expResult = false;
     boolean result = instance.hasTagKey(1);
     assertEquals(expResult, result);
 
     instance =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     expResult = true;
     result = instance.hasTagKey(1);
     assertEquals(expResult, result);
 
     instance =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 2, 3, 3}, 1000000000, 1000000000);
     expResult = false;
     result = instance.hasTagKeyExcluding(1, new int[] {2, 3});
     assertEquals(expResult, result);
 
     instance =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000L, 1000000000L);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     expResult = true;
     result = instance.hasTagKeyExcluding(1, new int[] {2, 3});
     assertEquals(expResult, result);
 
-    instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {2, 1, 3, 3}, 1000000000L, 1000000000L);
+    instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {2, 1, 3, 3}, 1000000000, 1000000000);
     expResult = false;
     result = instance.hasTagKeyExcluding(1, new int[] {1, 3});
     assertEquals(expResult, result);
@@ -195,12 +194,12 @@ public class OSMNodeTest {
   @Test
   public void testHasTagValue() {
     OSMNode instance =
-        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 3}, 1000000000L, 1000000000L);
+        new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 3}, 1000000000, 1000000000);
     boolean expResult = false;
     boolean result = instance.hasTagValue(1, 1);
     assertEquals(expResult, result);
 
-    instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 3}, 1000000000L, 1000000000L);
+    instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 3}, 1000000000, 1000000000);
     expResult = true;
     result = instance.hasTagValue(1, 1);
     assertEquals(expResult, result);
@@ -215,12 +214,12 @@ public class OSMNodeTest {
     long changeset = 4444;
     int userId = 23;
     int[] tags = new int[] {1, 1, 2, 2, 3, 3};
-    long longitude = 86809727L;
-    long latitude = 494094984L;
+    int longitude = 86809727;
+    int latitude = 494094984;
 
     OSMNode a = new OSMNode(id, version, timestamp, changeset, userId, tags, longitude, latitude);
     OSMNode b = new OSMNode(id, version, timestamp, changeset, userId, tags, longitude, latitude);
-    assertTrue(a.equals(b));
+    assertEquals(true, a.equals(b));
   }
 
   @Test
@@ -231,8 +230,8 @@ public class OSMNodeTest {
     long changeset = 4444;
     int userId = 23;
     int[] tags = new int[] {1, 1, 2, 2, 3, 3};
-    long longitude = 86809727L;
-    long latitude = 494094984L;
+    int longitude = 86809727;
+    int latitude = 494094984;
 
     OSMNode a = new OSMNode(id, version, timestamp, changeset, userId, tags, longitude, latitude);
 
@@ -240,7 +239,7 @@ public class OSMNodeTest {
 
     b = new OSMNode(id, version + 2, timestamp, changeset, userId, tags, longitude, latitude);
 
-    assertTrue(a.compareTo(b) < 0);
+    assertEquals(true, a.compareTo(b) < 0);
   }
 
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.osm;
 
 import static org.junit.Assert.assertEquals;
-
+import static org.junit.Assert.assertTrue;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -239,7 +239,7 @@ public class OSMNodeTest {
 
     b = new OSMNode(id, version + 2, timestamp, changeset, userId, tags, longitude, latitude);
 
-    assertEquals(true, a.compareTo(b) < 0);
+    assertTrue(a.compareTo(b) < 0);
   }
 
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundableTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundableTest.java
@@ -42,9 +42,9 @@ public class OSHDBBoundableTest {
   public void testIntersection() {
     OSHDBBoundable box2 = OSHDBBoundingBox.bboxOSMCoordinates(0, 0, 2, 2);
     OSHDBBoundable intersection = box2.intersection(box);
-    assertEquals(0, intersection.getMinLon());
-    assertEquals(0, intersection.getMinLat());
-    assertEquals(1, intersection.getMaxLon());
-    assertEquals(1, intersection.getMaxLat());
+    assertEquals(0, intersection.getMinLongitude());
+    assertEquals(0, intersection.getMinLatitude());
+    assertEquals(1, intersection.getMaxLongitude());
+    assertEquals(1, intersection.getMaxLatitude());
   }
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundableTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundableTest.java
@@ -9,8 +9,8 @@ import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.junit.Test;
 
 public class OSHDBBoundableTest {
-  private OSHDBBoundable point = new OSHDBBoundingBox(0L, 0L, 0L, 0L);
-  private OSHDBBoundable box = new OSHDBBoundingBox(-1L, -1L, 1L, 1L);
+  private OSHDBBoundable point = OSHDBBoundingBox.bboxOSMCoordinates(0, 0, 0, 0);
+  private OSHDBBoundable box = OSHDBBoundingBox.bboxOSMCoordinates(-1, -1, 1, 1);
 
   @Test
   public void testPoint() {
@@ -22,7 +22,7 @@ public class OSHDBBoundableTest {
   public void testValid() {
     assertTrue(point.isValid());
     assertTrue(box.isValid());
-    OSHDBBoundable invalid = new OSHDBBoundingBox(1L, 1L, -1L, -1L);
+    OSHDBBoundable invalid = OSHDBBoundingBox.bboxOSMCoordinates(1, 1, -1, -1);
     assertFalse(invalid.isValid());
   }
 
@@ -40,11 +40,11 @@ public class OSHDBBoundableTest {
 
   @Test
   public void testIntersection() {
-    OSHDBBoundable box2 = new OSHDBBoundingBox(0L, 0L, 2L, 2L);
+    OSHDBBoundable box2 = OSHDBBoundingBox.bboxOSMCoordinates(0, 0, 2, 2);
     OSHDBBoundable intersection = box2.intersection(box);
-    assertEquals(0, intersection.getMinLonLong());
-    assertEquals(0, intersection.getMinLatLong());
-    assertEquals(1, intersection.getMaxLonLong());
-    assertEquals(1, intersection.getMaxLatLong());
+    assertEquals(0, intersection.getMinLon());
+    assertEquals(0, intersection.getMinLat());
+    assertEquals(1, intersection.getMaxLon());
+    assertEquals(1, intersection.getMaxLat());
   }
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
@@ -13,7 +13,7 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testToString() {
-    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 1.0, 89.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 1.0, 89.0, 90.0);
     String expResult = "(0.0000000,1.0000000,89.0000000,90.0000000)";
     String result = instance.toString();
     assertEquals(expResult, result);
@@ -21,16 +21,16 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testIntersect() {
-    OSHDBBoundingBox first = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
-    OSHDBBoundingBox second = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.9, 2.0, 90.0);
-    OSHDBBoundingBox expResult = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.9, 1.0, 90.0);
+    OSHDBBoundingBox first = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox second = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.9, 2.0, 90.0);
+    OSHDBBoundingBox expResult = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.9, 1.0, 90.0);
     OSHDBBoundingBox result = first.intersection(second);
     assertEquals(expResult, result);
   }
 
   @Test
   public void testGetMinLon() {
-    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 0;
     int result = instance.getMinLongitude();
     assertEquals(expResult, result);
@@ -38,7 +38,7 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testGetMaxLon() {
-    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 1_0000000;
     int result = instance.getMaxLongitude();
     assertEquals(expResult, result);
@@ -46,7 +46,7 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testGetMinLat() {
-    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 89_0000000;
     int result = instance.getMinLatitude();
     assertEquals(expResult, result);
@@ -54,7 +54,7 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testGetMaxLat() {
-    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 90_0000000;
     int result = instance.getMaxLatitude();
     assertEquals(expResult, result);
@@ -62,7 +62,7 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testHashCode() {
-    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 1260356225;
     int result = instance.hashCode();
     assertEquals(expResult, result);
@@ -70,11 +70,11 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testEquals() {
-    Object obj = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    Object obj = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     assertEquals(obj, obj);
     assertNotEquals("", obj);
-    assertEquals(obj, OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0));
-    assertNotEquals(obj, OSHDBBoundingBox.bboxLonLatCoordinates(0.1, 89.0, 1.0, 90.0));
+    assertEquals(obj, OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0));
+    assertNotEquals(obj, OSHDBBoundingBox.bboxWgs84Coordinates(0.1, 89.0, 1.0, 90.0));
   }
 
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
@@ -1,6 +1,5 @@
 package org.heigit.ohsome.oshdb.util;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -32,49 +31,33 @@ public class OSHDBBoundingBoxTest {
   @Test
   public void testGetMinLon() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
-    double expResult = 0.0;
-    double result = instance.getMinLongitude();
-    assertEquals(expResult, result, 0.0);
+    int expResult = 0;
+    int result = instance.getMinLongitude();
+    assertEquals(expResult, result);
   }
 
   @Test
   public void testGetMaxLon() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
-    double expResult = 1.0;
-    double result = instance.getMaxLongitude();
-    assertEquals(expResult, result, 0.0);
+    int expResult = 1_0000000;
+    int result = instance.getMaxLongitude();
+    assertEquals(expResult, result);
   }
 
   @Test
   public void testGetMinLat() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
-    double expResult = 89.0;
-    double result = instance.getMinLatitude();
-    assertEquals(expResult, result, 0.0);
+    int expResult = 89_0000000;
+    int result = instance.getMinLatitude();
+    assertEquals(expResult, result);
   }
 
   @Test
   public void testGetMaxLat() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
-    double expResult = 90.0;
-    double result = instance.getMaxLatitude();
-    assertEquals(expResult, result, 0.0);
-  }
-
-  @Test
-  public void testGetLon() {
-    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
-    int[] expResult = new int[]{0, 10000000};
-    int[] result = instance.getLon();
-    assertArrayEquals(expResult, result);
-  }
-
-  @Test
-  public void testGetLat() {
-    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
-    int[] expResult = new int[]{890000000, 900000000};
-    int[] result = instance.getLat();
-    assertArrayEquals(expResult, result);
+    int expResult = 90_0000000;
+    int result = instance.getMaxLatitude();
+    assertEquals(expResult, result);
   }
 
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
@@ -2,6 +2,7 @@ package org.heigit.ohsome.oshdb.util;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.junit.Test;
@@ -13,7 +14,7 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testToString() {
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 1.0, 89.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 1.0, 89.0, 90.0);
     String expResult = "(0.0000000,1.0000000,89.0000000,90.0000000)";
     String result = instance.toString();
     assertEquals(expResult, result);
@@ -21,76 +22,76 @@ public class OSHDBBoundingBoxTest {
 
   @Test
   public void testIntersect() {
-    OSHDBBoundingBox first = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
-    OSHDBBoundingBox second = new OSHDBBoundingBox(0.0, 89.9, 2.0, 90.0);
-    OSHDBBoundingBox expResult = new OSHDBBoundingBox(0.0, 89.9, 1.0, 90.0);
+    OSHDBBoundingBox first = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox second = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.9, 2.0, 90.0);
+    OSHDBBoundingBox expResult = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.9, 1.0, 90.0);
     OSHDBBoundingBox result = first.intersection(second);
     assertEquals(expResult, result);
   }
 
   @Test
   public void testGetMinLon() {
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
     double expResult = 0.0;
-    double result = instance.getMinLon();
+    double result = instance.getMinLongitude();
     assertEquals(expResult, result, 0.0);
   }
 
   @Test
   public void testGetMaxLon() {
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
     double expResult = 1.0;
-    double result = instance.getMaxLon();
+    double result = instance.getMaxLongitude();
     assertEquals(expResult, result, 0.0);
   }
 
   @Test
   public void testGetMinLat() {
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
     double expResult = 89.0;
-    double result = instance.getMinLat();
+    double result = instance.getMinLatitude();
     assertEquals(expResult, result, 0.0);
   }
 
   @Test
   public void testGetMaxLat() {
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
     double expResult = 90.0;
-    double result = instance.getMaxLat();
+    double result = instance.getMaxLatitude();
     assertEquals(expResult, result, 0.0);
   }
 
   @Test
   public void testGetLon() {
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
-    long[] expResult = new long[]{0L, 10000000L};
-    long[] result = instance.getLon();
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    int[] expResult = new int[]{0, 10000000};
+    int[] result = instance.getLon();
     assertArrayEquals(expResult, result);
   }
 
   @Test
   public void testGetLat() {
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
-    long[] expResult = new long[]{890000000L, 900000000L};
-    long[] result = instance.getLat();
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    int[] expResult = new int[]{890000000, 900000000};
+    int[] result = instance.getLat();
     assertArrayEquals(expResult, result);
   }
 
   @Test
   public void testHashCode() {
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
-    int expResult = 748664391;
+    OSHDBBoundingBox instance = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    int expResult = 1260356225;
     int result = instance.hashCode();
     assertEquals(expResult, result);
   }
 
   @Test
   public void testEquals() {
-    Object obj = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
-    OSHDBBoundingBox instance = new OSHDBBoundingBox(0.0, 89.0, 1.0, 90.0);
-    boolean expResult = true;
-    boolean result = instance.equals(obj);
-    assertEquals(expResult, result);
+    Object obj = OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0);
+    assertEquals(obj, obj);
+    assertNotEquals("", obj);
+    assertEquals(obj, OSHDBBoundingBox.bboxLonLatCoordinates(0.0, 89.0, 1.0, 90.0));
+    assertNotEquals(obj, OSHDBBoundingBox.bboxLonLatCoordinates(0.1, 89.0, 1.0, 90.0));
   }
 
 }


### PR DESCRIPTION
This PR change the internal representation of the "osm-coordinates" from a `long` to `int` data-type.
It mainly affects the `OSHDBBoundingBox` class and a new `OSMCoordinates` helper class .

The OSHDBBoundingBox had 3 construtors with different data-types as  arguments:
- `double` type arguments, lon/lat wgs48 representation e.g. 8.6724, 49.3988
- `int` type arguments, also lon/lat wgs48 but omitting the decimal parts,  e.g. 8, 49
- `long` type  arguments, the interal "osm-coordinates", e.g. 86724000, 493988000

For better distinction, new constructor functions are introduced,
- `bboxLonLatCoordinates`, for lon/lat coordinates
- `bboxOSMCoordinates`, for "osm-coordinates"

And some helper methods
- `OSMCoordinates.toDouble` -> from "osm-coordinate" to lon/lat coordinate
- `OSMCoordinates.toOSM` -> from lon/lat to "osm-coordinate"

The refactoring where mostly done with search&replace like
```
var bbox = new OSHDBBoundingBox(-180, -90, 180, 90); // before
var bbox = OSHDBBoundingBox.bboxLonLatCoordinates(-180.0, -90.0, 180.0, 90.0); // after
```

`OSHDBGeometryBuilder` also got a new helper method
- `getCoordinate` which converts a "osm-coordinates" into `jts.Coordinates`

### other refactorings
#### `OSHEntity`
- `getNodes`, `getWays` don't throw an exception any more!
- code refactoring to avoid duplicated codelines

#### `OSHDBHandler`
The `OSHDBHandler` class in the etl module got some refactoring, mainly to get rid of duplicated codes sonar-lint warnings. For than  a new `OSHDBHandlerTest` class were written.


### Corresponding issue
Closes #320

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

