### PR TITLE
Add hashEode/equals to OSHEntityImpl to match OSMEntity hashCode/equals

### DIFF
--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.NoSuchElementException;
+import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.annotation.Nonnull;
@@ -296,8 +297,6 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
     public int getLength() {
       return length;
     }
-
-
   }
 
   protected OSHEntityImpl(final CommonEntityProps p) {
@@ -346,6 +345,23 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
     this.keys = keys;
     this.dataOffset = dataOffset;
     this.dataLength = dataLength;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getType(), id);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (!(obj instanceof OSHEntity)) {
+      return false;
+    }
+    OSHEntity other = (OSHEntity) obj;
+    return getType() == other.getType() && id == other.getId();
   }
 
   /**

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHEntityTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHEntityTest.java
@@ -1,0 +1,39 @@
+package org.heigit.ohsome.oshdb.osh;
+
+import static org.heigit.ohsome.oshdb.osh.OSHNodeTest.buildOSHNode;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import com.google.common.collect.Lists;
+import java.io.IOException;
+import java.util.Collections;
+import org.heigit.ohsome.oshdb.impl.osh.OSHRelationImpl;
+import org.heigit.ohsome.oshdb.osm.OSMMember;
+import org.heigit.ohsome.oshdb.osm.OSMNode;
+import org.heigit.ohsome.oshdb.osm.OSMRelation;
+import org.junit.Test;
+
+public class OSHEntityTest {
+
+  @Test
+  public void testHashCodeEquals() throws IOException {
+    var expected = buildOSHNode(
+        new OSMNode(123L, 1, 1L, 0L, 1, new int[0], 0, 0)
+    );
+
+    var a = buildOSHNode(
+        new OSMNode(123L, 1, 1L, 0L, 1, new int[0], 0, 0)
+    );
+
+    var b = OSHRelationImpl.build(Lists.newArrayList(
+        new OSMRelation(123L, 1, 3333L, 4444L, 23, new int[0],
+            new OSMMember[0])), Collections.emptyList(), Collections.emptyList());
+
+    assertEquals(expected.hashCode(), a.hashCode());
+    assertNotEquals(expected.hashCode(), b.hashCode());
+
+    assertEquals(expected, a);
+    assertNotEquals(expected, b);
+  }
+
+}

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHNodeTest.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.oshdb.osh;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 
 import com.google.common.collect.Iterables;
@@ -59,6 +60,27 @@ public class OSHNodeTest {
         "OSHNode ID:123 Vmax:+2+ Creation:1 BBox:(49.410283,8.675635),(49.418621,8.715334)";
     String result = instance.toString();
     assertEquals(expResult, result);
+  }
+
+  @Test
+  public void testHashCodeEquals() throws IOException {
+    var expected = buildOSHNode(
+        new OSMNode(123L, 1, 1L, 0L, USER_A, TAGS_A, 0, 0)
+    );
+
+    var a = buildOSHNode(
+        new OSMNode(123L, 1, 1L, 0L, USER_A, TAGS_A, 0, 0)
+    );
+
+    var b = buildOSHNode(
+        new OSMNode(444L, 1, 2L, 0L, USER_A, TAGS_A, 0, 0)
+    );
+
+    assertEquals(expected.hashCode(), a.hashCode());
+    assertNotEquals(expected.hashCode(), b.hashCode());
+
+    assertEquals(expected, a);
+    assertNotEquals(expected, b);
   }
 
   static OSHNode buildOSHNode(OSMNode... versions) throws IOException {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.oshdb.osh;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -179,5 +180,26 @@ public class OSHRelationTest {
         "OSHRelation ID:300 Vmax:+1+ Creation:3333 BBox:(8.680972,49.409496),(8.680974,49.409498)";
     String result = instance.toString();
     assertEquals(expResult, result);
+  }
+
+  @Test
+  public void testHashCodeEquals() throws IOException {
+    var expected = OSHRelationImpl.build(Lists.newArrayList(
+        new OSMRelation(123L, 1, 3333L, 4444L, 23, new int[]{},
+            new OSMMember[]{})), Collections.emptyList(), Collections.emptyList());
+
+    var a = OSHRelationImpl.build(Lists.newArrayList(
+        new OSMRelation(123L, 1, 3333L, 4444L, 23, new int[]{},
+            new OSMMember[]{})), Collections.emptyList(), Collections.emptyList());
+
+    var b = OSHRelationImpl.build(Lists.newArrayList(
+        new OSMRelation(444L, 1, 3333L, 4444L, 23, new int[]{},
+            new OSMMember[]{})), Collections.emptyList(), Collections.emptyList());
+
+    assertEquals(expected.hashCode(), a.hashCode());
+    assertNotEquals(expected.hashCode(), b.hashCode());
+
+    assertEquals(expected, a);
+    assertNotEquals(expected, b);
   }
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.oshdb.osh;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -116,5 +117,26 @@ public class OSHWayTest {
         "OSHWay ID:123 Vmax:+3+ Creation:3333 BBox:(8.680973,49.409498),(8.680973,49.409498)";
     String result = instance.toString();
     assertEquals(expResult, result);
+  }
+
+  @Test
+  public void testHashCodeEquals() throws IOException {
+    var expected = OSHWayImpl.build(Lists.newArrayList(
+        new OSMWay(123L, 1, 3333L, 4444L, 23, new int[]{},
+            new OSMMember[]{})), Arrays.asList());
+
+    var a = OSHWayImpl.build(Lists.newArrayList(
+        new OSMWay(123L, 1, 3333L, 4444L, 23, new int[]{},
+            new OSMMember[]{})), Arrays.asList());
+
+    var b = OSHWayImpl.build(Lists.newArrayList(
+        new OSMWay(444L, 1, 3333L, 4444L, 23, new int[]{},
+            new OSMMember[]{})), Arrays.asList());
+
+    assertEquals(expected.hashCode(), a.hashCode());
+    assertNotEquals(expected.hashCode(), b.hashCode());
+
+    assertEquals(expected, a);
+    assertNotEquals(expected, b);
   }
 }


### PR DESCRIPTION
OSHEntityImpl is missing to override hashCode/equals. This PR add both methods to OSHEntityImpl to match the hashCode/equals of the OSMEntity.

### Checklist
- [X] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- ~I have commented my code~
- ~I have written javadoc (required for public classes and methods)~
- [x] I have added sufficient unit tests
- ~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- ~I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)~
- ~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
