### PR TITLE
Jenkins: use SonarCloud PR feature

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -66,7 +66,17 @@ pipeline {
         script {
           // START CUSTOM oshdb
           withSonarQubeEnv('sonarcloud GIScience/ohsome') {
-            sh "mvn $MAVEN_GENERAL_OPTIONS sonar:sonar -Dsonar.branch.name=${env.BRANCH_NAME} -Dsonar.projectName=OSHDB"
+            SONAR_CLI_PARAMETER = "-Dsonar.projectName=OSHDB"
+            if (env.CHANGE_ID) {
+              SONAR_CLI_PARAMETER += " " +
+                "-Dsonar.pullrequest.key=${env.CHANGE_ID} " +
+                "-Dsonar.pullrequest.branch=${env.CHANGE_BRANCH} " +
+                "-Dsonar.pullrequest.base=${env.CHANGE_TARGET}"
+            } else {
+              SONAR_CLI_PARAMETER += " " +
+                "-Dsonar.branch.name=${env.BRANCH_NAME}"
+            }
+            sh "mvn $MAVEN_GENERAL_OPTIONS sonar:sonar ${SONAR_CLI_PARAMETER}"
           }
           // END CUSTOM oshdb
           report_basedir = "/srv/reports/${REPO_NAME}/${VERSION}_${env.BRANCH_NAME}/${env.BUILD_NUMBER}_${LATEST_COMMIT_ID}"


### PR DESCRIPTION
### Description
Jenkins now submits PR information when running as PR and not as a pure branch

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- ~[ ] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results~
- ~[ ] I have commented my code~
- ~[ ] I have written javadoc (required for public classes and methods)~
- ~[ ] I have added sufficient unit tests~
- ~[ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)~
- ~[ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~[ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
