### PR TITLE
fix serializability of geometry filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ Changelog
 
  * remove class `oshdb-util:util.time.TimestampFormatter` ([#419])
 
+### bugfixes
+
+* fix a bug which causes queries using the geometry filters `length:` and `area:` to fail when executed on an ignite cluster ([#426])
+
 [#419]: https://github.com/GIScience/oshdb/pull/419
+[#419]: https://github.com/GIScience/oshdb/pull/426
 
 
 ## 0.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changelog
 * fix a bug which causes queries using the geometry filters `length:` and `area:` to fail when executed on an ignite cluster ([#426])
 
 [#419]: https://github.com/GIScience/oshdb/pull/419
-[#419]: https://github.com/GIScience/oshdb/pull/426
+[#426]: https://github.com/GIScience/oshdb/pull/426
 
 
 ## 0.7.1

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryFilter.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryFilter.java
@@ -39,7 +39,7 @@ public abstract class GeometryFilter extends NegatableFilter {
     }
   }
 
-  interface GeometryMetricEvaluator extends SerializableToDoubleFunction<Geometry>, Serializable {
+  interface GeometryMetricEvaluator extends SerializableToDoubleFunction<Geometry> {
     double applyAsDouble(Geometry geometry);
 
     static GeometryMetricEvaluator fromLambda(

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryFilter.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryFilter.java
@@ -2,9 +2,9 @@ package org.heigit.ohsome.oshdb.filter;
 
 import java.io.Serializable;
 import java.util.function.Supplier;
-import java.util.function.ToDoubleFunction;
 import javax.annotation.Nonnull;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
+import org.heigit.ohsome.oshdb.util.function.SerializableToDoubleFunction;
 import org.locationtech.jts.geom.Geometry;
 
 /**
@@ -38,8 +38,6 @@ public abstract class GeometryFilter extends NegatableFilter {
       return toValue;
     }
   }
-
-  interface SerializableToDoubleFunction<X> extends ToDoubleFunction<X>, Serializable {}
 
   interface GeometryMetricEvaluator extends SerializableToDoubleFunction<Geometry>, Serializable {
     double applyAsDouble(Geometry geometry);

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryFilter.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryFilter.java
@@ -39,10 +39,13 @@ public abstract class GeometryFilter extends NegatableFilter {
     }
   }
 
-  interface GeometryMetricEvaluator extends ToDoubleFunction<Geometry>, Serializable {
+  interface SerializableToDoubleFunction<X> extends ToDoubleFunction<X>, Serializable {}
+
+  interface GeometryMetricEvaluator extends SerializableToDoubleFunction<Geometry>, Serializable {
     double applyAsDouble(Geometry geometry);
 
-    static GeometryMetricEvaluator fromLambda(ToDoubleFunction<Geometry> func, String name) {
+    static GeometryMetricEvaluator fromLambda(
+        SerializableToDoubleFunction<Geometry> func, String name) {
       return new GeometryMetricEvaluator() {
         @Override
         public double applyAsDouble(Geometry geometry) {

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/function/SerializableToDoubleFunction.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/function/SerializableToDoubleFunction.java
@@ -1,0 +1,9 @@
+package org.heigit.ohsome.oshdb.util.function;
+
+import java.io.Serializable;
+import java.util.function.ToDoubleFunction;
+
+/**
+ * A serializable {@link ToDoubleFunction}.
+ */
+public interface SerializableToDoubleFunction<T> extends ToDoubleFunction<T>, Serializable {}


### PR DESCRIPTION
### Description
Fixes a serializability issue involving the geometry based filters (`length:` and `area:`).

This currently causes ohsome API queries to fail if they use these filters: [example](https://api.ohsome.org/v1/elements/count?bboxes=8.67%2C49.39%2C8.71%2C49.42&filter=type%3Away%20and%20natural%3D*%20and%20length%3A(0..10)&format=json&time=2014-01-01%2F2017-01-01%2FP1Y)

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- ~~I have added sufficient unit tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~
