### PR TITLE
jts(1.18.2) and other dependencies plus reorganize version properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Changelog
 
 [#419]: https://github.com/GIScience/oshdb/pull/419
 
+### other changes
+
+ * update jts dependency to version 1.18.2
 
 ## 0.7.2
 

--- a/oshdb-etl/pom.xml
+++ b/oshdb-etl/pom.xml
@@ -11,6 +11,12 @@
   <artifactId>oshdb-etl</artifactId>
   <packaging>jar</packaging>
   <description>Extract, Transform and Load your data into an JDBC or Ignite Database.</description>
+  
+  <properties>
+    <roaringbitmap.version>0.9.17</roaringbitmap.version>
+    <fastutil.version>8.1.1</fastutil.version>
+    <jcommander.version>1.72</jcommander.version>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/oshdb-filter/pom.xml
+++ b/oshdb-filter/pom.xml
@@ -48,7 +48,6 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/oshdb-util/pom.xml
+++ b/oshdb-util/pom.xml
@@ -11,6 +11,10 @@
   <artifactId>oshdb-util</artifactId>
   <name>OSHDB utilities</name>
   <description>A collection of utilities for accessing to the OSHDB data and for performing computations on top of these.</description>
+  
+  <properties>
+    <googlejson.version>1.1.1</googlejson.version>
+  </properties>
 
   <dependencies>
     <dependency>

--- a/oshdb/pom.xml
+++ b/oshdb/pom.xml
@@ -11,6 +11,10 @@
   <artifactId>oshdb</artifactId>
   <name>OSHDB core</name>
   <description>The central data model of the OpenStreetMap History Database.</description>
+  
+  <properties>
+    <mavenassembly.version>3.3.0</mavenassembly.version>
+  </properties>
 
   <dependencies>
     <dependency>
@@ -52,6 +56,7 @@
       <build>
         <plugins>
           <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-assembly-plugin</artifactId>
             <version>${mavenassembly.version}</version>
             <configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -30,29 +30,19 @@
   </modules>
 
   <properties>
-    <apachecommons.version>3.1</apachecommons.version>
-    <commonsio.version>2.5</commonsio.version>
-    <fastutil.version>8.1.1</fastutil.version>
-    <gitcommitplugin.version>2.2.6</gitcommitplugin.version>
-    <glassfish.version>1.1</glassfish.version>
-    <googlejson.version>1.1.1</googlejson.version>
-    <guava.version>29.0-jre</guava.version>
-    <h2.version>1.4.197</h2.version>
+    <guava.version>30.1.1-jre</guava.version>
+    <jts.version>1.18.2</jts.version>
+    <wololo.version>0.16.1</wololo.version>
     <ignite.version>2.10.0</ignite.version>
-    <jcommander.version>1.72</jcommander.version>
-    <jetbrainsannotations.version>13.0</jetbrainsannotations.version>
-    <jts.version>1.16.1</jts.version>
-    <junit.version>4.13.1</junit.version>
-    <mavenassembly.version>3.1.1</mavenassembly.version>
-    <orgjson.version>20160810</orgjson.version>
-    <osmosis.version>0.45</osmosis.version>
+    <h2.version>1.4.197</h2.version>
     <postgresql.version>42.1.4</postgresql.version>
-    <roaringbitmap.version>0.6.59</roaringbitmap.version>
+    <slf4j.version>1.7.32</slf4j.version>
+    <junit.version>4.13.1</junit.version>
     <rxjava2.version>2.1.9</rxjava2.version>
-    <slf4j.version>1.7.25</slf4j.version>
+    <jetbrainsannotations.version>13.0</jetbrainsannotations.version>
+    
     <sonar.moduleKey>${project.artifactId}</sonar.moduleKey>
     <sonar.projectKey>${project.groupId}:oshdb</sonar.projectKey>
-    <wololo.version>0.13.0</wololo.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
This PR updates dependency versions
- jts 1.16.1 > 1.18.2
- wololo 0.13.0 > 0.16.1
- guava 29.0-jre > 30.1.1-jre
- slf4f 1.7.25 > 1.7.32

removes dependency versions/properties
- apachecommons.version 3.1
- commonsio.version 2.5
- orgjson.version 20160810
- osmosis.version 0.45

and reorganize properties, so that properties only used in a specific module is defined in this module instead.


### Checklist
- ~My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results~
- ~I have commented my code~
- ~I have written javadoc (required for public classes and methods)~
- ~I have added sufficient unit tests~
- ~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
