### PR TITLE
bugfix incorrect bbox in GridOSHEntity.toString

### DIFF
--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/grid/GridOSHEntity.java
@@ -55,7 +55,7 @@ public abstract class GridOSHEntity
   @Override
   public String toString() {
     if (id >= 0) {
-      OSHDBBoundingBox bbox = XYGrid.getBoundingBox(new CellId((int) id, level));
+      OSHDBBoundingBox bbox = XYGrid.getBoundingBox(new CellId(level, id));
       return String.format(Locale.ENGLISH, "ID:%d Level:%d %s", id, level, bbox);
     } else {
       return String.format(Locale.ENGLISH, "ID:%d Level:%d", id, level);


### PR DESCRIPTION
this PR fix a bug in the `GridOSHEntity.toString`. 
