### PR TITLE
never return negative values for areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Changelog
 ### bugfixes
 
 * change geometry filters to be based on full (unclipped) geometries ([#433])
+* make sure area computation never returns negative results (instead zero is returned for the invalid geometries which previously resulted in negative values) ([#438])
 
 ### other changes
 
@@ -17,6 +18,7 @@ Changelog
 
 [#419]: https://github.com/GIScience/oshdb/pull/419
 [#433]: https://github.com/GIScience/oshdb/issues/433
+[#438]: https://github.com/GIScience/oshdb/pull/438
 
 ## 0.7.2
 

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/Geo.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/Geo.java
@@ -164,7 +164,7 @@ public class Geo {
     for (int i = 0; i < poly.getNumInteriorRing(); i++) {
       area -= Math.abs(ringArea((LinearRing) poly.getInteriorRingN(i)));
     }
-    return area;
+    return Math.max(0, area);
   }
 
   /**

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/Geo.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/Geo.java
@@ -155,6 +155,11 @@ public class Geo {
    *   https://trs.jpl.nasa.gov/handle/2014/40409
    * </p>
    *
+   * <p>
+   * This method will never return a negative number. For invalid polygons with a larger inner
+   * rings area than the outer ring encompasses, zero is returned instead.
+   * </p>
+   *
    * @param poly the polygon for which the area should be calculated. coordinates must be in WGS84
    * @return The approximate signed geodesic area of the polygon in square meters.
    */

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/GeoTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/GeoTest.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.oshdb.util.geometry;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Test;
 import org.locationtech.jts.geom.Coordinate;
@@ -151,6 +152,25 @@ public class GeoTest {
     expectedResult = 410425.251; // calculated with QGIS
     polygon = gf.createPolygon(featurePole);
     assertEquals(1.0, Geo.areaOf(polygon) / expectedResult, relativeDelta);
+  }
+
+  @Test
+  public void testAreaNotNegative() {
+    Polygon poly = gf.createPolygon(constructRing(
+        0, 0,
+        0, 1,
+        1, 1,
+        1, 0,
+        0, 0
+    ), new LinearRing[] { constructRing(
+        0, 0,
+        0, 3,
+        3, 3,
+        3, 0,
+        0, 0
+    )});
+    // check that area is not negative
+    assertFalse(Geo.areaOf(poly) < 0);
   }
 
 


### PR DESCRIPTION
Invalid polygons can potentially in some certain situation have a bigger inner rings area than the outer ring area. The area method should however never return a value smaller than zero. This clips it to a minimum value of zero in such (errror) cases.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- ~~I have commented my code~~
- ~~I have written javadoc (required for public classes and methods)~~
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

<!--Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.-->
