### PR TITLE
Remove deprecations&cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,9 @@ Changelog
 * make sure area computation never returns negative results (instead zero is returned for the invalid geometries which previously resulted in negative values) ([#438])
 
 ### other changes
- * remove deprecated method `OSHEntity.getRawTagKeys` ([#441])
- * update jts dependency to version 1.18.2
+
+* remove deprecated method `OSHEntity.getRawTagKeys` ([#441])
+* update jts dependency to version 1.18.2
 
 [#419]: https://github.com/GIScience/oshdb/pull/419
 [#433]: https://github.com/GIScience/oshdb/issues/433

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,13 @@ Changelog
 * make sure area computation never returns negative results (instead zero is returned for the invalid geometries which previously resulted in negative values) ([#438])
 
 ### other changes
-
+ * remove deprecated method `OSHEntity.getRawTagKeys` ([#441])
  * update jts dependency to version 1.18.2
 
 [#419]: https://github.com/GIScience/oshdb/pull/419
 [#433]: https://github.com/GIScience/oshdb/issues/433
 [#438]: https://github.com/GIScience/oshdb/pull/438
+[#441]: https://github.com/GIScience/oshdb/pull/441
 
 ## 0.7.2
 

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBDatabase.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBDatabase.java
@@ -1,7 +1,6 @@
 package org.heigit.ohsome.oshdb.api.db;
 
 import java.util.OptionalLong;
-import org.heigit.ohsome.oshdb.OSHDB;
 import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer;
 import org.heigit.ohsome.oshdb.util.exceptions.OSHDBTimeoutException;
 import org.heigit.ohsome.oshdb.util.mappable.OSHDBMapReducible;
@@ -9,7 +8,7 @@ import org.heigit.ohsome.oshdb.util.mappable.OSHDBMapReducible;
 /**
  * OSHDB database backend connector.
  */
-public abstract class OSHDBDatabase extends OSHDB implements AutoCloseable {
+public abstract class OSHDBDatabase implements AutoCloseable {
   private String prefix = "";
   private Long timeout = null;
 

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
@@ -673,8 +673,8 @@ public abstract class MapReducer<X> implements
     }
     MapReducer<X> ret = this.copy();
     ret.preFilters.add(oshEntity -> {
-      for (int key : oshEntity.getRawTagKeys()) {
-        if (preKeyIds.contains(key)) {
+      for (var key : oshEntity.getTagKeys()) {
+        if (preKeyIds.contains(key.toInt())) {
           return true;
         }
       }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDB.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDB.java
@@ -1,17 +1,8 @@
 package org.heigit.ohsome.oshdb;
 
-public abstract class OSHDB {
+public class OSHDB {
+  private OSHDB() {}
 
   public static final int MAXZOOM = 14;
 
-  /**
-   * Returns various metadata properties of this OSHDB instance.
-   *
-   * <p>For example, metadata("extract.region") returns the geographic region for which the current
-   * oshdb extract has been generated in GeoJSON format.</p>
-   *
-   * @param property the metadata property to request
-   * @return the value of the requested metadata field
-   */
-  public abstract String metadata(String property);
 }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
@@ -432,11 +432,6 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
   }
 
   @Override
-  public int[] getRawTagKeys() {
-    return keys;
-  }
-
-  @Override
   public boolean hasTagKey(OSHDBTagKey tag) {
     return this.hasTagKey(tag.toInt());
   }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osh/OSHEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osh/OSHEntity.java
@@ -13,9 +13,6 @@ public interface OSHEntity extends OSHDBBoundable {
 
   OSMType getType();
 
-  @Deprecated(since = "0.7.0", forRemoval = true)
-  int[] getRawTagKeys();
-
   Iterable<OSHDBTagKey> getTagKeys();
 
   boolean hasTagKey(OSHDBTagKey tag);


### PR DESCRIPTION
remove deprecated methods, class and some minor cleanups

##  removed deprecation
- OSHEntity.getRawTagKeys


~- MapReducerSettings (replaced by filter)~
  - ~osmTag(String key),osmTag(OSMTagInterface tag)~
  - ~osmTag(String key, String value),~
  - ~osmTag(String key, Collection<String> values)~
  - ~osmTag(Collection<? extends OSMTagInterface> keyValuePairs)~
  - ~osmEntityFilter(OSMEntityFilter f) (filter(Filter.byOSMEntity(...)))~

Removing deprecate MapReducerSettings methods is unfortunately not straight forward, for example in
`TestMapReducer.testOSMEntitySnapshotViewStream` we got following query.
```
OSMEntitySnapshotView.on(oshdb)
  .osmType(type)
  .osmTag("highway") replace to -> filter("highway=*")
  .areaOfInterest(bbox)
  .timestamps(timestamps)
  .osmEntityFilter(entity -> entity.getId() == id)
  .groupByEntity()
```
will throw an 
```
new UnsupportedOperationException(
          "groupByEntity() must be called before any `map` or `flatMap` "
              + "transformation functions have been set");
```
the reason for that is that `filter(...)`  instead of `osmTag(...) ` adds a mapping step at https://github.com/GIScience/oshdb/blob/64bc0d8a434ee7bc04dcdefe2e1d0084e01806fa/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java#L796

which then conflicts with  `groupByEntity ` later on.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [ ] I have commented my code
- [ ] I have written javadoc (required for public classes and methods)
- [ ] I have added sufficient unit tests
- [ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository
- [ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
