### PR TITLE
add generic OSHDBException / add ownership and cluster state check to OSHDBIgnite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Changelog
 * add new interfaces `OSHDBTemporal` and `OSHDBBoundable` ([#369])
 * major improvements to code style guide adherence; fix some potential bugs found in static code analyis ([#374])
 * upgrade apache ignite to version 2.10.0 ([#386])
+* if cluster state is not active an exception will thrown ([#337])
 
 ### bugfixes
 
@@ -72,6 +73,7 @@ Changelog
 
 [#306]: https://github.com/GIScience/oshdb/pull/306
 [#327]: https://github.com/GIScience/oshdb/issues/327
+[#337]: https://github.com/GIScience/oshdb/issues/337
 [#338]: https://github.com/GIScience/oshdb/issues/338
 [#352]: https://github.com/GIScience/oshdb/pull/352
 [#353]: https://github.com/GIScience/oshdb/pull/353

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBIgnite.java
@@ -15,6 +15,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.backend.MapReducerIgniteLocalPeek;
 import org.heigit.ohsome.oshdb.api.mapreducer.backend.MapReducerIgniteScanQuery;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.TableNames;
+import org.heigit.ohsome.oshdb.util.exceptions.OSHDBException;
 import org.heigit.ohsome.oshdb.util.exceptions.OSHDBTableNotFoundException;
 import org.heigit.ohsome.oshdb.util.mappable.OSHDBMapReducible;
 
@@ -39,18 +40,32 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
   }
 
   private final Ignite ignite;
+  private final boolean owner;
   private ComputeMode computeMode = ComputeMode.LOCAL_PEEK;
 
   private IgniteRunnable onCloseCallback = null;
 
+  /**
+   * Create a new OSHDBDatabase based on default ("ignite-config.xml") configuration.
+   */
   public OSHDBIgnite() {
     this(new File("ignite-config.xml"));
   }
 
+  /**
+   * Creates a new OSHDBDatabase using the given Ignite instance.
+   *
+   * @param ignite Ignite instance to use.
+   */
   public OSHDBIgnite(Ignite ignite) {
-    this.ignite = ignite;
+    this(ignite, false);
   }
 
+  /**
+   * Opens a connection to oshdb data stored on an Ignite cluster.
+   *
+   * @param igniteConfigFilePath ignite configuration file
+   */
   public OSHDBIgnite(String igniteConfigFilePath) {
     this(new File(igniteConfigFilePath));
   }
@@ -61,8 +76,25 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
    * @param igniteConfig ignite configuration file
    */
   public OSHDBIgnite(File igniteConfig) {
+    this(startClient(igniteConfig), true);
+  }
+
+  private OSHDBIgnite(Ignite ignite, boolean owner) {
+    this.ignite = ignite;
+    this.owner = owner;
+    checkStateActive();
+  }
+
+  private static Ignite startClient(File igniteConfig) {
     Ignition.setClientMode(true);
-    this.ignite = Ignition.start(igniteConfig.toString());
+    return Ignition.start(igniteConfig.toString());
+  }
+
+  private void checkStateActive() {
+    var cluster = ignite.cluster();
+    if (cluster.state().active()) {
+      throw new OSHDBException("cluster not in state active!");
+    }
   }
 
   @Override
@@ -103,12 +135,20 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
     return null;
   }
 
+  /**
+   * Returns the actual Ignite instance.
+   *
+   * @return Ignite instance
+   */
   public Ignite getIgnite() {
     return this.ignite;
   }
 
+  @Override
   public void close() {
-    this.ignite.close();
+    if (owner) {
+      this.ignite.close();
+    }
   }
 
   /**
@@ -144,7 +184,6 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
     this.onCloseCallback = action;
     return this;
   }
-
 
   /**
    * Gets the onClose callback.

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBIgnite.java
@@ -97,7 +97,7 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
 
   private void checkStateActive() {
     var cluster = ignite.cluster();
-    if (cluster.state().active()) {
+    if (!cluster.state().active()) {
       throw new OSHDBException("cluster not in state active!");
     }
   }

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBIgnite.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBIgnite.java
@@ -47,6 +47,8 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
 
   /**
    * Create a new OSHDBDatabase based on default ("ignite-config.xml") configuration.
+   *
+   * @throws OSHDBException if cluster state is not active.
    */
   public OSHDBIgnite() {
     this(new File("ignite-config.xml"));
@@ -56,6 +58,7 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
    * Creates a new OSHDBDatabase using the given Ignite instance.
    *
    * @param ignite Ignite instance to use.
+   * @throws OSHDBException if cluster state is not active.
    */
   public OSHDBIgnite(Ignite ignite) {
     this(ignite, false);
@@ -65,6 +68,7 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
    * Opens a connection to oshdb data stored on an Ignite cluster.
    *
    * @param igniteConfigFilePath ignite configuration file
+   * @throws OSHDBException if cluster state is not active.
    */
   public OSHDBIgnite(String igniteConfigFilePath) {
     this(new File(igniteConfigFilePath));
@@ -74,6 +78,7 @@ public class OSHDBIgnite extends OSHDBDatabase implements AutoCloseable {
    * Opens a connection to oshdb data stored on an Ignite cluster.
    *
    * @param igniteConfig ignite configuration file
+   * @throws OSHDBException if cluster state is not active.
    */
   public OSHDBIgnite(File igniteConfig) {
     this(startClient(igniteConfig), true);

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBException.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBException.java
@@ -1,0 +1,43 @@
+package org.heigit.ohsome.oshdb.util.exceptions;
+
+/**
+ * General OSHDB exception. This exception is used to indicate any error condition while using
+ * OSHDB.
+ */
+public class OSHDBException extends RuntimeException {
+
+  /**
+   * Create empty exception.
+   */
+  public OSHDBException() {
+    super();
+  }
+
+  /**
+   * Creates new exception with given error message.
+   *
+   * @param message Error message.
+   */
+  public OSHDBException(String message) {
+    super(message);
+  }
+
+  /**
+   * Creates new grid exception with given throwable as a cause and source of error message.
+   *
+   * @param cause Non-null throwable cause.
+   */
+  public OSHDBException(Throwable cause) {
+    this(cause.getMessage(), cause);
+  }
+
+  /**
+   * Creates new exception with given error message and optional nested exception.
+   *
+   * @param message Error message.
+   * @param cause Optional nested exception (can be {@code null}).
+   */
+  public OSHDBException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBInvalidTimestampException.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBInvalidTimestampException.java
@@ -3,7 +3,7 @@ package org.heigit.ohsome.oshdb.util.exceptions;
 /**
  * An exception caused by invalid time string input.
  */
-public class OSHDBInvalidTimestampException extends RuntimeException {
+public class OSHDBInvalidTimestampException extends OSHDBException {
   public OSHDBInvalidTimestampException(String message) {
     super(message);
   }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBTableNotFoundException.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBTableNotFoundException.java
@@ -3,7 +3,7 @@ package org.heigit.ohsome.oshdb.util.exceptions;
 /**
  * An exception caused by missing tables or caches.
  */
-public class OSHDBTableNotFoundException extends RuntimeException {
+public class OSHDBTableNotFoundException extends OSHDBException {
   public OSHDBTableNotFoundException(String missingTable) {
     super("Database doesn't contain the required table(s)/cache(s): " + missingTable + ".");
   }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBTagOrRoleNotFoundException.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBTagOrRoleNotFoundException.java
@@ -3,7 +3,7 @@ package org.heigit.ohsome.oshdb.util.exceptions;
 /**
  * An exception caused by corrupt keytables data.
  */
-public class OSHDBTagOrRoleNotFoundException extends RuntimeException {
+public class OSHDBTagOrRoleNotFoundException extends OSHDBException {
   public OSHDBTagOrRoleNotFoundException(String msg) {
     super(msg);
   }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBTimeoutException.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/exceptions/OSHDBTimeoutException.java
@@ -3,4 +3,5 @@ package org.heigit.ohsome.oshdb.util.exceptions;
 /**
  * An exception caused by a timeout during a query.
  */
-public class OSHDBTimeoutException extends RuntimeException {}
+public class OSHDBTimeoutException extends OSHDBException {
+}


### PR DESCRIPTION
Adds a generic OSHDBException class.
Adds ownership and cluster state check to OSHDBIgnite.

### Corresponding issue
Closes #337

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- ~I have added sufficient unit tests~
- ~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~
