### PR TITLE
Fix contribution-based filters used in and/or expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## 0.8.0-SNAPSHOT (current master)
 
+* fix a bug where contribution-based filters are not applied when used in an and/or operation. ([#409])
+
+[#409]: https://github.com/GIScience/oshdb/issues/409
+
 
 ## 0.7.0
 

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/AndOperator.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/AndOperator.java
@@ -3,6 +3,8 @@ package org.heigit.ohsome.oshdb.filter;
 import java.util.function.Supplier;
 import org.heigit.ohsome.oshdb.osh.OSHEntity;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
+import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
+import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.locationtech.jts.geom.Geometry;
 
 /**
@@ -27,6 +29,16 @@ public class AndOperator extends BinaryOperator {
   public boolean applyOSMGeometry(OSMEntity entity, Supplier<Geometry> geometrySupplier) {
     return op1.applyOSMGeometry(entity, geometrySupplier)
         && op2.applyOSMGeometry(entity, geometrySupplier);
+  }
+
+  @Override
+  public boolean applyOSMEntitySnapshot(OSMEntitySnapshot snapshot) {
+    return op1.applyOSMEntitySnapshot(snapshot) && op2.applyOSMEntitySnapshot(snapshot);
+  }
+
+  @Override
+  public boolean applyOSMContribution(OSMContribution contribution) {
+    return op1.applyOSMContribution(contribution) && op2.applyOSMContribution(contribution);
   }
 
   @Override

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/OrOperator.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/OrOperator.java
@@ -3,6 +3,8 @@ package org.heigit.ohsome.oshdb.filter;
 import java.util.function.Supplier;
 import org.heigit.ohsome.oshdb.osh.OSHEntity;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
+import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
+import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.locationtech.jts.geom.Geometry;
 
 /**
@@ -27,6 +29,17 @@ public class OrOperator extends BinaryOperator {
   public boolean applyOSMGeometry(OSMEntity entity, Supplier<Geometry> geometrySupplier) {
     return op1.applyOSMGeometry(entity, geometrySupplier)
         || op2.applyOSMGeometry(entity, geometrySupplier);
+  }
+
+
+  @Override
+  public boolean applyOSMEntitySnapshot(OSMEntitySnapshot snapshot) {
+    return op1.applyOSMEntitySnapshot(snapshot) || op2.applyOSMEntitySnapshot(snapshot);
+  }
+
+  @Override
+  public boolean applyOSMContribution(OSMContribution contribution) {
+    return op1.applyOSMContribution(contribution) || op2.applyOSMContribution(contribution);
   }
 
   @Override

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMContributionTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMContributionTest.java
@@ -182,4 +182,16 @@ public class ApplyOSMContributionTest extends FilterTest {
     FilterParser parser = new FilterParser(tagTranslator, true);
     testContribution(parser.parse("contributor:(1..2)"));
   }
+
+  @Test
+  public void testAndOperator() {
+    FilterParser parser = new FilterParser(tagTranslator, true);
+    testContribution(parser.parse("contributor:1 and type:node"));
+  }
+
+  @Test
+  public void testOrOperator() {
+    FilterParser parser = new FilterParser(tagTranslator, true);
+    testContribution(parser.parse("contributor:1 or foo=doesntexist"));
+  }
 }

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
@@ -118,4 +118,16 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
     FilterParser parser = new FilterParser(tagTranslator, true);
     testFailWithSnapshot(parser.parse("contributor:(1..3)"));
   }
+
+  @Test(expected = IllegalStateException.class)
+  public void testAndOperator() {
+    FilterParser parser = new FilterParser(tagTranslator, true);
+    testFailWithSnapshot(parser.parse("contributor:1 and type:node"));
+  }
+
+  @Test(expected = IllegalStateException.class)
+  public void testOrOperator() {
+    FilterParser parser = new FilterParser(tagTranslator, true);
+    testFailWithSnapshot(parser.parse("contributor:1 or foo=doesntexist"));
+  }
 }


### PR DESCRIPTION
### Description
Adds missing implementation of `applyOSMContribution`/`applyOSMEntitySnapshot` for and and or operators.

### Corresponding issue
Fixes #409

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

