### PR TITLE
Remove deprecated OSMEntity.getRawTags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ Changelog
 ### other changes
 
 * remove deprecated method `OSHEntity.getRawTagKeys` ([#441])
+* remove deprecated method `OSMEntity.getRawTags` ([#443])
 * update jts dependency to version 1.18.2
 
 [#419]: https://github.com/GIScience/oshdb/pull/419
 [#433]: https://github.com/GIScience/oshdb/issues/433
 [#438]: https://github.com/GIScience/oshdb/pull/438
 [#441]: https://github.com/GIScience/oshdb/pull/441
+[#441]: https://github.com/GIScience/oshdb/pull/443
 
 ## 0.7.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ Changelog
 [#433]: https://github.com/GIScience/oshdb/issues/433
 [#438]: https://github.com/GIScience/oshdb/pull/438
 [#441]: https://github.com/GIScience/oshdb/pull/441
-[#441]: https://github.com/GIScience/oshdb/pull/443
+[#443]: https://github.com/GIScience/oshdb/pull/443
 
 ## 0.7.2
 

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
@@ -584,13 +584,10 @@ public abstract class MapReducer<X> implements
     MapReducer<X> ret = this.copy();
     ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(keyId));
     ret.filters.add(osmEntity -> {
-      int[] tags = osmEntity.getRawTags();
-      for (int i = 0; i < tags.length; i += 2) {
-        if (tags[i] > keyId) {
-          break;
-        }
-        if (tags[i] == keyId) {
-          return valueIds.contains(tags[i + 1]);
+      var tags = osmEntity.getTags();
+      for (var tag : tags) {
+        if (tag.getKey() == keyId) {
+          return valueIds.contains(tag.getValue());
         }
       }
       return false;
@@ -618,13 +615,10 @@ public abstract class MapReducer<X> implements
     MapReducer<X> ret = this.copy();
     ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(keyId));
     ret.filters.add(osmEntity -> {
-      int[] tags = osmEntity.getRawTags();
-      for (int i = 0; i < tags.length; i += 2) {
-        if (tags[i] > keyId) {
-          return false;
-        }
-        if (tags[i] == keyId) {
-          String value = this.getTagTranslator().getOSMTagOf(keyId, tags[i + 1]).getValue();
+      var tags = osmEntity.getTags();
+      for (var tag : tags) {
+        if (tag.getKey() == keyId) {
+          String value = this.getTagTranslator().getOSMTagOf(keyId, tag.getValue()).getValue();
           return valuePattern.matcher(value).matches();
         }
       }
@@ -695,7 +689,7 @@ public abstract class MapReducer<X> implements
   private MapReducer<X> osmTag(OSHDBTag tag) {
     MapReducer<X> ret = this.copy();
     ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(tag.getKey()));
-    ret.filters.add(osmEntity -> osmEntity.hasTagValue(tag.getKey(), tag.getValue()));
+    ret.filters.add(osmEntity -> osmEntity.getTags().hasTagValue(tag.getKey(), tag.getValue()));
     return ret;
   }
 
@@ -703,7 +697,7 @@ public abstract class MapReducer<X> implements
   private MapReducer<X> osmTag(OSHDBTagKey tagKey) {
     MapReducer<X> ret = this.copy();
     ret.preFilters.add(oshEntity -> oshEntity.hasTagKey(tagKey));
-    ret.filters.add(osmEntity -> osmEntity.hasTagKey(tagKey));
+    ret.filters.add(osmEntity -> osmEntity.getTags().hasTagKey(tagKey));
     return ret;
   }
 

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/load/LoaderNode.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/load/LoaderNode.java
@@ -98,7 +98,7 @@ public class LoaderNode extends Loader {
 
       if (onlyNodesWithTags) {
         grid.entities = nodes.stream().filter(osh -> {
-          return osh.stream().anyMatch(osm -> osm.getRawTags().length > 0);
+          return osh.stream().anyMatch(osm -> osm.getTags().size() > 0);
         }).collect(Collectors.toList());
       } else {
         grid.entities = new ArrayList<>(nodes);

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/OSHEntity2.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/OSHEntity2.java
@@ -90,8 +90,7 @@ public abstract class OSHEntity2 {
       long timestamp = 0;
       long changeset = 0;
       int userId = -1;
-      OSHDBTags tags = null; // new int[0];
-
+      var tags = OSHDBTags.empty();
       for (OSMEntity version : versions) {
         final int visible = version.isVisible() ? 1 : -1;
 

--- a/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/OSHEntity2.java
+++ b/oshdb-etl/src/main/java/org/heigit/ohsome/oshdb/tool/importer/transform/oshdb/OSHEntity2.java
@@ -1,7 +1,6 @@
 package org.heigit.ohsome.oshdb.tool.importer.transform.oshdb;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -9,6 +8,7 @@ import java.util.NoSuchElementException;
 import java.util.Set;
 import java.util.TreeSet;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
+import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.bytearray.ByteArrayOutputWrapper;
 import org.heigit.ohsome.oshdb.util.bytearray.ByteArrayWrapper;
@@ -90,7 +90,7 @@ public abstract class OSHEntity2 {
       long timestamp = 0;
       long changeset = 0;
       int userId = -1;
-      int[] tags = new int[0];
+      OSHDBTags tags = null; // new int[0];
 
       for (OSMEntity version : versions) {
         final int visible = version.isVisible() ? 1 : -1;
@@ -106,15 +106,14 @@ public abstract class OSHEntity2 {
             changed |= CHANGED_USER_ID;
             userId = aux.writeS32Delta(version.getUserId(), userId);
           }
-          if (!Arrays.equals(version.getRawTags(), tags)) {
+          if (!version.getTags().equals(tags)) {
             changed |= CHANGED_TAGS;
-            tags = version.getRawTags();
-            aux.writeU32(tags.length);
-            for (int i = 0; i < tags.length; i++) {
-              aux.writeU32(tags[i]);
-              if (i % 2 == 0) {
-                keySet.add(Integer.valueOf(tags[i]));
-              }
+            tags = version.getTags();
+            aux.writeU32(tags.size() * 2);
+            for (var tag : tags) {
+              aux.writeU32(tag.getKey());
+              aux.writeU32(tag.getValue());
+              keySet.add(tag.getKey());
             }
           }
           if (extension(aux, version, baseLongitude, baseLatitude, nodeOffsets, wayOffsets,

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryTypeFilter.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/GeometryTypeFilter.java
@@ -150,8 +150,8 @@ public class GeometryTypeFilter implements Filter {
         OSMMember[] wayNodes = ((OSMWay) entity).getMembers();
         return wayNodes.length >= 4 && wayNodes[0].getId() == wayNodes[wayNodes.length - 1].getId();
       } else if (osmType == OSMType.RELATION) {
-        return entity.hasTagValue(typeMultipolygon.getKey(), typeMultipolygon.getValue())
-            || entity.hasTagValue(typeBoundary.getKey(), typeBoundary.getValue());
+        return entity.getTags().hasTagValue(typeMultipolygon.getKey(), typeMultipolygon.getValue())
+            || entity.getTags().hasTagValue(typeBoundary.getKey(), typeBoundary.getValue());
       }
     }
     return true;

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/TagFilterEquals.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/TagFilterEquals.java
@@ -21,7 +21,7 @@ public class TagFilterEquals implements TagFilter {
 
   @Override
   public boolean applyOSM(OSMEntity entity) {
-    return entity.hasTagValue(tag.getKey(), tag.getValue());
+    return entity.getTags().hasTagValue(tag.getKey(), tag.getValue());
   }
 
   @Override

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/TagFilterEqualsAny.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/TagFilterEqualsAny.java
@@ -21,7 +21,7 @@ public class TagFilterEqualsAny implements TagFilter {
 
   @Override
   public boolean applyOSM(OSMEntity entity) {
-    return entity.hasTagKey(tag.toInt());
+    return entity.getTags().hasTagKey(tag.toInt());
   }
 
   @Override

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/TagFilterNotEquals.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/TagFilterNotEquals.java
@@ -27,7 +27,7 @@ public class TagFilterNotEquals implements TagFilter {
 
   @Override
   public boolean applyOSM(OSMEntity entity) {
-    return !entity.hasTagValue(tag.getKey(), tag.getValue());
+    return !entity.getTags().hasTagValue(tag.getKey(), tag.getValue());
   }
 
   @Override

--- a/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/TagFilterNotEqualsAny.java
+++ b/oshdb-filter/src/main/java/org/heigit/ohsome/oshdb/filter/TagFilterNotEqualsAny.java
@@ -27,7 +27,7 @@ public class TagFilterNotEqualsAny implements TagFilter {
 
   @Override
   public boolean applyOSM(OSMEntity entity) {
-    return !entity.hasTagKey(tag.toInt());
+    return !entity.getTags().hasTagKey(tag.toInt());
   }
 
   @Override

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
@@ -724,18 +724,7 @@ public class CellIterator implements Serializable {
               switch (contributionType) {
                 case TAG_CHANGE:
                   // look if tags have been changed between versions
-                  boolean tagsChange = false;
-                  if (prevEntity.getRawTags().length != osmEntity.getRawTags().length) {
-                    tagsChange = true;
-                  } else {
-                    for (int i = 0; i < prevEntity.getRawTags().length; i++) {
-                      if (prevEntity.getRawTags()[i] != osmEntity.getRawTags()[i]) {
-                        tagsChange = true;
-                        break;
-                      }
-                    }
-                  }
-                  return tagsChange;
+                  return !prevEntity.getTags().equals(osmEntity.getTags());
                 case GEOMETRY_CHANGE:
                   // look if geometry has been changed between versions
                   return !prevGeometry.equals(geom);

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/taginterpreter/BaseTagInterpreter.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/taginterpreter/BaseTagInterpreter.java
@@ -1,7 +1,9 @@
 package org.heigit.ohsome.oshdb.util.taginterpreter;
 
+import static java.util.Collections.emptySet;
 import java.util.Map;
 import java.util.Set;
+import org.heigit.ohsome.oshdb.OSHDBTag;
 import org.heigit.ohsome.oshdb.osh.OSHWay;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.osm.OSMMember;
@@ -45,13 +47,13 @@ class BaseTagInterpreter implements TagInterpreter {
   }
 
   private boolean evaluateWayForArea(OSMWay entity) {
-    int[] tags = entity.getRawTags();
-    if (entity.hasTagValue(areaNoTagKeyId, areaNoTagValueId)) {
+    var tags = entity.getTags();
+    if (tags.hasTagValue(areaNoTagKeyId, areaNoTagValueId)) {
       return false;
     }
-    for (int i = 0; i < tags.length; i += 2) {
-      if (wayAreaTags.containsKey(tags[i])
-          && wayAreaTags.get(tags[i]).contains(tags[i + 1])) {
+    for (var tag : entity.getTags()) {
+      if (wayAreaTags.getOrDefault(tag.getKey(), emptySet())
+          .contains(tag.getValue())) {
         return true;
       }
     }
@@ -59,11 +61,10 @@ class BaseTagInterpreter implements TagInterpreter {
   }
 
   protected boolean evaluateRelationForArea(OSMRelation entity) {
-    int[] tags = entity.getRawTags();
     // skip area=no check, since that doesn't make much sense for multipolygon relations (does it??)
-    for (int i = 0; i < tags.length; i += 2) {
-      if (relationAreaTags.containsKey(tags[i])
-          && relationAreaTags.get(tags[i]).contains(tags[i + 1])) {
+    for (var tag : entity.getTags()) {
+      if (relationAreaTags.getOrDefault(tag.getKey(), emptySet())
+          .contains(tag.getValue())) {
         return true;
       }
     }
@@ -97,9 +98,8 @@ class BaseTagInterpreter implements TagInterpreter {
 
   @Override
   public boolean hasInterestingTagKey(OSMEntity osm) {
-    int[] tags = osm.getRawTags();
-    for (int i = 0; i < tags.length; i += 2) {
-      if (!uninterestingTagKeys.contains(tags[i])) {
+    for(var tag : osm.getTags()) {
+      if (!uninterestingTagKeys.contains(tag.getKey())) {
         return true;
       }
     }
@@ -121,13 +121,13 @@ class BaseTagInterpreter implements TagInterpreter {
     if (outerWayCount != 1) {
       return false;
     }
-    int[] tags = osmRelation.getRawTags();
-    for (int i = 0; i < tags.length; i += 2) {
-      if (relationAreaTags.containsKey(tags[i])
-          && relationAreaTags.get(tags[i]).contains(tags[i + 1])) {
+    var tags = osmRelation.getTags();
+    for (var tag : tags) {
+      if (relationAreaTags.getOrDefault(tag.getKey(), emptySet())
+          .contains(tag.getValue())) {
         continue;
       }
-      if (!uninterestingTagKeys.contains(tags[i])) {
+      if (!uninterestingTagKeys.contains(tag.getKey())) {
         return false;
       }
     }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/taginterpreter/DefaultTagInterpreter.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/taginterpreter/DefaultTagInterpreter.java
@@ -176,14 +176,14 @@ public class DefaultTagInterpreter extends BaseTagInterpreter {
   // checks if the relation has the tag "type=multipolygon"
   @Override
   protected boolean evaluateRelationForArea(OSMRelation entity) {
-    int[] tags = entity.getRawTags();
+    var tags = entity.getTags();
     // skip area=no check, since that doesn't make much sense for multipolygon relations (does it??)
     // the following is slightly faster than running
     // `return entity.hasTagValue(k1,v1) || entity.hasTagValue(k2,v2);`
-    for (int i = 0; i < tags.length; i += 2) {
-      if (tags[i] == typeKey) {
-        return tags[i + 1] == typeMultipolygonValue || tags[i + 1] == typeBoundaryValue;
-      } else if (tags[i] > typeKey) {
+    for (var tag : tags) {
+      if (tag.getKey() == typeKey) {
+        return tag.getValue() == typeMultipolygonValue || tag.getValue() == typeBoundaryValue;
+      } else if (tag.getKey() > typeKey) {
         return false;
       }
     }
@@ -192,6 +192,6 @@ public class DefaultTagInterpreter extends BaseTagInterpreter {
 
   // checks if the relation has the tag "type=route"
   private boolean evaluateRelationForLine(OSMRelation entity) {
-    return entity.hasTagValue(typeKey, typeRouteValue);
+    return entity.getTags().hasTagValue(typeKey, typeRouteValue);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -81,7 +81,7 @@ public class IterateByContributionNodesTest {
     assertTrue(geom instanceof Point);
     assertEquals(result.get(0).geometry.get(), result.get(1).previousGeometry.get());
     assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertEquals(result.get(1).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
+    assertEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
   }
 
   @Test
@@ -116,8 +116,8 @@ public class IterateByContributionNodesTest {
         result.get(2).activities.get()
     );
     assertEquals(3, result.get(0).changeset);
-    assertNotEquals(result.get(1).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
-    assertNotEquals(result.get(2).osmEntity.getRawTags(), result.get(1).osmEntity.getRawTags());
+    assertNotEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
+    assertNotEquals(result.get(2).osmEntity.getTags(), result.get(1).osmEntity.getTags());
   }
 
   @Test
@@ -211,10 +211,10 @@ public class IterateByContributionNodesTest {
         result.get(5).activities.get()
     );
     assertEquals(11, result.get(0).changeset);
-    assertNotEquals(result.get(1).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
-    assertNotEquals(result.get(3).osmEntity.getRawTags(), result.get(1).osmEntity.getRawTags());
-    assertEquals(result.get(4).osmEntity.getRawTags(), result.get(3).osmEntity.getRawTags());
-    assertNotEquals(result.get(5).osmEntity.getRawTags(), result.get(4).osmEntity.getRawTags());
+    assertNotEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
+    assertNotEquals(result.get(3).osmEntity.getTags(), result.get(1).osmEntity.getTags());
+    assertEquals(result.get(4).osmEntity.getTags(), result.get(3).osmEntity.getTags());
+    assertNotEquals(result.get(5).osmEntity.getTags(), result.get(4).osmEntity.getTags());
   }
 
   @Test
@@ -309,7 +309,7 @@ public class IterateByContributionNodesTest {
         OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
-        osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
+        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByContribution(
         oshdbDataGridCell
@@ -345,7 +345,7 @@ public class IterateByContributionNodesTest {
         OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 7,
-        osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("disused:shop")),
+        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("disused:shop")),
         false
     )).iterateByContribution(
         oshdbDataGridCell
@@ -377,7 +377,7 @@ public class IterateByContributionNodesTest {
         OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 0.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 8,
-        osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
+        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByContribution(
         oshdbDataGridCell
@@ -410,7 +410,7 @@ public class IterateByContributionNodesTest {
         OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
-        osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),
+        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),
         false
     )).iterateByContribution(
         oshdbDataGridCell
@@ -468,7 +468,7 @@ public class IterateByContributionNodesTest {
         areaDecider,
         oshEntity -> oshEntity.getId() == 6,
         // filter entity for tag = shop
-        osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
+        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByContribution(
         oshdbDataGridCell

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
@@ -312,8 +312,8 @@ public class IterateByContributionWaysTest {
     );
 
     assertEquals(44, result.get(0).changeset);
-    assertNotEquals(result.get(1).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
-    assertEquals(result.get(5).osmEntity.getRawTags(), result.get(3).osmEntity.getRawTags());
+    assertNotEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
+    assertEquals(result.get(5).osmEntity.getTags(), result.get(3).osmEntity.getTags());
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -87,17 +87,17 @@ public class IterateByTimestampsNodesTest {
         oshdbDataGridCell
     ).collect(Collectors.toList());
     assertEquals(12, result.size());
-    assertNotEquals(result.get(1).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
-    assertEquals(result.get(2).osmEntity.getRawTags(), result.get(1).osmEntity.getRawTags());
-    assertEquals(result.get(3).osmEntity.getRawTags(), result.get(2).osmEntity.getRawTags());
-    assertEquals(result.get(4).osmEntity.getRawTags(), result.get(3).osmEntity.getRawTags());
-    assertEquals(result.get(5).osmEntity.getRawTags(), result.get(4).osmEntity.getRawTags());
-    assertEquals(result.get(6).osmEntity.getRawTags(), result.get(5).osmEntity.getRawTags());
-    assertNotEquals(result.get(7).osmEntity.getRawTags(), result.get(6).osmEntity.getRawTags());
-    assertEquals(result.get(8).osmEntity.getRawTags(), result.get(7).osmEntity.getRawTags());
-    assertEquals(result.get(9).osmEntity.getRawTags(), result.get(8).osmEntity.getRawTags());
-    assertEquals(result.get(10).osmEntity.getRawTags(), result.get(9).osmEntity.getRawTags());
-    assertEquals(result.get(11).osmEntity.getRawTags(), result.get(10).osmEntity.getRawTags());
+    assertNotEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
+    assertEquals(result.get(2).osmEntity.getTags(), result.get(1).osmEntity.getTags());
+    assertEquals(result.get(3).osmEntity.getTags(), result.get(2).osmEntity.getTags());
+    assertEquals(result.get(4).osmEntity.getTags(), result.get(3).osmEntity.getTags());
+    assertEquals(result.get(5).osmEntity.getTags(), result.get(4).osmEntity.getTags());
+    assertEquals(result.get(6).osmEntity.getTags(), result.get(5).osmEntity.getTags());
+    assertNotEquals(result.get(7).osmEntity.getTags(), result.get(6).osmEntity.getTags());
+    assertEquals(result.get(8).osmEntity.getTags(), result.get(7).osmEntity.getTags());
+    assertEquals(result.get(9).osmEntity.getTags(), result.get(8).osmEntity.getTags());
+    assertEquals(result.get(10).osmEntity.getTags(), result.get(9).osmEntity.getTags());
+    assertEquals(result.get(11).osmEntity.getTags(), result.get(10).osmEntity.getTags());
   }
 
   @Test
@@ -158,16 +158,16 @@ public class IterateByTimestampsNodesTest {
         result.get(3).geometry.get().getCoordinates());
     assertArrayEquals(result.get(9).geometry.get().getCoordinates(),
         result.get(6).geometry.get().getCoordinates());
-    assertNotEquals(result.get(1).osmEntity.getRawTags(),
-        result.get(0).osmEntity.getRawTags());
-    assertEquals(result.get(2).osmEntity.getRawTags(),
-        result.get(1).osmEntity.getRawTags());
-    assertNotEquals(result.get(3).osmEntity.getRawTags(),
-        result.get(2).osmEntity.getRawTags());
-    assertEquals(result.get(5).osmEntity.getRawTags(),
-        result.get(4).osmEntity.getRawTags());
-    assertNotEquals(result.get(9).osmEntity.getRawTags(),
-        result.get(6).osmEntity.getRawTags());
+    assertNotEquals(result.get(1).osmEntity.getTags(),
+        result.get(0).osmEntity.getTags());
+    assertEquals(result.get(2).osmEntity.getTags(),
+        result.get(1).osmEntity.getTags());
+    assertNotEquals(result.get(3).osmEntity.getTags(),
+        result.get(2).osmEntity.getTags());
+    assertEquals(result.get(5).osmEntity.getTags(),
+        result.get(4).osmEntity.getTags());
+    assertNotEquals(result.get(9).osmEntity.getTags(),
+        result.get(6).osmEntity.getTags());
   }
 
   @Test
@@ -182,7 +182,7 @@ public class IterateByTimestampsNodesTest {
         OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
-        osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
+        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
@@ -202,7 +202,7 @@ public class IterateByTimestampsNodesTest {
         OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
-        osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),
+        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
@@ -231,7 +231,7 @@ public class IterateByTimestampsNodesTest {
         polygonFromCoordinates,
         areaDecider,
         oshEntity -> oshEntity.getId() == 6,
-        osmEntity -> osmEntity.hasTagKey(osmXmlTestData.keys().get("shop")),
+        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByTimestamps(
         oshdbDataGridCell

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -60,7 +60,7 @@ public class IterateByTimestampsWaysTest {
         oshdbDataGridCell
     ).collect(Collectors.toList());
     assertEquals(10, result.size());
-    assertEquals(result.get(1).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
+    assertEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
     assertEquals(4, result.get(0).geometry.get().getNumPoints());
     assertEquals(8, result.get(1).geometry.get().getNumPoints());
     assertEquals(9, result.get(2).geometry.get().getNumPoints());
@@ -161,8 +161,8 @@ public class IterateByTimestampsWaysTest {
     assertTrue(geom2 instanceof LineString);
     Geometry geom3 = result.get(10).geometry.get();
     assertTrue(geom3 instanceof LineString);
-    assertNotEquals(result.get(2).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
-    assertNotEquals(result.get(10).osmEntity.getRawTags(), result.get(2).osmEntity.getRawTags());
+    assertNotEquals(result.get(2).osmEntity.getTags(), result.get(0).osmEntity.getTags());
+    assertNotEquals(result.get(10).osmEntity.getTags(), result.get(2).osmEntity.getTags());
     assertNotEquals(result.get(2).geometry.get(), result.get(0).geometry.get());
     assertEquals(result.get(10).geometry.get(), result.get(2).geometry.get());
   }
@@ -217,8 +217,8 @@ public class IterateByTimestampsWaysTest {
     ).collect(Collectors.toList());
     assertEquals(7, result.size());
 
-    assertNotEquals(result.get(2).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
-    assertEquals(result.get(6).osmEntity.getRawTags(), result.get(2).osmEntity.getRawTags());
+    assertNotEquals(result.get(2).osmEntity.getTags(), result.get(0).osmEntity.getTags());
+    assertEquals(result.get(6).osmEntity.getTags(), result.get(2).osmEntity.getTags());
     assertEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
     assertNotEquals(result.get(3).geometry.get(), result.get(1).geometry.get());
     assertNotEquals(result.get(6).geometry.get(), result.get(3).geometry.get());
@@ -250,7 +250,7 @@ public class IterateByTimestampsWaysTest {
     assertTrue(geom instanceof Polygon);
     Geometry geom2 = result.get(8).geometry.get();
     assertTrue(geom2 instanceof LineString);
-    assertNotEquals(result.get(8).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
+    assertNotEquals(result.get(8).osmEntity.getTags(), result.get(0).osmEntity.getTags());
     assertNotEquals(result.get(8).geometry.get(), result.get(0).geometry.get());
   }
 
@@ -279,7 +279,7 @@ public class IterateByTimestampsWaysTest {
     assertTrue(geom instanceof Polygon);
     Geometry geom2 = result.get(8).geometry.get();
     assertTrue(geom2 instanceof LineString);
-    assertEquals(result.get(8).osmEntity.getRawTags(), result.get(0).osmEntity.getRawTags());
+    assertEquals(result.get(8).osmEntity.getTags(), result.get(0).osmEntity.getTags());
     assertNotEquals(result.get(8).geometry.get(), result.get(0).geometry.get());
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/helpers/OSMXmlReaderTagInterpreter.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/helpers/OSMXmlReaderTagInterpreter.java
@@ -38,10 +38,10 @@ public class OSMXmlReaderTagInterpreter extends FakeTagInterpreter {
     if (e instanceof OSMWay) {
       OSMMember[] nds = ((OSMWay) e).getMembers();
       return nds.length >= 4 && nds[0].getId() == nds[nds.length - 1].getId()
-          && e.hasTagValue(area, areaYes);
+          && e.getTags().hasTagValue(area, areaYes);
     }
     if (e instanceof OSMRelation) {
-      return e.hasTagValue(type, typeMultipolygon);
+      return e.getTags().hasTagValue(type, typeMultipolygon);
     }
     return true;
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/osh/TestOSHEntityTimeUtils.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/osh/TestOSHEntityTimeUtils.java
@@ -59,7 +59,7 @@ public class TestOSHEntityTimeUtils {
     ));
 
     List<OSHDBTimestamp> tss =
-        OSHEntityTimeUtils.getModificationTimestamps(hnode, e -> e.hasTagValue(1, 1));
+        OSHEntityTimeUtils.getModificationTimestamps(hnode, e -> e.getTags().hasTagValue(1, 1));
 
     assertNotNull(tss);
     assertEquals(2, tss.size());
@@ -177,7 +177,7 @@ public class TestOSHEntityTimeUtils {
 
     tss = OSHEntityTimeUtils.getModificationTimestamps(
         hway,
-        osmEntity -> osmEntity.hasTagValue(2, 1)
+        osmEntity -> osmEntity.getTags().hasTagValue(2, 1)
     );
     assertNotNull(tss);
     assertEquals(5, tss.size());

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
@@ -8,7 +8,7 @@ import java.util.stream.IntStream;
 import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
 
 /**
- *
+ * Collection class for OSHDBTag.
  *
  */
 public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements Serializable {
@@ -65,7 +65,12 @@ public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements 
     return !(e1.hasNext() || e2.hasNext());
   }
 
-
+  /**
+   * KV based OSHDBTags.
+   *
+   * @param tags kv based array
+   * @return OSHDBTags instance
+   */
   public static OSHDBTags of(int[] tags) {
     return new IntArrayOSHDBTags(tags);
   }
@@ -74,7 +79,7 @@ public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements 
 
     private final int[] tags;
 
-    public IntArrayOSHDBTags(int[] tags) {
+    private IntArrayOSHDBTags(int[] tags) {
       this.tags = tags;
     }
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
@@ -1,0 +1,166 @@
+package org.heigit.ohsome.oshdb;
+
+import java.io.Serializable;
+import java.util.AbstractCollection;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.stream.IntStream;
+import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
+
+/**
+ *
+ *
+ */
+public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements Serializable {
+  private static final OSHDBTags EMPTY = new IntArrayOSHDBTags(new int[0]);
+
+  public static OSHDBTags empty() {
+    return EMPTY;
+  }
+
+  public boolean hasTagKey(OSHDBTagKey key) {
+    return hasTagKey(key.toInt());
+  }
+
+  /**
+   * Test this {@code OSMEntity} if it contains a certain tag key(integer).
+   */
+  public abstract boolean hasTagKey(int key);
+
+  /**
+   * Tests if any a given key is present but ignores certain values. Useful when looking for example
+   * "TagKey" != "no"
+   *
+   * @param key the key to search for
+   * @param uninterestingValues list of values, that should return false although the key is
+   *        actually present
+   * @return true if the key is present and is NOT in a combination with the given values, false
+   *         otherwise
+   */
+  public abstract boolean hasTagKeyExcluding(int key, int[] uninterestingValues);
+
+  /**
+   * Test for a certain key/value combination.
+   */
+  public abstract boolean hasTagValue(int key, int value);
+
+  @Override
+  public boolean equals(Object obj) {
+    if (!(obj instanceof OSHDBTags)) {
+      return false;
+    }
+    var other = (OSHDBTags) obj;
+    if (size() != other.size()) {
+      return false;
+    }
+    var e1 = iterator();
+    var e2 = other.iterator();
+    while (e1.hasNext() && e2.hasNext()) {
+      var o1 = e1.next();
+      var o2 = e2.next();
+      if (!(o1 == null ? o2 == null : o1.equals(o2))) {
+        return false;
+      }
+    }
+    return !(e1.hasNext() || e2.hasNext());
+  }
+
+
+  public static OSHDBTags of(int[] tags) {
+    return new IntArrayOSHDBTags(tags);
+  }
+
+  private static class IntArrayOSHDBTags extends OSHDBTags {
+
+    private final int[] tags;
+
+    public IntArrayOSHDBTags(int[] tags) {
+      this.tags = tags;
+    }
+
+    @Override
+    public int size() {
+      return tags.length / 2;
+    }
+
+    @Override
+    public Iterator<OSHDBTag> iterator() {
+      return IntStream.range(0, tags.length / 2)
+          .map(i -> i * 2)
+          .mapToObj(i -> new OSHDBTag(tags[i], tags[i + 1]))
+          .iterator();
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + Arrays.hashCode(tags);
+      return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (obj instanceof IntArrayOSHDBTags) {
+        var other = (IntArrayOSHDBTags) obj;
+        return Arrays.equals(tags, other.tags);
+      }
+      if (!(obj instanceof OSHDBTags)) {
+        return false;
+      }
+      return super.equals(obj);
+    }
+
+    @Override
+    public boolean hasTagKey(int key) {
+      for (int i = 0; i < tags.length; i += 2) {
+        if (tags[i] < key) {
+          continue;
+        }
+        if (tags[i] == key) {
+          return true;
+        }
+        if (tags[i] > key) {
+          return false;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public boolean hasTagKeyExcluding(int key, int[] uninterestingValues) {
+      for (int i = 0; i < tags.length; i += 2) {
+        if (tags[i] < key) {
+          continue;
+        }
+        if (tags[i] == key) {
+          final int value = tags[i + 1];
+          return !IntStream.of(uninterestingValues).anyMatch(x -> x == value);
+        }
+        if (tags[i] > key) {
+          return false;
+        }
+      }
+      return false;
+    }
+
+    @Override
+    public boolean hasTagValue(int key, int value) {
+      for (int i = 0; i < tags.length; i += 2) {
+        if (tags[i] < key) {
+          continue;
+        }
+        if (tags[i] == key) {
+          return tags[i + 1] == value;
+        }
+        if (tags[i] > key) {
+          return false;
+        }
+      }
+      return false;
+    }
+  }
+}

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
@@ -65,6 +65,15 @@ public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements 
     return !(e1.hasNext() || e2.hasNext());
   }
 
+  @Override
+  public int hashCode() {
+    int hashCode = 1;
+    for (var e : this) {
+      hashCode = 31 * hashCode + (e == null ? 0 : e.hashCode());
+    }
+    return hashCode;
+  }
+
   /**
    * KV based OSHDBTags.
    *
@@ -90,10 +99,8 @@ public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements 
 
     @Override
     public Iterator<OSHDBTag> iterator() {
-      return IntStream.range(0, tags.length / 2)
-          .map(i -> i * 2)
-          .mapToObj(i -> new OSHDBTag(tags[i], tags[i + 1]))
-          .iterator();
+      return IntStream.range(0, tags.length / 2).map(i -> i * 2)
+          .mapToObj(i -> new OSHDBTag(tags[i], tags[i + 1])).iterator();
     }
 
     @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
@@ -105,10 +105,7 @@ public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements 
 
     @Override
     public int hashCode() {
-      final int prime = 31;
-      int result = 1;
-      result = prime * result + Arrays.hashCode(tags);
-      return result;
+      return Arrays.hashCode(tags);
     }
 
     @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTags.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb;
 
 import java.io.Serializable;
-import java.util.AbstractCollection;
+import java.util.AbstractSet;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.stream.IntStream;
@@ -11,7 +11,7 @@ import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
  * Collection class for OSHDBTag.
  *
  */
-public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements Serializable {
+public abstract class OSHDBTags extends AbstractSet<OSHDBTag> implements Serializable {
   private static final OSHDBTags EMPTY = new IntArrayOSHDBTags(new int[0]);
 
   public static OSHDBTags empty() {
@@ -43,36 +43,6 @@ public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements 
    * Test for a certain key/value combination.
    */
   public abstract boolean hasTagValue(int key, int value);
-
-  @Override
-  public boolean equals(Object obj) {
-    if (!(obj instanceof OSHDBTags)) {
-      return false;
-    }
-    var other = (OSHDBTags) obj;
-    if (size() != other.size()) {
-      return false;
-    }
-    var e1 = iterator();
-    var e2 = other.iterator();
-    while (e1.hasNext() && e2.hasNext()) {
-      var o1 = e1.next();
-      var o2 = e2.next();
-      if (!(o1 == null ? o2 == null : o1.equals(o2))) {
-        return false;
-      }
-    }
-    return !(e1.hasNext() || e2.hasNext());
-  }
-
-  @Override
-  public int hashCode() {
-    int hashCode = 1;
-    for (var e : this) {
-      hashCode = 31 * hashCode + (e == null ? 0 : e.hashCode());
-    }
-    return hashCode;
-  }
 
   /**
    * KV based OSHDBTags.
@@ -116,9 +86,6 @@ public abstract class OSHDBTags extends AbstractCollection<OSHDBTag> implements 
       if (obj instanceof IntArrayOSHDBTags) {
         var other = (IntArrayOSHDBTags) obj;
         return Arrays.equals(tags, other.tags);
-      }
-      if (!(obj instanceof OSHDBTags)) {
-        return false;
       }
       return super.equals(obj);
     }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHEntityImpl.java
@@ -38,7 +38,7 @@ public abstract class OSHEntityImpl implements OSHEntity, Comparable<OSHEntity>,
     long lastTimestamp = 0;
     long lastChangeset = 0;
     int lastUserId = 0;
-    OSHDBTags lastKeyValues = null; //new int[0];
+    OSHDBTags lastKeyValues = OSHDBTags.empty();
 
     SortedSet<Integer> keySet = new TreeSet<>();
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMEntity.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/osm/OSMEntity.java
@@ -1,17 +1,9 @@
 package org.heigit.ohsome.oshdb.osm;
 
 import java.io.Serializable;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.NoSuchElementException;
 import java.util.Objects;
-import java.util.stream.IntStream;
-import javax.annotation.Nonnull;
-import org.heigit.ohsome.oshdb.OSHDBTag;
 import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.heigit.ohsome.oshdb.OSHDBTemporal;
-import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
 
 public abstract class OSMEntity implements OSHDBTemporal, Serializable {
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
@@ -1,0 +1,82 @@
+package org.heigit.ohsome.oshdb;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
+import org.junit.Test;
+
+/**
+ * Test class for OSHDBTags interface.
+ *
+ */
+@SuppressWarnings("javadoc")
+public class OSHDBTagsTest {
+  int[] kvs = new int[] {1, 2, 2, 3, 4, 5};
+
+  @Test
+  public void testArrayHasTagKey() {
+    var tags = OSHDBTags.of(kvs);
+
+    var tagKey2 = new OSHDBTagKey(2);
+    var tagKey3 = new OSHDBTagKey(3);
+
+    assertTrue("tag key should exist", tags.hasTagKey(tagKey2));
+    assertFalse("tag key should not exist", tags.hasTagKey(tagKey3));
+    assertFalse("tag key should not exist", tags.hasTagKey(5));
+  }
+
+  @Test
+  public void testArrayHasTagKeyExcluding() {
+    var tags = OSHDBTags.of(kvs);
+
+    assertTrue(tags.hasTagKeyExcluding(2, new int[] {1, 2, 4}));
+
+    assertFalse(tags.hasTagKeyExcluding(2, new int[] {3}));
+    assertFalse(tags.hasTagKeyExcluding(3, new int[0]));
+    assertFalse(tags.hasTagKeyExcluding(5, new int[0]));
+
+  }
+
+  @Test
+  public void testArrayHasTagValue() {
+    var tags = OSHDBTags.of(kvs);
+
+    assertTrue(tags.hasTagValue(1, 2));
+
+    assertFalse(tags.hasTagValue(2, 2));
+    assertFalse(tags.hasTagValue(3, 4));
+    assertFalse(tags.hasTagValue(5, 6));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testImmutableAdd() {
+    var tags = OSHDBTags.of(kvs);
+
+    tags.add(new OSHDBTag(5, 6));
+  }
+
+  @Test(expected = UnsupportedOperationException.class)
+  public void testImmutableRemove() {
+    var tags = OSHDBTags.of(kvs);
+
+    tags.removeIf(tag -> tag.getKey() == 2);
+  }
+
+  @Test
+  public void testArrayEquality() {
+    var tags = OSHDBTags.of(new int[] {2, 2, 4, 4});
+
+    assertEquals(tags, tags);
+    assertEquals(tags, OSHDBTags.of(new int[] {2, 2, 4, 4}));
+    assertEquals(tags, Set.of(new OSHDBTag(2, 2), new OSHDBTag(4, 4)));
+
+    assertNotEquals(tags, OSHDBTags.of(new int[] {1, 1, 4, 4}));
+    assertNotEquals(tags, List.of(new OSHDBTag(2, 2), new OSHDBTag(4, 4)));
+  }
+
+}

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
@@ -2,7 +2,7 @@ package org.heigit.ohsome.oshdb.osm;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
+import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -156,39 +156,39 @@ public class OSMNodeTest {
   @Test
   public void testGetTags() {
     OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
-    int[] expResult = new int[] {};
-    int[] result = instance.getRawTags();
-    Assert.assertArrayEquals(expResult, result);
+    var expResult = OSHDBTags.empty();
+    var result = instance.getTags();
+    Assert.assertEquals(expResult, result);
   }
 
   @Test
   public void testHasTagKey() {
     OSMNode instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     boolean expResult = false;
-    boolean result = instance.hasTagKey(1);
+    boolean result = instance.getTags().hasTagKey(1);
     assertEquals(expResult, result);
 
     instance =
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     expResult = true;
-    result = instance.hasTagKey(1);
+    result = instance.getTags().hasTagKey(1);
     assertEquals(expResult, result);
 
     instance =
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 2, 3, 3}, 1000000000, 1000000000);
     expResult = false;
-    result = instance.hasTagKeyExcluding(1, new int[] {2, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {2, 3});
     assertEquals(expResult, result);
 
     instance =
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     expResult = true;
-    result = instance.hasTagKeyExcluding(1, new int[] {2, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {2, 3});
     assertEquals(expResult, result);
 
     instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {2, 1, 3, 3}, 1000000000, 1000000000);
     expResult = false;
-    result = instance.hasTagKeyExcluding(1, new int[] {1, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {1, 3});
     assertEquals(expResult, result);
   }
 
@@ -197,12 +197,12 @@ public class OSMNodeTest {
     OSMNode instance =
         new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 3}, 1000000000, 1000000000);
     boolean expResult = false;
-    boolean result = instance.hasTagValue(1, 1);
+    boolean result = instance.getTags().hasTagValue(1, 1);
     assertEquals(expResult, result);
 
     instance = new OSMNode(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 3}, 1000000000, 1000000000);
     expResult = true;
-    result = instance.hasTagValue(1, 1);
+    result = instance.getTags().hasTagValue(1, 1);
     assertEquals(expResult, result);
   }
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
@@ -2,6 +2,7 @@ package org.heigit.ohsome.oshdb.osm;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.Assert;
 import org.junit.Test;

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
@@ -3,7 +3,7 @@ package org.heigit.ohsome.oshdb.osm;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
+import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -117,9 +117,9 @@ public class OSMRelationTest {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         new OSMRelation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
-    int[] expResult = new int[] {1, 1, 2, 2};
-    int[] result = instance.getRawTags();
-    Assert.assertArrayEquals(expResult, result);
+    var expResult = OSHDBTags.of(new int[] {1, 1, 2, 2});
+    var result = instance.getTags();
+    Assert.assertEquals(expResult, result);
   }
 
   @Test
@@ -128,35 +128,35 @@ public class OSMRelationTest {
     OSMRelation instance =
         new OSMRelation(1L, 2, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     boolean expResult = false;
-    boolean result = instance.hasTagKey(1);
+    boolean result = instance.getTags().hasTagKey(1);
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.WAY, 1);
     instance = new OSMRelation(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3},
         new OSMMember[] {part, part});
     expResult = true;
-    result = instance.hasTagKey(1);
+    result = instance.getTags().hasTagKey(1);
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.WAY, 1);
     instance = new OSMRelation(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 2, 3, 3},
         new OSMMember[] {part, part});
     expResult = false;
-    result = instance.hasTagKeyExcluding(1, new int[] {2, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {2, 3});
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.WAY, 1);
     instance = new OSMRelation(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3},
         new OSMMember[] {part, part});
     expResult = true;
-    result = instance.hasTagKeyExcluding(1, new int[] {2, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {2, 3});
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.WAY, 1);
     instance =
         new OSMRelation(1L, 1, 1L, 1L, 1, new int[] {2, 1, 3, 3}, new OSMMember[] {part, part});
     expResult = false;
-    result = instance.hasTagKeyExcluding(1, new int[] {1, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {1, 3});
     assertEquals(expResult, result);
   }
 
@@ -166,7 +166,7 @@ public class OSMRelationTest {
     OSMRelation instance =
         new OSMRelation(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 3}, new OSMMember[] {part, part});
     boolean expResult = false;
-    boolean result = instance.hasTagValue(1, 1);
+    boolean result = instance.getTags().hasTagValue(1, 1);
     assertEquals(expResult, result);
   }
 
@@ -176,19 +176,7 @@ public class OSMRelationTest {
     OSMRelation instance =
         new OSMRelation(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 3}, new OSMMember[] {part, part});
     boolean expResult = true;
-    boolean result = instance.hasTagValue(1, 1);
+    boolean result = instance.getTags().hasTagValue(1, 1);
     assertEquals(expResult, result);
   }
-
-  @Test
-  public void testToString() {
-    OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
-    OSMRelation instance =
-        new OSMRelation(1L, 2, 1L, 1L, 1, new int[] {1, 2}, new OSMMember[] {part, part});
-    String expResult = "Relation-> ID:1 V:+2+ TS:1 CS:1 VIS:true UID:1 TAGS:[1, 2] "
-        + "Mem:[T:WAY ID:1 R:1, T:WAY ID:1 R:1]";
-    String result = instance.toString();
-    assertEquals(expResult, result);
-  }
-
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
@@ -3,6 +3,7 @@ package org.heigit.ohsome.oshdb.osm;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.Assert;
 import org.junit.Test;

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
@@ -3,7 +3,7 @@ package org.heigit.ohsome.oshdb.osm;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
+import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -28,26 +28,6 @@ public class OSMWayTest {
     expResult = null;
     result = instance.getMembers();
     assertArrayEquals(expResult, result);
-  }
-
-  @Test
-  public void testToString() {
-    OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
-    OSMWay instance = new OSMWay(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
-    String expResult =
-        "WAY-> ID:1 V:+1+ TS:1 CS:1 VIS:true UID:1 TAGS:[] Refs:[T:NODE ID:1 R:1, T:NODE ID:1 R:1]";
-    String result = instance.toString();
-    assertEquals(expResult, result);
-
-    instance = new OSMWay(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {});
-    expResult = "WAY-> ID:1 V:+1+ TS:1 CS:1 VIS:true UID:1 TAGS:[1, 1, 2, 2] Refs:[]";
-    result = instance.toString();
-    assertEquals(expResult, result);
-
-    instance = new OSMWay(1L, 1, 1L, 1L, 1, new int[] {}, null);
-    expResult = "WAY-> ID:1 V:+1+ TS:1 CS:1 VIS:true UID:1 TAGS:[] Refs:null";
-    result = instance.toString();
-    assertEquals(expResult, result);
   }
 
   @Test
@@ -133,9 +113,9 @@ public class OSMWayTest {
   public void testGetTags() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = new OSMWay(1L, 1, 1L, 1L, 1, new int[] {1, 1}, new OSMMember[] {part, part});
-    int[] expResult = new int[] {1, 1};
-    int[] result = instance.getRawTags();
-    Assert.assertArrayEquals(expResult, result);
+    var expResult = OSHDBTags.of(new int[] {1, 1});
+    var result = instance.getTags();
+    Assert.assertEquals(expResult, result);
   }
 
   @Test
@@ -143,34 +123,34 @@ public class OSMWayTest {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = new OSMWay(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     boolean expResult = false;
-    boolean result = instance.hasTagKey(1);
+    boolean result = instance.getTags().hasTagKey(1);
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.NODE, 1);
     instance =
         new OSMWay(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, new OSMMember[] {part, part});
     expResult = true;
-    result = instance.hasTagKey(1);
+    result = instance.getTags().hasTagKey(1);
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.NODE, 1);
     instance =
         new OSMWay(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 2, 3, 3}, new OSMMember[] {part, part});
     expResult = false;
-    result = instance.hasTagKeyExcluding(1, new int[] {2, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {2, 3});
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.NODE, 1);
     instance =
         new OSMWay(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, new OSMMember[] {part, part});
     expResult = true;
-    result = instance.hasTagKeyExcluding(1, new int[] {2, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {2, 3});
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.NODE, 1);
     instance = new OSMWay(1L, 1, 1L, 1L, 1, new int[] {2, 1, 3, 3}, new OSMMember[] {part, part});
     expResult = false;
-    result = instance.hasTagKeyExcluding(1, new int[] {1, 3});
+    result = instance.getTags().hasTagKeyExcluding(1, new int[] {1, 3});
     assertEquals(expResult, result);
   }
 
@@ -180,13 +160,13 @@ public class OSMWayTest {
     OSMWay instance =
         new OSMWay(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 3}, new OSMMember[] {part, part});
     boolean expResult = false;
-    boolean result = instance.hasTagValue(1, 1);
+    boolean result = instance.getTags().hasTagValue(1, 1);
     assertEquals(expResult, result);
 
     part = new OSMMember(1L, OSMType.NODE, 1);
     instance = new OSMWay(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 3}, new OSMMember[] {part, part});
     expResult = true;
-    result = instance.hasTagValue(1, 1);
+    result = instance.getTags().hasTagValue(1, 1);
     assertEquals(expResult, result);
   }
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
@@ -3,6 +3,7 @@ package org.heigit.ohsome.oshdb.osm;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
 import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.Assert;
 import org.junit.Test;


### PR DESCRIPTION
Replace deprecated `OSMEntity.getRawTags` with a new `OSHDBTags` collection class.

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- [ ] I have added sufficient unit tests → see #445 
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- [ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository
- [ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
