### PR TITLE
OSMWay: rename  getRefEntities to getMemberEntities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ Changelog
   | moved and renamed module | `oshdb-tool/etl` | `oshdb-etl` |
   | moved and renamed module | `oshdb-tool/oshpbf-parser` | `oshdb-oshpbf-parser` |
   | renamed method | `OSMWay.getRef()` | `OSMWay.getMember()` |
+  | renamed method | `OSMWay.getRefEntities(long)` | `OSMWay.getMemberEntities(long)` |
   | renamed method | `OSHDBTimestamp.getRawUnixTimestamp()` | `OSHDBTimestamp.getEpochSecond()` |
   | moved class | `oshdb.util.OSHDBTimestamp` | `oshdb.OSHDBTimestamp` |
   | moved class | `oshdb.util.OSHDBBoundingBox` | `oshdb.OSHDBBoundingBox` |

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/object/OSMContributionImpl.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/object/OSMContributionImpl.java
@@ -140,7 +140,7 @@ public class OSMContributionImpl implements OSMContribution {
     int userId = -1;
     // search children for actual contributor's userId
     if (entity instanceof OSMWay) {
-      userId = ((OSMWay) entity).getRefEntities(contributionTimestamp)
+      userId = ((OSMWay) entity).getMemberEntities(contributionTimestamp)
           .filter(Objects::nonNull)
           .filter(n -> n.getEpochSecond() == contributionTimestamp.getEpochSecond())
           .findFirst()
@@ -160,7 +160,7 @@ public class OSMContributionImpl implements OSMContribution {
                   // todo: what to do with rel->node member changes or rel->rel[->*] changes?
                   .filter(e -> e instanceof OSMWay)
                   .map(e -> (OSMWay) e)
-                  .flatMap(w -> w.getRefEntities(contributionTimestamp))
+                  .flatMap(w -> w.getMemberEntities(contributionTimestamp))
                   .filter(Objects::nonNull)
                   .filter(n -> n.getEpochSecond() == contributionTimestamp.getEpochSecond())
                   .findFirst()

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -95,7 +95,7 @@ public class OSHDBGeometryBuilder {
       }
       // todo: handle old-style multipolygons here???
       Coordinate[] coords =
-          way.getRefEntities(timestamp)
+          way.getMemberEntities(timestamp)
               .filter(Objects::nonNull)
               .filter(OSMEntity::isVisible)
               .map(nd -> new Coordinate(nd.getLongitude(), nd.getLatitude()))
@@ -316,7 +316,7 @@ public class OSHDBGeometryBuilder {
         .map(osm -> (OSMWay) osm)
         .filter(Objects::nonNull)
         .filter(OSMEntity::isVisible)
-        .map(way -> way.getRefEntities(timestamp)
+        .map(way -> way.getMemberEntities(timestamp)
             .filter(Objects::nonNull)
             .filter(OSMEntity::isVisible)
         );

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMRelation.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMRelation.java
@@ -34,6 +34,12 @@ public class OSMRelation extends OSMEntity implements Comparable<OSMRelation>, S
         .filter(Objects::nonNull).map(entity -> OSHEntities.getByTimestamp(entity, timestamp));
   }
 
+  /**
+   * Returns a stream of all member entities (OSM) for the given timestamp.
+   *
+   * @param timestamp the timestamp for the osm member entity
+   * @return stream of member entities (OSM)
+   */
   public Stream<OSMEntity> getMemberEntities(OSHDBTimestamp timestamp) {
     return this.getMemberEntities(timestamp, osmMember -> true);
   }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMWay.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMWay.java
@@ -32,7 +32,13 @@ public class OSMWay extends OSMEntity implements Comparable<OSMWay>, Serializabl
     return members;
   }
 
-  public Stream<OSMNode> getRefEntities(OSHDBTimestamp timestamp) {
+  /**
+   * Returns a stream of all member entities (OSM) for the given timestamp.
+   *
+   * @param timestamp the timestamp for the osm member entity
+   * @return stream of member entities (OSM)
+   */
+  public Stream<OSMNode> getMemberEntities(OSHDBTimestamp timestamp) {
     return Arrays.stream(this.getMembers())
         .map(OSMMember::getEntity)
         .filter(Objects::nonNull)


### PR DESCRIPTION
Renaming `OSMWay.getRefEntities` to `OSMWay.getMemberEntities` to make this method name more aligned with the `getMembers` method.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)~
- ~I have added sufficient unit tests~
- ~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository
- [ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
