### PR TITLE
Bug/#427 make iterate by contribute more streamable, replace filter with takewhile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ Changelog
 ### bugfixes
 
 * fix a bug which causes queries using the geometry filters `length:` and `area:` to fail when executed on an ignite cluster ([#426])
+* fix a bug which cause ComputeJobs to keep processing for a while despite they are already canceled ([#428])
 
 [#419]: https://github.com/GIScience/oshdb/pull/419
 [#426]: https://github.com/GIScience/oshdb/pull/426
+[#428]: https://github.com/GIScience/oshdb/pull/428
 
 
 ## 0.7.1

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/Kernels.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/Kernels.java
@@ -22,7 +22,7 @@ class Kernels implements Serializable {
   interface CellProcessor<S> extends SerializableBiFunction<GridOSHEntity, CellIterator, S> {}
 
   interface CancelableProcessStatus {
-    default <T> boolean isActive(T ignore) {
+    default <T> boolean isActive(T ignored) {
       return isActive();
     }
 

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/Kernels.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/Kernels.java
@@ -22,6 +22,10 @@ class Kernels implements Serializable {
   interface CellProcessor<S> extends SerializableBiFunction<GridOSHEntity, CellIterator, S> {}
 
   interface CancelableProcessStatus {
+    default <T> boolean isActive(T ignore) {
+      return isActive();
+    }
+
     boolean isActive();
   }
 
@@ -57,7 +61,7 @@ class Kernels implements Serializable {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       cellIterator.iterateByContribution(oshEntityCell)
-          .filter(ignored -> process.isActive())
+          .takeWhile(process::isActive)
           .forEach(contribution -> {
             OSMContribution osmContribution = new OSMContributionImpl(contribution);
             accInternal.set(accumulator.apply(accInternal.get(), mapper.apply(osmContribution)));
@@ -87,7 +91,7 @@ class Kernels implements Serializable {
       // iterate over the history of all OSM objects in the current cell
       List<OSMContribution> contributions = new ArrayList<>();
       cellIterator.iterateByContribution(oshEntityCell)
-          .filter(ignored -> process.isActive())
+          .takeWhile(process::isActive)
           .forEach(contribution -> {
             OSMContribution thisContribution = new OSMContributionImpl(contribution);
             if (contributions.size() > 0
@@ -131,7 +135,7 @@ class Kernels implements Serializable {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       cellIterator.iterateByTimestamps(oshEntityCell)
-          .filter(ignored -> process.isActive())
+          .takeWhile(process::isActive)
           .forEach(data -> {
             OSMEntitySnapshot snapshot = new OSMEntitySnapshotImpl(data);
             // immediately fold the result
@@ -162,7 +166,7 @@ class Kernels implements Serializable {
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
       cellIterator.iterateByTimestamps(oshEntityCell)
-          .filter(ignored -> process.isActive())
+          .takeWhile(process::isActive)
           .forEach(data -> {
             OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshotImpl(data);
             if (osmEntitySnapshots.size() > 0
@@ -203,7 +207,7 @@ class Kernels implements Serializable {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       return cellIterator.iterateByContribution(oshEntityCell)
-          .filter(ignored -> process.isActive())
+          .takeWhile(process::isActive)
           .map(OSMContributionImpl::new)
           .map(mapper);
     };
@@ -226,7 +230,7 @@ class Kernels implements Serializable {
       List<OSMContribution> contributions = new ArrayList<>();
       List<S> result = new LinkedList<>();
       cellIterator.iterateByContribution(oshEntityCell)
-          .filter(ignored -> process.isActive())
+          .takeWhile(process::isActive)
           .map(OSMContributionImpl::new)
           .forEach(contribution -> {
             if (contributions.size() > 0 && contribution.getEntityAfter().getId()
@@ -260,7 +264,7 @@ class Kernels implements Serializable {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       return cellIterator.iterateByTimestamps(oshEntityCell)
-          .filter(ignored -> process.isActive())
+          .takeWhile(process::isActive)
           .map(OSMEntitySnapshotImpl::new)
           .map(mapper);
     };
@@ -283,7 +287,7 @@ class Kernels implements Serializable {
       List<OSMEntitySnapshot> snapshots = new ArrayList<>();
       List<S> result = new LinkedList<>();
       cellIterator.iterateByTimestamps(oshEntityCell)
-          .filter(ignored -> process.isActive())
+          .takeWhile(process::isActive)
           .map(OSMEntitySnapshotImpl::new)
           .forEach(contribution -> {
             if (snapshots.size() > 0 && contribution.getEntity().getId()

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/osh/OSHEntityTimeUtils.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/osh/OSHEntityTimeUtils.java
@@ -176,6 +176,9 @@ public class OSHEntityTimeUtils {
       OSHEntity osh, boolean recurse, Predicate<OSMEntity> osmEntityFilter) {
     // first, store this ways direct modifications (i.e. the "major" versions' timestamps)
     var entityTimestamps = getModificationTimestampsReverseNonRecursed(osh, osmEntityFilter);
+    if (entityTimestamps.isEmpty()) {
+      return entityTimestamps;
+    }
     if (!recurse || osh instanceof OSHNode) {
       return Lists.reverse(entityTimestamps);
     }


### PR DESCRIPTION
This is the PR for Issue #427

Task keep processing for a while despite it is canceled.

### Description
Replacing/refactoring the for-loop in CellIterator `iterateByContribution`, to an Iterator which could be stream.
The previous approach with a for-loop keeps generating all Contributions for an OSHEntity, collecting those into an LinkedList and finally streams the list "out" of the method  `iterateByContribution`.
The new version skips the collecting of all Contributions to a LinkedList completely, that has the advantage, 
- only one/two Contribution exists at a given time
- stopping generating Contributions when not needed

### Corresponding issue
Closes #427

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- [x] I have added sufficient unit tests
- ~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~

<!--Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.-->