### PR TITLE
geometry filters are now based on unclipped geometries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,18 @@ Changelog
 
 ### breaking changes
 
- * remove class `oshdb-util:util.time.TimestampFormatter` ([#419])
+* remove class `oshdb-util:util.time.TimestampFormatter` ([#419])
 
-[#419]: https://github.com/GIScience/oshdb/pull/419
+### bugfixes
+
+* change geometry filters to be based on full (unclipped) geometries ([#433])
 
 ### other changes
 
  * update jts dependency to version 1.18.2
+
+[#419]: https://github.com/GIScience/oshdb/pull/419
+[#433]: https://github.com/GIScience/oshdb/issues/433
 
 ## 0.7.2
 

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/FilterExpression.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/FilterExpression.java
@@ -85,7 +85,7 @@ public interface FilterExpression extends Serializable {
    */
   @Contract(pure = true)
   default boolean applyOSMEntitySnapshot(OSMEntitySnapshot snapshot) {
-    return applyOSMGeometry(snapshot.getEntity(), snapshot::getGeometry);
+    return applyOSMGeometry(snapshot.getEntity(), snapshot::getGeometryUnclipped);
   }
 
   /**
@@ -100,12 +100,16 @@ public interface FilterExpression extends Serializable {
   @Contract(pure = true)
   default boolean applyOSMContribution(OSMContribution contribution) {
     if (contribution.is(ContributionType.CREATION)) {
-      return applyOSMGeometry(contribution.getEntityAfter(), contribution::getGeometryAfter);
+      return applyOSMGeometry(contribution.getEntityAfter(),
+          contribution::getGeometryUnclippedAfter);
     } else if (contribution.is(ContributionType.DELETION)) {
-      return applyOSMGeometry(contribution.getEntityBefore(), contribution::getGeometryBefore);
+      return applyOSMGeometry(contribution.getEntityBefore(),
+          contribution::getGeometryUnclippedBefore);
     } else {
-      return applyOSMGeometry(contribution.getEntityBefore(), contribution::getGeometryBefore)
-          || applyOSMGeometry(contribution.getEntityAfter(), contribution::getGeometryAfter);
+      return applyOSMGeometry(contribution.getEntityBefore(),
+          contribution::getGeometryUnclippedBefore)
+          || applyOSMGeometry(contribution.getEntityAfter(),
+          contribution::getGeometryUnclippedAfter);
     }
   }
 


### PR DESCRIPTION
### Description
Changes geometry filters to the entities' full (unclipped) geometry into account.

### Corresponding issue
Closes #433

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- ~~I have written javadoc (required for public classes and methods)~~
- ~~I have added sufficient unit tests~~
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~