### PR TITLE
Migrate to junit5

### DIFF
--- a/oshdb-api-ignite/pom.xml
+++ b/oshdb-api-ignite/pom.xml
@@ -44,5 +44,12 @@
       <artifactId>ignite-slf4j</artifactId>
       <version>${ignite.version}</version>
     </dependency>
+    
+    <!-- TEST dependencies -->
+    <dependency>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/oshdb-api-ignite/pom.xml
+++ b/oshdb-api-ignite/pom.xml
@@ -44,12 +44,5 @@
       <artifactId>ignite-slf4j</artifactId>
       <version>${ignite.version}</version>
     </dependency>
-    
-    <!-- TEST dependencies -->
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgnite.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgnite.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgnite.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgnite.java
@@ -46,7 +46,7 @@ abstract class TestMapReduceOSHDBIgnite extends TestMapReduce {
     ignite = Ignition.start(cfg);
   }
 
-  public TestMapReduceOSHDBIgnite(OSHDBIgnite oshdb) throws Exception {
+  TestMapReduceOSHDBIgnite(OSHDBIgnite oshdb) throws Exception {
     super(oshdb);
 
     final String prefix = "tests";

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteAffinityCall.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteAffinityCall.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Runs the tests using the "affinity call" Ignite backend.</p>
  */
-public class TestMapReduceOSHDBIgniteAffinityCall extends TestMapReduceOSHDBIgnite {
+class TestMapReduceOSHDBIgniteAffinityCall extends TestMapReduceOSHDBIgnite {
   /**
    * Creates the test runner using the ignite affinitycall backend.
    *
@@ -24,7 +24,7 @@ public class TestMapReduceOSHDBIgniteAffinityCall extends TestMapReduceOSHDBIgni
   }
 
   @Test
-  public void testOSMEntitySnapshotViewStreamNullValues() throws Exception {
+  void testOSMEntitySnapshotViewStreamNullValues() throws Exception {
     // simple stream query
     Set<Integer> result = createMapReducerOSMEntitySnapshot()
         .timestamps(

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteAffinityCall.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteAffinityCall.java
@@ -1,12 +1,12 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.api.db.OSHDBIgnite;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * {@inheritDoc}

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteAffinityCall.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteAffinityCall.java
@@ -19,7 +19,7 @@ class TestMapReduceOSHDBIgniteAffinityCall extends TestMapReduceOSHDBIgnite {
    *
    * @throws Exception if something goes wrong
    */
-  public TestMapReduceOSHDBIgniteAffinityCall() throws Exception {
+  TestMapReduceOSHDBIgniteAffinityCall() throws Exception {
     super(new OSHDBIgnite(ignite).computeMode(OSHDBIgnite.ComputeMode.AFFINITY_CALL));
   }
 

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteLocalPeek.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteLocalPeek.java
@@ -7,13 +7,13 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBIgnite;
  *
  * <p>Runs the tests using the "local peek" Ignite backend.</p>
  */
-public class TestMapReduceOSHDBIgniteLocalPeek extends TestMapReduceOSHDBIgnite {
+class TestMapReduceOSHDBIgniteLocalPeek extends TestMapReduceOSHDBIgnite {
   /**
    * Creates the test runner using the ignite localpeak backend.
    *
    * @throws Exception if something goes wrong
    */
-  public TestMapReduceOSHDBIgniteLocalPeek() throws Exception {
+  TestMapReduceOSHDBIgniteLocalPeek() throws Exception {
     super(new OSHDBIgnite(ignite).computeMode(OSHDBIgnite.ComputeMode.LOCAL_PEEK));
   }
 }

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
@@ -9,20 +9,20 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for proper error messages is caches are not pnt on ignite.
  */
-public class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgnite {
+class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgnite {
   /**
    * Creates the test runner using an Ignite backend.
    *
    * @throws Exception if something goes wrong
    */
-  public TestMapReduceOSHDBIgniteMissingCache() throws Exception {
+  TestMapReduceOSHDBIgniteMissingCache() throws Exception {
     super(new OSHDBIgnite(ignite));
     this.oshdb.prefix("<test caches not present>");
   }
 
   @Override
   @Test()
-  public void testOSMContributionView() throws Exception {
+  void testOSMContributionView() throws Exception {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       super.testOSMContributionView();
     });
@@ -30,7 +30,7 @@ public class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgni
 
   @Override
   @Test()
-  public void testOSMEntitySnapshotView() throws Exception {
+  void testOSMEntitySnapshotView() throws Exception {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       super.testOSMEntitySnapshotView();
     });
@@ -38,7 +38,7 @@ public class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgni
 
   @Override
   @Test()
-  public void testOSMContributionViewStream() throws Exception {
+  void testOSMContributionViewStream() throws Exception {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       super.testOSMEntitySnapshotView();
     });
@@ -46,7 +46,7 @@ public class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgni
 
   @Override
   @Test()
-  public void testOSMEntitySnapshotViewStream() throws Exception {
+  void testOSMEntitySnapshotViewStream() throws Exception {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       super.testOSMEntitySnapshotView();
     });
@@ -54,7 +54,7 @@ public class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgni
 
   @Override
   @Test()
-  public void testTimeoutMapReduce() throws Exception {
+  void testTimeoutMapReduce() throws Exception {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       timeoutMapReduce();
     });
@@ -62,7 +62,7 @@ public class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgni
 
   @Override
   @Test()
-  public void testTimeoutStream() {
+  void testTimeoutStream() {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       timeoutStream();
     });

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
@@ -1,8 +1,10 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.heigit.ohsome.oshdb.api.db.OSHDBIgnite;
 import org.heigit.ohsome.oshdb.util.exceptions.OSHDBTableNotFoundException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for proper error messages is caches are not pnt on ignite.
@@ -19,38 +21,46 @@ public class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgni
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
+  @Test()
   public void testOSMContributionView() throws Exception {
-    super.testOSMContributionView();
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      super.testOSMContributionView();
+    });
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
+  @Test()
   public void testOSMEntitySnapshotView() throws Exception {
-    super.testOSMEntitySnapshotView();
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      super.testOSMEntitySnapshotView();
+    });
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
+  @Test()
   public void testOSMContributionViewStream() throws Exception {
-    super.testOSMEntitySnapshotView();
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      super.testOSMEntitySnapshotView();
+    });
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
+  @Test()
   public void testOSMEntitySnapshotViewStream() throws Exception {
-    super.testOSMEntitySnapshotView();
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      super.testOSMEntitySnapshotView();
+    });
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
+  @Test()
   public void testTimeoutMapReduce() throws Exception {
-    super.testTimeoutMapReduce();
+    // no-op no test for timeout if we got a missing table!
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
+  @Test()
   public void testTimeoutStream() throws Exception {
-    super.testTimeoutStream();
+    // no-op no test for timeout if we got a missing table!
   }
 }

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
@@ -40,7 +40,7 @@ class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgnite {
   @Test()
   void testOSMContributionViewStream() throws Exception {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMEntitySnapshotView();
+      super.testOSMContributionViewStream();
     });
   }
 
@@ -48,7 +48,7 @@ class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgnite {
   @Test()
   void testOSMEntitySnapshotViewStream() throws Exception {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMEntitySnapshotView();
+      super.testOSMEntitySnapshotViewStream();
     });
   }
 

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
@@ -55,12 +55,16 @@ public class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgni
   @Override
   @Test()
   public void testTimeoutMapReduce() throws Exception {
-    // no-op no test for timeout if we got a missing table!
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      timeoutMapReduce();
+    });
   }
 
   @Override
   @Test()
-  public void testTimeoutStream() throws Exception {
-    // no-op no test for timeout if we got a missing table!
+  public void testTimeoutStream() {
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      timeoutStream();
+    });
   }
 }

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteScanQuery.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteScanQuery.java
@@ -10,19 +10,19 @@ import org.junit.jupiter.api.Test;
  *
  * <p>Runs the tests using the "scan query" Ignite backend.</p>
  */
-public class TestMapReduceOSHDBIgniteScanQuery extends TestMapReduceOSHDBIgnite {
+class TestMapReduceOSHDBIgniteScanQuery extends TestMapReduceOSHDBIgnite {
   /**
    * Creates the test runner using the ignite scanquery backend.
    *
    * @throws Exception if something goes wrong
    */
-  public TestMapReduceOSHDBIgniteScanQuery() throws Exception {
+  TestMapReduceOSHDBIgniteScanQuery() throws Exception {
     super(new OSHDBIgnite(ignite).computeMode(OSHDBIgnite.ComputeMode.SCAN_QUERY));
   }
 
   @Override
   @Test
-  public void testTimeoutStream() throws Exception {
+  void testTimeoutStream() throws Exception {
     // ignore this test -> scanquery backend currently doesn't support timeouts for stream()
     assertTrue(true);
   }

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteScanQuery.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteScanQuery.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.api.db.OSHDBIgnite;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * {@inheritDoc}

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -79,8 +79,8 @@
     
     <!-- TEST dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     

--- a/oshdb-api/pom.xml
+++ b/oshdb-api/pom.xml
@@ -79,12 +79,6 @@
     
     <!-- TEST dependencies -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Iterables;
 import java.util.Collections;
@@ -16,7 +16,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.OSMContributionView;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the collect method of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the collect method of the OSHDB API.
  */
-public class TestCollect {
+class TestCollect {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
@@ -42,7 +42,7 @@ public class TestCollect {
   }
 
   @Test
-  public void testCollect() throws Exception {
+  void testCollect() throws Exception {
     List<OSMContribution> result = this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .collect();
@@ -53,7 +53,7 @@ public class TestCollect {
   }
 
   @Test
-  public void testMapCollect() throws Exception {
+  void testMapCollect() throws Exception {
     List<Long> result = this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .map(contribution -> contribution.getEntityAfter().getId())
@@ -64,7 +64,7 @@ public class TestCollect {
   }
 
   @Test
-  public void testFlatMapCollect() throws Exception {
+  void testFlatMapCollect() throws Exception {
     List<Long> result = this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .flatMap(contribution -> Collections
@@ -76,7 +76,7 @@ public class TestCollect {
   }
 
   @Test
-  public void testFlatMapCollectGroupedById() throws Exception {
+  void testFlatMapCollectGroupedById() throws Exception {
     List<Long> result = this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .groupByEntity()
@@ -89,7 +89,7 @@ public class TestCollect {
   }
 
   @Test
-  public void testAggregatedByTimestamp() throws Exception {
+  void testAggregatedByTimestamp() throws Exception {
     SortedMap<OSHDBTimestamp, List<Long>> result = this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .aggregateByTimestamp()

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestCollect.java
@@ -29,7 +29,7 @@ class TestCollect {
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 
-  public TestCollect() throws Exception {
+  TestCollect() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
@@ -19,7 +19,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.OSMContributionView;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test flat map method of the MapAggregator class of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
@@ -33,7 +33,7 @@ class TestFlatMapAggregate {
 
   private static final double DELTA = 1e-8;
 
-  public TestFlatMapAggregate() throws Exception {
+  TestFlatMapAggregate() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregate.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test flat map method of the MapAggregator class of the OSHDB API.
  */
-public class TestFlatMapAggregate {
+class TestFlatMapAggregate {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
@@ -46,7 +46,7 @@ public class TestFlatMapAggregate {
   }
 
   @Test
-  public void test() throws Exception {
+  void test() throws Exception {
     SortedMap<Long, Set<Entry<Integer, Integer>>> result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .flatMap(

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test flat map method with groupByEntity of the MapAggregator class of the OSHDB API.
  */
-public class TestFlatMapAggregateGroupedByEntity {
+class TestFlatMapAggregateGroupedByEntity {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
@@ -44,7 +44,7 @@ public class TestFlatMapAggregateGroupedByEntity {
   }
 
   @Test
-  public void test() throws Exception {
+  void test() throws Exception {
     SortedMap<Long, Integer> result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .groupByEntity()

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
@@ -31,7 +31,7 @@ class TestFlatMapAggregateGroupedByEntity {
 
   private static final double DELTA = 1e-8;
 
-  public TestFlatMapAggregateGroupedByEntity() throws Exception {
+  TestFlatMapAggregateGroupedByEntity() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapAggregateGroupedByEntity.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
@@ -17,7 +17,7 @@ import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.celliterator.ContributionType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test flat map method with groupByEntity of the MapAggregator class of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.AbstractMap.SimpleImmutableEntry;
 import java.util.ArrayList;
@@ -19,7 +19,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.OSMContributionView;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test flat map method of the MapReducer class of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test flat map method of the MapReducer class of the OSHDB API.
  */
-public class TestFlatMapReduce {
+class TestFlatMapReduce {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
@@ -44,7 +44,7 @@ public class TestFlatMapReduce {
   }
 
   @Test
-  public void test() throws Exception {
+  void test() throws Exception {
     Set<Entry<Integer, Integer>> result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .flatMap(contribution -> {
@@ -74,7 +74,7 @@ public class TestFlatMapReduce {
   }
 
   @Test
-  public void testSet() throws Exception {
+  void testSet() throws Exception {
     Set<Integer> input = new TreeSet<>();
     input.add(1);
     input.add(2);
@@ -88,7 +88,7 @@ public class TestFlatMapReduce {
   }
 
   @Test
-  public void testIterable() throws Exception {
+  void testIterable() throws Exception {
     Set<Integer> input = new TreeSet<>();
     input.add(1);
     input.add(2);

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduce.java
@@ -31,7 +31,7 @@ class TestFlatMapReduce {
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 
-  public TestFlatMapReduce() throws Exception {
+  TestFlatMapReduce() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test flat map method with groupByEntity of the MapReducer class of the OSHDB API.
+ * Test flatMap method with groupByEntity of the MapReducer class of the OSHDB API.
  */
 abstract class TestFlatMapReduceGroupedByEntity {
   private final OSHDBDatabase oshdb;

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -15,7 +15,7 @@ import org.heigit.ohsome.oshdb.util.celliterator.ContributionType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test flat map method with groupByEntity of the MapReducer class of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntity.java
@@ -50,7 +50,7 @@ abstract class TestFlatMapReduceGroupedByEntity {
   }
 
   @Test
-  public void testOSMContributionView() throws Exception {
+  void testOSMContributionView() throws Exception {
     Number result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .groupByEntity()
@@ -77,7 +77,7 @@ abstract class TestFlatMapReduceGroupedByEntity {
   }
 
   @Test
-  public void testOSMEntitySnapshotView() throws Exception {
+  void testOSMEntitySnapshotView() throws Exception {
     Number result = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps6)
         .groupByEntity()

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntityOSHDBH2Multithread.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntityOSHDBH2Multithread.java
@@ -7,14 +7,14 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
  *
  * <p>Runs the tests using the multithreaded H2 backend.</p>
  */
-public class TestFlatMapReduceGroupedByEntityOSHDBH2Multithread extends
+class TestFlatMapReduceGroupedByEntityOSHDBH2Multithread extends
     TestFlatMapReduceGroupedByEntity {
   /**
    * Creates the test runner using the multithreaded H2 backend.
    *
    * @throws Exception if something goes wrong
    */
-  public TestFlatMapReduceGroupedByEntityOSHDBH2Multithread() throws Exception {
+  TestFlatMapReduceGroupedByEntityOSHDBH2Multithread() throws Exception {
     super(
         (new OSHDBH2("./src/test/resources/test-data")).multithreading(true)
     );

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntityOSHDBH2Singlethread.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestFlatMapReduceGroupedByEntityOSHDBH2Singlethread.java
@@ -7,14 +7,14 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
  *
  * <p>Runs the tests using the singlethreaded H2 backend.</p>
  */
-public class TestFlatMapReduceGroupedByEntityOSHDBH2Singlethread extends
+class TestFlatMapReduceGroupedByEntityOSHDBH2Singlethread extends
     TestFlatMapReduceGroupedByEntity {
   /**
    * Creates the test runner using the singlethreaded "dummy" H2 backend.
    *
    * @throws Exception if something goes wrong
    */
-  public TestFlatMapReduceGroupedByEntityOSHDBH2Singlethread() throws Exception {
+  TestFlatMapReduceGroupedByEntityOSHDBH2Singlethread() throws Exception {
     super(
         (new OSHDBH2("./src/test/resources/test-data")).multithreading(false)
     );

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
@@ -14,7 +14,7 @@ import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test for each method of the OSHDB API.
+ * Test forEach method of the OSHDB API.
  */
 class TestForEach {
   private final OSHDBDatabase oshdb;

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test for each method of the OSHDB API.
  */
-public class TestForEach {
+class TestForEach {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
@@ -37,7 +37,7 @@ public class TestForEach {
   }
 
   @Test
-  public void testForEach() throws Exception {
+  void testForEach() throws Exception {
     ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
     this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -48,7 +48,7 @@ public class TestForEach {
   }
 
   @Test
-  public void testForEachGroupedById() throws Exception {
+  void testForEachGroupedById() throws Exception {
     ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
     this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -62,7 +62,7 @@ public class TestForEach {
   }
 
   @Test
-  public void testForEachAggregatedByTimestamp() throws Exception {
+  void testForEachAggregatedByTimestamp() throws Exception {
     ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
     this.createMapReducerOSMContribution()
         .timestamps(timestamps72)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
@@ -24,7 +24,7 @@ class TestForEach {
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 
-  public TestForEach() throws Exception {
+  TestForEach() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestForEach.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.ConcurrentHashMap;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
@@ -11,7 +11,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.OSMContributionView;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for each method of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
@@ -33,7 +33,7 @@ class TestHelpersOSMContributionView {
 
   private static final double DELTA = 1e-8;
 
-  public TestHelpersOSMContributionView() throws Exception {
+  TestHelpersOSMContributionView() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -17,7 +17,7 @@ import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.celliterator.ContributionType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test special reducers of the OSHDB API when using the contribution view.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMContributionView.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test special reducers of the OSHDB API when using the contribution view.
  */
-public class TestHelpersOSMContributionView {
+class TestHelpersOSMContributionView {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
@@ -46,7 +46,7 @@ public class TestHelpersOSMContributionView {
   }
 
   @Test
-  public void testSum() throws Exception {
+  void testSum() throws Exception {
     // single timestamp
     SortedMap<OSHDBTimestamp, Number> result1 = this.createMapReducer()
         .timestamps(timestamps2)
@@ -93,7 +93,7 @@ public class TestHelpersOSMContributionView {
   }
 
   @Test
-  public void testCount() throws Exception {
+  void testCount() throws Exception {
     // single timestamp
     SortedMap<OSHDBTimestamp, Integer> result1 = this.createMapReducer()
         .timestamps(timestamps2)
@@ -131,7 +131,7 @@ public class TestHelpersOSMContributionView {
   }
 
   @Test
-  public void testAverage() throws Exception {
+  void testAverage() throws Exception {
     // single timestamp
     Double result1 = this.createMapReducer()
         .timestamps(timestamps2)
@@ -169,7 +169,7 @@ public class TestHelpersOSMContributionView {
   }
 
   @Test
-  public void testWeightedAverage() throws Exception {
+  void testWeightedAverage() throws Exception {
     // single timestamp
     Double result1 = this.createMapReducer()
         .timestamps(timestamps2)
@@ -211,7 +211,7 @@ public class TestHelpersOSMContributionView {
   }
 
   @Test
-  public void testUniq() throws Exception {
+  void testUniq() throws Exception {
     // single timestamp
     SortedMap<OSHDBTimestamp, Set<Long>> result1 = this.createMapReducer()
         .timestamps(timestamps2)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
@@ -30,7 +30,7 @@ class TestHelpersOSMEntitySnapshotView {
 
   private static final double DELTA = 1e-8;
 
-  public TestHelpersOSMEntitySnapshotView() throws Exception {
+  TestHelpersOSMEntitySnapshotView() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 import java.util.SortedMap;
@@ -14,7 +14,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.OSMEntitySnapshotView;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test special reducers of the OSHDB API when using the contribution view.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestHelpersOSMEntitySnapshotView.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test special reducers of the OSHDB API when using the contribution view.
  */
-public class TestHelpersOSMEntitySnapshotView {
+class TestHelpersOSMEntitySnapshotView {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
@@ -43,7 +43,7 @@ public class TestHelpersOSMEntitySnapshotView {
   }
 
   @Test
-  public void testSum() throws Exception {
+  void testSum() throws Exception {
     // single timestamp
     SortedMap<OSHDBTimestamp, Number> result1 = this.createMapReducer()
         .timestamps(timestamps1)
@@ -87,7 +87,7 @@ public class TestHelpersOSMEntitySnapshotView {
   }
 
   @Test
-  public void testCount() throws Exception {
+  void testCount() throws Exception {
     // single timestamp
     SortedMap<OSHDBTimestamp, Integer> result1 = this.createMapReducer()
         .timestamps(timestamps1)
@@ -133,7 +133,7 @@ public class TestHelpersOSMEntitySnapshotView {
   }
 
   @Test
-  public void testAverage() throws Exception {
+  void testAverage() throws Exception {
     // single timestamp
     Double result1 = this.createMapReducer()
         .timestamps(timestamps1)
@@ -170,7 +170,7 @@ public class TestHelpersOSMEntitySnapshotView {
   }
 
   @Test
-  public void testWeightedAverage() throws Exception {
+  void testWeightedAverage() throws Exception {
     // single timestamp
     Double result1 = this.createMapReducer()
         .timestamps(timestamps1)
@@ -214,7 +214,7 @@ public class TestHelpersOSMEntitySnapshotView {
   }
 
   @Test
-  public void testUniq() throws Exception {
+  void testUniq() throws Exception {
     // single timestamp
     SortedMap<OSHDBTimestamp, Set<Long>> result1 = this.createMapReducer()
         .timestamps(timestamps1)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 import java.util.SortedMap;
@@ -14,7 +14,7 @@ import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.celliterator.ContributionType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests lambda functions as filters.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
@@ -28,7 +28,7 @@ class TestLambdaFilter {
 
   private static final double DELTA = 1e-8;
 
-  public TestLambdaFilter() throws Exception {
+  TestLambdaFilter() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestLambdaFilter.java
@@ -19,7 +19,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests lambda functions as filters.
  */
-public class TestLambdaFilter {
+class TestLambdaFilter {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
@@ -41,7 +41,7 @@ public class TestLambdaFilter {
   }
 
   @Test
-  public void testFilter() throws Exception {
+  void testFilter() throws Exception {
     Set<Integer> result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .osmEntityFilter(entity -> entity.getId() == 617308093)
@@ -57,7 +57,7 @@ public class TestLambdaFilter {
   }
 
   @Test
-  public void testAggregateFilter() throws Exception {
+  void testAggregateFilter() throws Exception {
     SortedMap<Long, Set<Integer>> result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
         .osmEntityFilter(entity -> entity.getId() == 617308093)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Test aggregate by geometry method of the OSHDB API.
+ * Test aggregateByGeometry method of the OSHDB API.
  */
 class TestMapAggregateByGeometry {
   private final OSHDBDatabase oshdb;

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
@@ -1,8 +1,9 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -24,7 +25,7 @@ import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Polygon;
 
 /**
@@ -181,23 +182,27 @@ public class TestMapAggregateByGeometry {
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored") //  we test for a thrown exception here
-  @Test(expected = UnsupportedOperationException.class)
+  @Test()
   public void testCombinedWithAggregateByTimestampUnsupportedOrder1() throws Exception {
-    createMapReducerOSMEntitySnapshot()
-        .timestamps(timestamps1)
-        .map(ignored -> null)
-        .aggregateByTimestamp()
-        .aggregateByGeometry(getSubRegions())
-        .collect();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      createMapReducerOSMEntitySnapshot()
+          .timestamps(timestamps1)
+          .map(ignored -> null)
+          .aggregateByTimestamp()
+          .aggregateByGeometry(getSubRegions())
+          .collect();
+    });
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored") //  we test for a thrown exception here
-  @Test(expected = UnsupportedOperationException.class)
+  @Test()
   public void testCombinedWithAggregateByTimestampUnsupportedOrder3() throws Exception {
-    createMapReducerOSMEntitySnapshot()
-        .timestamps(timestamps1)
-        .groupByEntity()
-        .aggregateByGeometry(getSubRegions())
-        .collect();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      createMapReducerOSMEntitySnapshot()
+          .timestamps(timestamps1)
+          .groupByEntity()
+          .aggregateByGeometry(getSubRegions())
+          .collect();
+    });
   }
 }

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
@@ -40,7 +40,7 @@ class TestMapAggregateByGeometry {
 
   private static final double DELTA = 1e-4;
 
-  public TestMapAggregateByGeometry() throws Exception {
+  TestMapAggregateByGeometry() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByGeometry.java
@@ -31,7 +31,7 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Test aggregate by geometry method of the OSHDB API.
  */
-public class TestMapAggregateByGeometry {
+class TestMapAggregateByGeometry {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
@@ -78,7 +78,7 @@ public class TestMapAggregateByGeometry {
   }
 
   @Test
-  public void testOSMContribution() throws Exception {
+  void testOSMContribution() throws Exception {
     SortedMap<String, Integer> resultCount = createMapReducerOSMContribution()
         .timestamps(timestamps2)
         .aggregateByGeometry(getSubRegions())
@@ -103,7 +103,7 @@ public class TestMapAggregateByGeometry {
   }
 
   @Test
-  public void testOSMEntitySnapshot() throws Exception {
+  void testOSMEntitySnapshot() throws Exception {
     SortedMap<String, Integer> resultCount = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps1)
         .aggregateByGeometry(getSubRegions())
@@ -128,7 +128,7 @@ public class TestMapAggregateByGeometry {
   }
 
   @Test
-  public void testZerofill() throws Exception {
+  void testZerofill() throws Exception {
     SortedMap<String, Integer> resultZerofilled = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps1)
         .aggregateByGeometry(getSubRegions())
@@ -138,7 +138,7 @@ public class TestMapAggregateByGeometry {
   }
 
   @Test
-  public void testCombinedWithAggregateByTimestamp() throws Exception {
+  void testCombinedWithAggregateByTimestamp() throws Exception {
     SortedMap<OSHDBCombinedIndex<OSHDBTimestamp, String>, Integer> result =
         createMapReducerOSMEntitySnapshot()
             .timestamps(timestamps1)
@@ -157,7 +157,7 @@ public class TestMapAggregateByGeometry {
   }
 
   @Test
-  public void testCombinedWithAggregateByTimestampOrder() throws Exception {
+  void testCombinedWithAggregateByTimestampOrder() throws Exception {
     SortedMap<OSHDBCombinedIndex<String, OSHDBTimestamp>, List<Long>> resultGeomTime =
         createMapReducerOSMEntitySnapshot()
             .timestamps(timestamps2)
@@ -183,7 +183,7 @@ public class TestMapAggregateByGeometry {
 
   @SuppressWarnings("ResultOfMethodCallIgnored") //  we test for a thrown exception here
   @Test()
-  public void testCombinedWithAggregateByTimestampUnsupportedOrder1() throws Exception {
+  void testCombinedWithAggregateByTimestampUnsupportedOrder1() throws Exception {
     assertThrows(UnsupportedOperationException.class, () -> {
       createMapReducerOSMEntitySnapshot()
           .timestamps(timestamps1)
@@ -196,7 +196,7 @@ public class TestMapAggregateByGeometry {
 
   @SuppressWarnings("ResultOfMethodCallIgnored") //  we test for a thrown exception here
   @Test()
-  public void testCombinedWithAggregateByTimestampUnsupportedOrder3() throws Exception {
+  void testCombinedWithAggregateByTimestampUnsupportedOrder3() throws Exception {
     assertThrows(UnsupportedOperationException.class, () -> {
       createMapReducerOSMEntitySnapshot()
           .timestamps(timestamps1)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test aggregate by custom index method of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test aggregate by custom index method of the OSHDB API.
  */
-public class TestMapAggregateByIndex {
+class TestMapAggregateByIndex {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox = bboxWgs84Coordinates(8.0, 49.0, 9.0, 50.0);
@@ -55,7 +55,7 @@ public class TestMapAggregateByIndex {
   }
 
   @Test
-  public void testOSMContribution() throws Exception {
+  void testOSMContribution() throws Exception {
     SortedMap<Long, Set<Integer>> result = createMapReducerOSMContribution()
         .timestamps(timestamps2)
         .osmEntityFilter(entity -> entity.getId() == 617308093)
@@ -81,7 +81,7 @@ public class TestMapAggregateByIndex {
   }
 
   @Test
-  public void testOSMEntitySnapshot() throws Exception {
+  void testOSMEntitySnapshot() throws Exception {
     SortedMap<Long, Set<Integer>> result = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps72)
         .osmEntityFilter(entity -> entity.getId() == 617308093)
@@ -107,7 +107,7 @@ public class TestMapAggregateByIndex {
   }
 
   @Test
-  public void testZerofill() throws Exception {
+  void testZerofill() throws Exception {
     // partially empty result
     SortedMap<Long, Integer> result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -139,7 +139,7 @@ public class TestMapAggregateByIndex {
   }
 
   @Test
-  public void testMultiple2() throws Exception {
+  void testMultiple2() throws Exception {
     SortedMap<OSHDBCombinedIndex<Long, OSMType>, Integer> result =
         createMapReducerOSMEntitySnapshot()
             .timestamps(timestamps1)
@@ -155,7 +155,7 @@ public class TestMapAggregateByIndex {
   }
 
   @Test
-  public void testMultiple3() throws Exception {
+  void testMultiple3() throws Exception {
     SortedMap<OSHDBCombinedIndex<OSHDBCombinedIndex<Long, OSMType>, Integer>, Integer> result =
         createMapReducerOSMEntitySnapshot()
             .timestamps(timestamps1)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByIndex.java
@@ -34,7 +34,7 @@ class TestMapAggregateByIndex {
 
   private static final double DELTA = 1e-8;
 
-  public TestMapAggregateByIndex() throws Exception {
+  TestMapAggregateByIndex() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
@@ -34,7 +34,7 @@ class TestMapAggregateByTimestamp {
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 
-  public TestMapAggregateByTimestamp() throws Exception {
+  TestMapAggregateByTimestamp() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
@@ -22,7 +22,7 @@ import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test aggregate by timestamp method of the OSHDB API.
+ * Test aggregateByTimestamp method of the OSHDB API.
  */
 class TestMapAggregateByTimestamp {
   private final OSHDBDatabase oshdb;

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Test aggregate by timestamp method of the OSHDB API.
  */
-public class TestMapAggregateByTimestamp {
+class TestMapAggregateByTimestamp {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
@@ -33,8 +33,6 @@ public class TestMapAggregateByTimestamp {
   private final OSHDBTimestamps timestamps2 = new OSHDBTimestamps("2014-01-01", "2014-12-30");
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
-
-  private static final double DELTA = 1e-8;
 
   public TestMapAggregateByTimestamp() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
@@ -57,7 +55,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testOSMContribution() throws Exception {
+  void testOSMContribution() throws Exception {
     // single timestamp
     SortedMap<OSHDBTimestamp, Integer> result1 = createMapReducerOSMContribution()
         .timestamps(timestamps2)
@@ -84,7 +82,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testOSMContributionCustomDefault() throws Exception {
+  void testOSMContributionCustomDefault() throws Exception {
     // check if it produces the same result as the automatic aggregateByTimestamp()
     SortedMap<OSHDBTimestamp, Integer> resultAuto = createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -105,7 +103,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testOSMContributionCustom() throws Exception {
+  void testOSMContributionCustom() throws Exception {
     // most basic custom timestamp index possible -> map all to one single timestamp
     SortedMap<OSHDBTimestamp, Integer> resultCustom = createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -117,7 +115,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testOSMEntitySnapshot() throws Exception {
+  void testOSMEntitySnapshot() throws Exception {
     // single timestamp
     SortedMap<OSHDBTimestamp, Integer> result1 = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps1)
@@ -147,7 +145,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testOSMEntitySnapshotCustomDefault() throws Exception {
+  void testOSMEntitySnapshotCustomDefault() throws Exception {
     // check if it produces the same result as the automatic aggregateByTimestamp()
     SortedMap<OSHDBTimestamp, Integer> resultAuto = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps72)
@@ -168,7 +166,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testOSMEntitySnapshotCustom() throws Exception {
+  void testOSMEntitySnapshotCustom() throws Exception {
     // most basic custom timestamp index possible -> map all to one single timestamp
     SortedMap<OSHDBTimestamp, Integer> resultCustom = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps72)
@@ -181,7 +179,7 @@ public class TestMapAggregateByTimestamp {
 
   @SuppressWarnings("ResultOfMethodCallIgnored") // we test for a thrown exception here
   @Test()
-  public void testInvalidUsage() throws Exception {
+  void testInvalidUsage() throws Exception {
     assertThrows(OSHDBInvalidTimestampException.class, () -> {
       // indexing function returns a timestamp outside the requested time range -> should throw
       createMapReducerOSMContribution()
@@ -194,7 +192,7 @@ public class TestMapAggregateByTimestamp {
 
   @SuppressWarnings("ResultOfMethodCallIgnored") // we test for a thrown exception here
   @Test()
-  public void testUnsupportedUsage() throws Exception {
+  void testUnsupportedUsage() throws Exception {
     assertThrows(UnsupportedOperationException.class, () -> {
       createMapReducerOSMContribution()
           .timestamps(timestamps72)
@@ -204,9 +202,8 @@ public class TestMapAggregateByTimestamp {
     });
   }
 
-
   @Test
-  public void testMapperFunctions() throws Exception {
+  void testMapperFunctions() throws Exception {
     // check if it produces the same result whether the map function was set before or after aggr.
     SortedMap<OSHDBTimestamp, Number> result1 = createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -230,7 +227,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testCombinedWithAggregateByIndex() throws Exception {
+  void testCombinedWithAggregateByIndex() throws Exception {
     SortedMap<OSHDBCombinedIndex<OSHDBTimestamp, OSMType>, Integer> result =
         createMapReducerOSMEntitySnapshot()
             .timestamps(timestamps1)
@@ -249,7 +246,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testCombinedWithAggregateByIndexAuto() throws Exception {
+  void testCombinedWithAggregateByIndexAuto() throws Exception {
     SortedMap<OSHDBCombinedIndex<OSHDBTimestamp, OSMType>, List<Long>> result =
         createMapReducerOSMEntitySnapshot()
             .timestamps(timestamps2)
@@ -268,7 +265,7 @@ public class TestMapAggregateByTimestamp {
   }
 
   @Test
-  public void testCombinedWithAggregateByIndexOrder() throws Exception {
+  void testCombinedWithAggregateByIndexOrder() throws Exception {
     SortedMap<OSHDBCombinedIndex<OSMType, OSHDBTimestamp>, List<Long>> resultIndexTime =
         createMapReducerOSMEntitySnapshot()
             .timestamps(timestamps2)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapAggregateByTimestamp.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Map;
@@ -18,7 +19,7 @@ import org.heigit.ohsome.oshdb.util.exceptions.OSHDBInvalidTimestampException;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test aggregate by timestamp method of the OSHDB API.
@@ -179,25 +180,30 @@ public class TestMapAggregateByTimestamp {
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored") // we test for a thrown exception here
-  @Test(expected = OSHDBInvalidTimestampException.class)
+  @Test()
   public void testInvalidUsage() throws Exception {
-    // indexing function returns a timestamp outside the requested time range -> should throw
-    createMapReducerOSMContribution()
-        .timestamps(timestamps2)
-        .groupByEntity()
-        .aggregateByTimestamp(ignored -> timestamps72.get().first())
-        .collect();
+    assertThrows(OSHDBInvalidTimestampException.class, () -> {
+      // indexing function returns a timestamp outside the requested time range -> should throw
+      createMapReducerOSMContribution()
+          .timestamps(timestamps2)
+          .groupByEntity()
+          .aggregateByTimestamp(ignored -> timestamps72.get().first())
+          .collect();
+    });
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored") // we test for a thrown exception here
-  @Test(expected = UnsupportedOperationException.class)
+  @Test()
   public void testUnsupportedUsage() throws Exception {
-    createMapReducerOSMContribution()
-        .timestamps(timestamps72)
-        .groupByEntity()
-        .aggregateByTimestamp()
-        .collect();
+    assertThrows(UnsupportedOperationException.class, () -> {
+      createMapReducerOSMContribution()
+          .timestamps(timestamps72)
+          .groupByEntity()
+          .aggregateByTimestamp()
+          .collect();
+    });
   }
+
 
   @Test
   public void testMapperFunctions() throws Exception {

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
@@ -54,7 +54,7 @@ abstract class TestMapReduce {
   }
 
   @Test
-  public void testOSMContributionView() throws Exception {
+  void testOSMContributionView() throws Exception {
     // simple query
     Set<Integer> result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -89,7 +89,7 @@ abstract class TestMapReduce {
   }
 
   @Test
-  public void testOSMEntitySnapshotView() throws Exception {
+  void testOSMEntitySnapshotView() throws Exception {
     // simple query
     Set<Integer> result = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps6)
@@ -120,7 +120,7 @@ abstract class TestMapReduce {
   }
 
   @Test
-  public void testOSMContributionViewStream() throws Exception {
+  void testOSMContributionViewStream() throws Exception {
     // simple query
     Set<Integer> result = createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -159,7 +159,7 @@ abstract class TestMapReduce {
   }
 
   @Test
-  public void testOSMEntitySnapshotViewStream() throws Exception {
+  void testOSMEntitySnapshotViewStream() throws Exception {
     // simple stream query
     Set<Integer> result = createMapReducerOSMEntitySnapshot()
         .timestamps(timestamps6)
@@ -194,7 +194,7 @@ abstract class TestMapReduce {
   }
 
   @Test
-  public void testTimeoutMapReduce() throws Exception {
+  void testTimeoutMapReduce() throws Exception {
     assertThrows(OSHDBTimeoutException.class, () -> {
       timeoutMapReduce();
     });
@@ -219,7 +219,7 @@ abstract class TestMapReduce {
   }
 
   @Test
-  public void testTimeoutStream() throws Exception {
+  void testTimeoutStream() throws Exception {
     assertThrows(OSHDBTimeoutException.class, () -> {
       timeoutStream();
     });

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
@@ -1,7 +1,8 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 import java.util.Set;
@@ -18,7 +19,7 @@ import org.heigit.ohsome.oshdb.util.function.SerializableFunction;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Base class for testing the map-reducer backend implementations of the OSHDB API.
@@ -194,36 +195,36 @@ abstract class TestMapReduce {
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored") // we only test for thrown exceptions here
-  @Test(expected = OSHDBTimeoutException.class)
+  @Test()
   public void testTimeoutMapReduce() throws Exception {
     // set short timeout -> query should fail
     oshdb.timeoutInMilliseconds(30);
-
-    // simple query with a sleep. would take about ~500ms (1 entity for ~5 timestamp)
-    createMapReducerOSMEntitySnapshot()
-        .timestamps(timestamps6)
-        .osmEntityFilter(entity -> entity.getId() == 617308093)
-        .map(delay(100))
-        .count();
-
-    // reset timeout
-    oshdb.timeoutInMilliseconds(Long.MAX_VALUE);
+    assertThrows(OSHDBTimeoutException.class, () -> {
+      // simple query with a sleep. would take about ~500ms (1 entity for ~5 timestamp)
+      createMapReducerOSMEntitySnapshot()
+          .timestamps(timestamps6)
+          .osmEntityFilter(entity -> entity.getId() == 617308093)
+          .map(delay(100))
+          .count();
+    });
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored") // we only test for thrown exceptions here
-  @Test(expected = OSHDBTimeoutException.class)
+  @Test()
   public void testTimeoutStream() throws Exception {
     // set super short timeout -> all queries should fail
     oshdb.timeoutInMilliseconds(30);
 
-    // simple query
-    createMapReducerOSMEntitySnapshot()
-        .timestamps(timestamps6)
-        .osmEntityFilter(entity -> entity.getId() == 617308093)
-        .map(snapshot -> snapshot.getEntity().getId())
-        .map(delay(100))
-        .stream()
-        .count();
+    assertThrows(OSHDBTimeoutException.class, () -> {
+      // simple query
+      createMapReducerOSMEntitySnapshot()
+          .timestamps(timestamps6)
+          .osmEntityFilter(entity -> entity.getId() == 617308093)
+          .map(snapshot -> snapshot.getEntity().getId())
+          .map(delay(100))
+          .stream()
+          .count();
+    });
 
     // reset timeout
     oshdb.timeoutInMilliseconds(Long.MAX_VALUE);

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBH2Multithread.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBH2Multithread.java
@@ -7,13 +7,13 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
  *
  * <p>Runs the tests using the multithreaded H2 backend.</p>
  */
-public class TestMapReduceOSHDBH2Multithread extends TestMapReduce {
+class TestMapReduceOSHDBH2Multithread extends TestMapReduce {
   /**
    * Creates the test runner using the multithreaded H2 backend.
    *
    * @throws Exception if something goes wrong
    */
-  public TestMapReduceOSHDBH2Multithread() throws Exception {
+  TestMapReduceOSHDBH2Multithread() throws Exception {
     super(
         (new OSHDBH2("./src/test/resources/test-data")).multithreading(true)
     );

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBH2Singlethread.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBH2Singlethread.java
@@ -7,13 +7,13 @@ import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
  *
  * <p>Runs the tests using the singlethreaded H2 backend.</p>
  */
-public class TestMapReduceOSHDBH2Singlethread extends TestMapReduce {
+class TestMapReduceOSHDBH2Singlethread extends TestMapReduce {
   /**
    * Creates the test runner using the singlethreaded "dummy" H2 backend.
    *
    * @throws Exception if something goes wrong
    */
-  public TestMapReduceOSHDBH2Singlethread() throws Exception {
+  TestMapReduceOSHDBH2Singlethread() throws Exception {
     super(
         (new OSHDBH2("./src/test/resources/test-data")).multithreading(false)
     );

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
@@ -1,8 +1,10 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 import org.heigit.ohsome.oshdb.api.db.OSHDBH2;
 import org.heigit.ohsome.oshdb.util.exceptions.OSHDBTableNotFoundException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for proper error messages if tables are not present on H2.
@@ -20,38 +22,46 @@ public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
-  public void testOSMContributionView() throws Exception {
-    super.testOSMContributionView();
+  @Test()
+  public void testOSMContributionView() {
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      super.testOSMContributionView();
+    });
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
-  public void testOSMEntitySnapshotView() throws Exception {
-    super.testOSMEntitySnapshotView();
+  @Test()
+  public void testOSMEntitySnapshotView() {
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      super.testOSMEntitySnapshotView();
+    });
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
-  public void testOSMContributionViewStream() throws Exception {
-    super.testOSMEntitySnapshotView();
+  @Test()
+  public void testOSMContributionViewStream() {
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      super.testOSMEntitySnapshotView();
+    });
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
-  public void testOSMEntitySnapshotViewStream() throws Exception {
-    super.testOSMEntitySnapshotView();
+  @Test()
+  public void testOSMEntitySnapshotViewStream() {
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      super.testOSMEntitySnapshotView();
+    });
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
-  public void testTimeoutMapReduce() throws Exception {
-    super.testTimeoutMapReduce();
+  @Test()
+  public void testTimeoutMapReduce() {
+    // no-op no test for timeout if we got a missing table!
   }
 
   @Override
-  @Test(expected = OSHDBTableNotFoundException.class)
-  public void testTimeoutStream() throws Exception {
-    super.testTimeoutStream();
+  @Test()
+  public void testTimeoutStream() {
+    // no-op no test for timeout if we got a missing table!
   }
 }

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
@@ -41,7 +41,7 @@ class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
   @Test()
   void testOSMContributionViewStream() {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMEntitySnapshotView();
+      super.testOSMContributionViewStream();
     });
   }
 
@@ -49,7 +49,7 @@ class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
   @Test()
   void testOSMEntitySnapshotViewStream() {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMEntitySnapshotView();
+      super.testOSMEntitySnapshotViewStream();
     });
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
@@ -55,13 +55,17 @@ public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
 
   @Override
   @Test()
-  public void testTimeoutMapReduce() {
-    // no-op no test for timeout if we got a missing table!
+  public void testTimeoutMapReduce() throws Exception {
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      timeoutMapReduce();
+    });
   }
 
   @Override
   @Test()
   public void testTimeoutStream() {
-    // no-op no test for timeout if we got a missing table!
+    assertThrows(OSHDBTableNotFoundException.class, () -> {
+      timeoutStream();
+    });
   }
 }

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for proper error messages if tables are not present on H2.
  */
-public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
+class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
   /**
    * Creates the test runner using an H2 backend.
    *
    * @throws Exception if something goes wrong
    */
-  public TestMapReduceOSHDBJdbcMissingTables() throws Exception {
+  TestMapReduceOSHDBJdbcMissingTables() throws Exception {
     super((new OSHDBH2("./src/test/resources/test-data"))
         .prefix("<test tables not present>")
     );

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
@@ -23,7 +23,7 @@ public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
 
   @Override
   @Test()
-  public void testOSMContributionView() {
+  void testOSMContributionView() {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       super.testOSMContributionView();
     });
@@ -31,7 +31,7 @@ public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
 
   @Override
   @Test()
-  public void testOSMEntitySnapshotView() {
+  void testOSMEntitySnapshotView() {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       super.testOSMEntitySnapshotView();
     });
@@ -39,7 +39,7 @@ public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
 
   @Override
   @Test()
-  public void testOSMContributionViewStream() {
+  void testOSMContributionViewStream() {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       super.testOSMEntitySnapshotView();
     });
@@ -47,7 +47,7 @@ public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
 
   @Override
   @Test()
-  public void testOSMEntitySnapshotViewStream() {
+  void testOSMEntitySnapshotViewStream() {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       super.testOSMEntitySnapshotView();
     });
@@ -55,7 +55,7 @@ public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
 
   @Override
   @Test()
-  public void testTimeoutMapReduce() throws Exception {
+  void testTimeoutMapReduce() throws Exception {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       timeoutMapReduce();
     });
@@ -63,7 +63,7 @@ public class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
 
   @Override
   @Test()
-  public void testTimeoutStream() {
+  void testTimeoutStream() {
     assertThrows(OSHDBTableNotFoundException.class, () -> {
       timeoutStream();
     });

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
@@ -39,7 +39,7 @@ class TestOSHDBFilter {
    *
    * @throws Exception if something goes wrong.
    */
-  public TestOSHDBFilter() throws Exception {
+  TestOSHDBFilter() throws Exception {
     OSHDBH2 oshdb = new OSHDBH2("./src/test/resources/test-data");
     filterParser = new FilterParser(new TagTranslator(oshdb.getConnection()));
     this.oshdb = oshdb;

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
  *   of unit tests.
  * </p>
  */
-public class TestOSHDBFilter {
+class TestOSHDBFilter {
   private final OSHDBJdbc oshdb;
   private final FilterParser filterParser;
 
@@ -58,7 +58,7 @@ public class TestOSHDBFilter {
   }
 
   @Test
-  public void testFilterString() throws Exception {
+  void testFilterString() throws Exception {
     Number result = createMapReducerOSMEntitySnapshot()
         .map(x -> 1)
         .filter("type:way and geometry:polygon and building=*")
@@ -75,7 +75,7 @@ public class TestOSHDBFilter {
   }
 
   @Test
-  public void testFilterObject() throws Exception {
+  void testFilterObject() throws Exception {
     Number result = createMapReducerOSMEntitySnapshot()
         .filter(filterParser.parse("type:way and geometry:polygon and building=*"))
         .count();
@@ -84,7 +84,7 @@ public class TestOSHDBFilter {
   }
 
   @Test
-  public void testAggregateFilter() throws Exception {
+  void testAggregateFilter() throws Exception {
     SortedMap<OSMType, Integer> result = createMapReducerOSMEntitySnapshot()
         .aggregateBy(x -> x.getEntity().getType())
         .filter("(geometry:polygon or geometry:other) and building=*")
@@ -96,7 +96,7 @@ public class TestOSHDBFilter {
   }
 
   @Test
-  public void testAggregateFilterObject() throws Exception {
+  void testAggregateFilterObject() throws Exception {
     SortedMap<OSMType, Integer> result = createMapReducerOSMEntitySnapshot()
         .aggregateBy(x -> x.getEntity().getType())
         .filter(filterParser.parse("(geometry:polygon or geometry:other) and building=*"))
@@ -106,7 +106,7 @@ public class TestOSHDBFilter {
   }
 
   @Test
-  public void testFilterGroupByEntity() throws Exception {
+  void testFilterGroupByEntity() throws Exception {
     MapReducer<?> mr = createMapReducerOSMEntitySnapshot();
     Number osmTypeFilterResult = mr.groupByEntity().osmType(OSMType.WAY).count();
     Number stringFilterResult = mr.groupByEntity().filter("type:way").count();
@@ -122,7 +122,7 @@ public class TestOSHDBFilter {
 
   @Test
   @SuppressWarnings("ResultOfMethodCallIgnored")
-  public void testFilterNonExistentTag() throws Exception {
+  void testFilterNonExistentTag() throws Exception {
     FilterParser parser = new FilterParser(new TagTranslator(oshdb.getConnection()));
     try {
       createMapReducerOSMEntitySnapshot()
@@ -137,7 +137,7 @@ public class TestOSHDBFilter {
   }
 
   @Test
-  public void testFilterNotCrashDuringNormalize() throws Exception {
+  void testFilterNotCrashDuringNormalize() throws Exception {
     var mr = createMapReducerOSMContribution();
     mr = mr.filter(new FilterExpression() {
       @Override

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSHDBFilter.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.SortedMap;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
@@ -17,7 +17,7 @@ import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.tagtranslator.TagTranslator;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests integration of oshdb-filter library.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMContributionGetContributorUserId.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMContributionGetContributorUserId.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,7 +21,7 @@ import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateAllEntry;
 import org.heigit.ohsome.oshdb.util.celliterator.ContributionType;
 import org.heigit.ohsome.oshdb.util.celliterator.LazyEvaluatedContributionTypes;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the get contributor user id method of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMContributionGetContributorUserId.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMContributionGetContributorUserId.java
@@ -26,8 +26,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the get contributor user id method of the OSHDB API.
  */
-@SuppressWarnings("javadoc")
-public class TestOSMContributionGetContributorUserId {
+class TestOSMContributionGetContributorUserId {
   public TestOSMContributionGetContributorUserId() throws Exception {
   }
 
@@ -36,7 +35,7 @@ public class TestOSMContributionGetContributorUserId {
   ));
 
   @Test
-  public void node() throws Exception {
+  void node() throws Exception {
     // timestamp match
     OSMContribution c = new OSMContributionImpl(new IterateAllEntry(
         new OSHDBTimestamp(123),
@@ -92,7 +91,7 @@ public class TestOSMContributionGetContributorUserId {
   }
 
   @Test
-  public void wayDirect() throws Exception {
+  void wayDirect() throws Exception {
     OSMContribution c = new OSMContributionImpl(new IterateAllEntry(
         new OSHDBTimestamp(123),
         OSM.way(1L, 1, 123L, 1L, 7, new int[] {}, new OSMMember[] {}), null,
@@ -105,7 +104,7 @@ public class TestOSMContributionGetContributorUserId {
   }
 
   @Test
-  public void wayIndirect() throws Exception {
+  void wayIndirect() throws Exception {
     List<OSMNode> versions = new ArrayList<>();
     versions.add(OSM.node(3L, 3, 125L, 4L, 8, new int[] {}, 0, 0));
     versions.add(OSM.node(3L, 2, 123L, 3L, 7, new int[] {}, 0, 0));
@@ -127,7 +126,7 @@ public class TestOSMContributionGetContributorUserId {
   }
 
   @Test
-  public void relationDirect() throws Exception {
+  void relationDirect() throws Exception {
     OSMContribution c = new OSMContributionImpl(new IterateAllEntry(
         new OSHDBTimestamp(123),
         OSM.relation(1L, 1, 123L, 1L, 7, new int[] {}, new OSMMember[] {}),
@@ -141,7 +140,7 @@ public class TestOSMContributionGetContributorUserId {
   }
 
   @Test
-  public void relationIndirectWay() throws Exception {
+  void relationIndirectWay() throws Exception {
     List<OSMWay> versions = new ArrayList<>();
     versions.add(
         OSM.way(3L, 3, 125L, 4L, 8, new int[] {}, new OSMMember[] {})
@@ -169,7 +168,7 @@ public class TestOSMContributionGetContributorUserId {
   }
 
   @Test
-  public void relationIndirectWayNode() throws Exception {
+  void relationIndirectWayNode() throws Exception {
     List<OSMNode> nodeVersions = new ArrayList<>();
     nodeVersions.add(OSM.node(3L, 3, 125L, 4L, 8, new int[] {}, 0, 0));
     nodeVersions.add(OSM.node(3L, 2, 123L, 3L, 7, new int[] {}, 0, 0));

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMContributionGetContributorUserId.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMContributionGetContributorUserId.java
@@ -27,8 +27,7 @@ import org.junit.jupiter.api.Test;
  * Tests the get contributor user id method of the OSHDB API.
  */
 class TestOSMContributionGetContributorUserId {
-  public TestOSMContributionGetContributorUserId() throws Exception {
-  }
+  TestOSMContributionGetContributorUserId() throws Exception {}
 
   private final OSHEntity dummyOshEntity = OSHNodeImpl.build(Collections.singletonList(
       OSM.node(-1L, 1, 0L, 1L, 1, new int[]{}, 0, 0)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
@@ -30,7 +30,7 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests osm data filters.
  */
-public class TestOSMDataFilters {
+class TestOSMDataFilters {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
@@ -49,7 +49,7 @@ public class TestOSMDataFilters {
   // filter: osm type
 
   @Test
-  public void bbox() throws Exception {
+  void bbox() throws Exception {
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmType(OSMType.NODE)
         .areaOfInterest(bbox)
@@ -59,7 +59,7 @@ public class TestOSMDataFilters {
   }
 
   @Test
-  public void polygon() throws Exception {
+  void polygon() throws Exception {
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmType(OSMType.NODE)
         .areaOfInterest(OSHDBGeometryBuilder.getGeometry(bbox))
@@ -69,7 +69,7 @@ public class TestOSMDataFilters {
   }
 
   @Test
-  public void multiPolygon() throws Exception {
+  void multiPolygon() throws Exception {
     GeometryFactory gf = new GeometryFactory();
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmType(OSMType.NODE)
@@ -82,7 +82,7 @@ public class TestOSMDataFilters {
   }
 
   @Test
-  public void types() throws Exception {
+  void types() throws Exception {
     Set<OSMType> result;
     // single type
     result = createMapReducerOSMEntitySnapshot()
@@ -130,7 +130,7 @@ public class TestOSMDataFilters {
   // filter: osm tags
 
   @Test
-  public void tagKey() throws Exception {
+  void tagKey() throws Exception {
     SortedMap<OSMType, Integer> result = createMapReducerOSMEntitySnapshot()
         .osmTag("building")
         .areaOfInterest(bbox)
@@ -142,7 +142,7 @@ public class TestOSMDataFilters {
   }
 
   @Test
-  public void tagKeyValue() throws Exception {
+  void tagKeyValue() throws Exception {
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmTag("highway", "residential")
         .osmType(OSMType.WAY)
@@ -153,7 +153,7 @@ public class TestOSMDataFilters {
   }
 
   @Test
-  public void tagKeyValues() throws Exception {
+  void tagKeyValues() throws Exception {
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmTag("highway", Arrays.asList("residential", "unclassified"))
         .osmType(OSMType.WAY)
@@ -164,7 +164,7 @@ public class TestOSMDataFilters {
   }
 
   @Test
-  public void tagKeyValueRegexp() throws Exception {
+  void tagKeyValueRegexp() throws Exception {
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmTag("highway", Pattern.compile("residential|unclassified"))
         .osmType(OSMType.WAY)
@@ -175,7 +175,7 @@ public class TestOSMDataFilters {
   }
 
   @Test
-  public void tagList() throws Exception {
+  void tagList() throws Exception {
     // only tags
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmTag(Arrays.asList(
@@ -202,7 +202,7 @@ public class TestOSMDataFilters {
   }
 
   @Test
-  public void tagMultiple() throws Exception {
+  void tagMultiple() throws Exception {
     Set<Integer> result = createMapReducerOSMEntitySnapshot()
         .osmTag("name")
         .osmTag("highway")
@@ -224,7 +224,7 @@ public class TestOSMDataFilters {
 
 
   @Test
-  public void tagNotExists() throws Exception {
+  void tagNotExists() throws Exception {
     Integer result = createMapReducerOSMEntitySnapshot()
         .osmTag("buildingsss")
         .areaOfInterest(bbox)
@@ -250,7 +250,7 @@ public class TestOSMDataFilters {
   // custom filter
 
   @Test
-  public void custom() throws Exception {
+  void custom() throws Exception {
     Set<Integer> result = createMapReducerOSMEntitySnapshot()
         .osmEntityFilter(entity -> entity.getVersion() > 2)
         .osmType(OSMType.WAY)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
@@ -37,7 +37,7 @@ class TestOSMDataFilters {
       OSHDBBoundingBox.bboxWgs84Coordinates(8.651133, 49.387611, 8.6561, 49.390513);
   private final OSHDBTimestamps timestamps1 = new OSHDBTimestamps("2014-01-01");
 
-  public TestOSMDataFilters() throws Exception {
+  TestOSMDataFilters() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestOSMDataFilters.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Comparator;
@@ -23,7 +23,7 @@ import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.tagtranslator.OSMTag;
 import org.heigit.ohsome.oshdb.util.tagtranslator.OSMTagKey;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -17,7 +17,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.OSMEntitySnapshotView;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the quantiles reducer of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the quantiles reducer of the OSHDB API.
  */
-public class TestQuantiles {
+class TestQuantiles {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
@@ -63,7 +63,7 @@ public class TestQuantiles {
   }
 
   @Test
-  public void testMedian() throws Exception {
+  void testMedian() throws Exception {
     MapReducer<Integer> mr = this.createMapReducer()
         .map(s -> s.getGeometry().getCoordinates().length);
     List<Integer> fullResult = mr.collect();
@@ -73,7 +73,7 @@ public class TestQuantiles {
   }
 
   @Test
-  public void testQuantile() throws Exception {
+  void testQuantile() throws Exception {
     MapReducer<Integer> mr = this.createMapReducer()
         .map(s -> s.getGeometry().getCoordinates().length);
     List<Integer> fullResult = mr.collect();
@@ -83,7 +83,7 @@ public class TestQuantiles {
   }
 
   @Test
-  public void testQuantiles() throws Exception {
+  void testQuantiles() throws Exception {
     MapReducer<Integer> mr = this.createMapReducer()
         .map(s -> s.getGeometry().getCoordinates().length);
     List<Integer> fullResult = mr.collect();
@@ -98,7 +98,7 @@ public class TestQuantiles {
   }
 
   @Test
-  public void testQuantilesFunction() throws Exception {
+  void testQuantilesFunction() throws Exception {
     MapReducer<Integer> mr = this.createMapReducer()
         .map(s -> s.getGeometry().getCoordinates().length);
     List<Integer> fullResult = mr.collect();
@@ -124,7 +124,7 @@ public class TestQuantiles {
   }
 
   @Test
-  public void testMedianMapAggregator() throws Exception {
+  void testMedianMapAggregator() throws Exception {
     MapAggregator<OSHDBTimestamp, Integer> mr = this.createMapAggregator()
         .map(s -> s.getGeometry().getCoordinates().length);
     SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
@@ -138,7 +138,7 @@ public class TestQuantiles {
   }
 
   @Test
-  public void testQuantileMapAggregator() throws Exception {
+  void testQuantileMapAggregator() throws Exception {
     MapAggregator<OSHDBTimestamp, Integer> mr = this.createMapAggregator()
         .map(s -> s.getGeometry().getCoordinates().length);
     SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
@@ -152,7 +152,7 @@ public class TestQuantiles {
   }
 
   @Test
-  public void testQuantilesMapAggregator() throws Exception {
+  void testQuantilesMapAggregator() throws Exception {
     MapAggregator<OSHDBTimestamp, Integer> mr = this.createMapAggregator()
         .map(s -> s.getGeometry().getCoordinates().length);
     SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();
@@ -173,7 +173,7 @@ public class TestQuantiles {
   }
 
   @Test
-  public void testQuantilesFunctionMapAggregator() throws Exception {
+  void testQuantilesFunctionMapAggregator() throws Exception {
     MapAggregator<OSHDBTimestamp, Integer> mr = this.createMapAggregator()
         .map(s -> s.getGeometry().getCoordinates().length);
     SortedMap<OSHDBTimestamp, List<Integer>> fullResult = mr.collect();

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestQuantiles.java
@@ -32,7 +32,7 @@ class TestQuantiles {
 
   private static final double REQUIRED_ACCURACY = 1E-4;
 
-  public TestQuantiles() throws Exception {
+  TestQuantiles() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data");
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the stream method of the OSHDB API.
  */
-public class TestStream {
+class TestStream {
   private final OSHDBDatabase oshdb;
 
   private final OSHDBBoundingBox bbox =
@@ -37,7 +37,7 @@ public class TestStream {
   }
 
   @Test
-  public void testForEach() throws Exception {
+  void testForEach() throws Exception {
     ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
     this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -49,7 +49,7 @@ public class TestStream {
   }
 
   @Test
-  public void testForEachGroupedById() throws Exception {
+  void testForEachGroupedById() throws Exception {
     ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
     this.createMapReducerOSMContribution()
         .timestamps(timestamps72)
@@ -61,7 +61,7 @@ public class TestStream {
   }
 
   @Test
-  public void testForEachAggregatedByTimestamp() throws Exception {
+  void testForEachAggregatedByTimestamp() throws Exception {
     ConcurrentHashMap<Long, Boolean> result = new ConcurrentHashMap<>();
     this.createMapReducerOSMContribution()
         .timestamps(timestamps72)

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.concurrent.ConcurrentHashMap;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
@@ -11,7 +11,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.OSMContributionView;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the stream method of the OSHDB API.

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestStream.java
@@ -24,7 +24,7 @@ class TestStream {
   private final OSHDBTimestamps timestamps72 = new OSHDBTimestamps("2010-01-01", "2015-12-01",
       OSHDBTimestamps.Interval.MONTHLY);
 
-  public TestStream() throws Exception {
+  TestStream() throws Exception {
     oshdb = new OSHDBH2("./src/test/resources/test-data").multithreading(false);
   }
 

--- a/oshdb-filter/pom.xml
+++ b/oshdb-filter/pom.xml
@@ -46,9 +46,9 @@
 
     <!-- junit unit test framework -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
+        <groupId>org.junit.jupiter</groupId>
+        <artifactId>junit-jupiter</artifactId>
+        <scope>test</scope>
     </dependency>
 
     <!-- H2 database (for tests) -->

--- a/oshdb-filter/pom.xml
+++ b/oshdb-filter/pom.xml
@@ -44,13 +44,6 @@
       <version>${jetbrainsannotations.version}</version>
     </dependency>
 
-    <!-- junit unit test framework -->
-    <dependency>
-        <groupId>org.junit.jupiter</groupId>
-        <artifactId>junit-jupiter</artifactId>
-        <scope>test</scope>
-    </dependency>
-
     <!-- H2 database (for tests) -->
     <dependency>
       <groupId>com.h2database</groupId>

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSHTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSHTest.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the application of filters to OSH entities.
  */
-public class ApplyOSHTest extends FilterTest {
+class ApplyOSHTest extends FilterTest {
 
   @Test
-  public void testTagFilterEquals() throws IOException {
+  void testTagFilterEquals() throws IOException {
     FilterExpression expression = parser.parse("highway=residential");
     // matching tag (exact match)
     assertTrue(expression.applyOSH(createTestOSHEntityNode(
@@ -38,7 +38,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterEqualsAny() throws IOException {
+  void testTagFilterEqualsAny() throws IOException {
     FilterExpression expression = parser.parse("highway=*");
     // matching tag
     assertTrue(expression.applyOSH(createTestOSHEntityNode(
@@ -56,7 +56,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEquals() throws IOException {
+  void testTagFilterNotEquals() throws IOException {
     FilterExpression expression = parser.parse("highway!=residential");
     // matching tag
     assertFalse(expression.applyOSH(createTestOSHEntityNode(
@@ -74,7 +74,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEqualsAny() throws IOException {
+  void testTagFilterNotEqualsAny() throws IOException {
     FilterExpression expression = parser.parse("highway!=*");
     // matching tag
     assertFalse(expression.applyOSH(createTestOSHEntityNode(
@@ -92,7 +92,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterEqualsAnyOf() throws IOException {
+  void testTagFilterEqualsAnyOf() throws IOException {
     FilterExpression expression = parser.parse("highway in (residential, track)");
     // matching tag
     assertTrue(expression.applyOSH(createTestOSHEntityNode(
@@ -119,7 +119,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterEquals() throws IOException {
+  void testIdFilterEquals() throws IOException {
     assertTrue(parser.parse("id:1").applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode())));
     assertFalse(parser.parse("id:2").applyOSH(createTestOSHEntityNode(
@@ -127,7 +127,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterNotEquals() throws IOException {
+  void testIdFilterNotEquals() throws IOException {
     assertFalse(parser.parse("id:1").negate().applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode())));
     assertTrue(parser.parse("id:2").negate().applyOSH(createTestOSHEntityNode(
@@ -135,7 +135,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterEqualsAnyOf() throws IOException {
+  void testIdFilterEqualsAnyOf() throws IOException {
     assertTrue(parser.parse("id:(1,2,3)").applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode())));
     assertFalse(parser.parse("id:(2,3)").applyOSH(createTestOSHEntityNode(
@@ -143,7 +143,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterNotEqualsAnyOf() throws IOException {
+  void testIdFilterNotEqualsAnyOf() throws IOException {
     assertFalse(parser.parse("id:(1,2,3)").negate().applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode())));
     assertTrue(parser.parse("id:(2,3)").negate().applyOSH(createTestOSHEntityNode(
@@ -151,7 +151,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterInRange() throws IOException {
+  void testIdFilterInRange() throws IOException {
     assertTrue(parser.parse("id:(1..3)").applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode())));
     assertFalse(parser.parse("id:(2..3)").applyOSH(createTestOSHEntityNode(
@@ -167,7 +167,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterNotInRange() throws IOException {
+  void testIdFilterNotInRange() throws IOException {
     assertFalse(parser.parse("id:(1..3)").negate().applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode())));
     assertTrue(parser.parse("id:(2..3)").negate().applyOSH(createTestOSHEntityNode(
@@ -183,7 +183,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testTypeFilter() throws IOException {
+  void testTypeFilter() throws IOException {
     assertTrue(parser.parse("type:node").applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode()
     )));
@@ -193,7 +193,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testAndOperator() throws IOException {
+  void testAndOperator() throws IOException {
     FilterExpression expression = parser.parse("highway=* and name=*");
     // exact match
     assertTrue(expression.applyOSH(createTestOSHEntityNode(
@@ -238,7 +238,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testOrOperator() throws IOException {
+  void testOrOperator() throws IOException {
     FilterExpression expression = parser.parse("highway=* or name=*");
     // exact match
     assertTrue(expression.applyOSH(createTestOSHEntityNode(
@@ -258,7 +258,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterPoint() throws IOException {
+  void testGeometryTypeFilterPoint() throws IOException {
     FilterExpression expression = parser.parse("geometry:point");
     assertTrue(expression.applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode()
@@ -272,7 +272,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterLine() throws IOException {
+  void testGeometryTypeFilterLine() throws IOException {
     FilterExpression expression = parser.parse("geometry:line");
     assertTrue(expression.applyOSH(createTestOSHEntityWay(
         createTestOSMEntityWay(new long[] {})
@@ -289,7 +289,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterPolygon() throws IOException {
+  void testGeometryTypeFilterPolygon() throws IOException {
     FilterExpression expression = parser.parse("geometry:polygon");
     assertTrue(expression.applyOSH(createTestOSHEntityWay(
         createTestOSMEntityWay(new long[] {1, 2, 3, 4, 1})
@@ -303,7 +303,7 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterOther() throws IOException {
+  void testGeometryTypeFilterOther() throws IOException {
     FilterExpression expression = parser.parse("geometry:other");
     assertFalse(expression.applyOSH(createTestOSHEntityNode(
         createTestOSMEntityNode()
@@ -317,19 +317,19 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testConstant() throws IOException {
+  void testConstant() throws IOException {
     FilterExpression expression = parser.parse("");
     assertTrue(expression.applyOSH(createTestOSHEntityNode(createTestOSMEntityNode())));
   }
 
   @Test
-  public void testGeometryFilterArea() throws IOException {
+  void testGeometryFilterArea() throws IOException {
     FilterExpression expression = parser.parse("area:(1..2)");
     assertTrue(expression.applyOSH(createTestOSHEntityWay(createTestOSMEntityWay(new long[] {}))));
   }
 
   @Test
-  public void testGeometryFilterLength() throws IOException {
+  void testGeometryFilterLength() throws IOException {
     FilterExpression expression = parser.parse("length:(1..2)");
     assertTrue(expression.applyOSH(createTestOSHEntityWay(createTestOSMEntityWay(new long[] {}))));
   }
@@ -378,34 +378,34 @@ public class ApplyOSHTest extends FilterTest {
   }
 
   @Test
-  public void testChangesetId() throws IOException {
+  void testChangesetId() throws IOException {
     testOSHEntityWithMetadata(parser.parse("changeset:42"));
   }
 
   @Test
-  public void testChangesetIdList() throws IOException {
+  void testChangesetIdList() throws IOException {
     testOSHEntityWithMetadata(parser.parse("changeset:(41,42,43)"));
   }
 
   @Test
-  public void testChangesetIdRange() throws IOException {
+  void testChangesetIdRange() throws IOException {
     testOSHEntityWithMetadata(parser.parse("changeset:(41..43)"));
   }
 
   @Test
-  public void testContributorUserId() throws IOException {
+  void testContributorUserId() throws IOException {
     var parser = new FilterParser(tagTranslator, true);
     testOSHEntityWithMetadata(parser.parse("contributor:4"));
   }
 
   @Test
-  public void testContributorUserIdList() throws IOException {
+  void testContributorUserIdList() throws IOException {
     var parser = new FilterParser(tagTranslator, true);
     testOSHEntityWithMetadata(parser.parse("contributor:(3,4,5)"));
   }
 
   @Test
-  public void testContributorUserIdRange() throws IOException {
+  void testContributorUserIdRange() throws IOException {
     var parser = new FilterParser(tagTranslator, true);
     testOSHEntityWithMetadata(parser.parse("contributor:(3..5)"));
   }

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSHTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSHTest.java
@@ -1,14 +1,14 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import org.heigit.ohsome.oshdb.osh.OSHNode;
 import org.heigit.ohsome.oshdb.osh.OSHWay;
 import org.heigit.ohsome.oshdb.osm.OSMRelation;
 import org.heigit.ohsome.oshdb.osm.OSMWay;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the application of filters to OSH entities.

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMContributionTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMContributionTest.java
@@ -35,7 +35,7 @@ class ApplyOSMContributionTest extends FilterTest {
     private final int contributorUserId;
     private final Set<ContributionType> contributionTypes;
 
-    public TestOSMContribution(
+    TestOSMContribution(
         OSMEntity entityBefore, Geometry geometryBefore,
         OSMEntity entityAfter, Geometry geometryAfter,
         long changesetId, int contributorUserId, Set<ContributionType> contributionTypes) {

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMContributionTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMContributionTest.java
@@ -18,7 +18,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 /**
  * Tests the parsing of filters and the application to OSM entity snapshots.
  */
-public class ApplyOSMContributionTest extends FilterTest {
+class ApplyOSMContributionTest extends FilterTest {
   private final GeometryFactory gf = new GeometryFactory();
   private final Geometry point = gf.createPoint();
   private final Geometry line = gf.createLineString();
@@ -115,7 +115,7 @@ public class ApplyOSMContributionTest extends FilterTest {
   }
 
   @Test
-  public void testBasicFallback() {
+  void testBasicFallback() {
     FilterExpression expression = parser.parse("geometry:point");
     // expect true if either the "before" state …
     assertTrue(expression.applyOSMContribution(new TestOSMContribution(
@@ -132,7 +132,7 @@ public class ApplyOSMContributionTest extends FilterTest {
   }
 
   @Test
-  public void testNegatableFilter() {
+  void testNegatableFilter() {
     FilterExpression expression = parser.parse("id:(1,2)");
     var testObject = new TestOSMContribution(
         entity, point, entity, point, 1L, 2, NO_TYPE
@@ -151,46 +151,46 @@ public class ApplyOSMContributionTest extends FilterTest {
   }
 
   @Test
-  public void testChangesetId() {
+  void testChangesetId() {
     testContribution(parser.parse("changeset:42"));
   }
 
   @Test
-  public void testChangesetIdList() {
+  void testChangesetIdList() {
     testContribution(parser.parse("changeset:(41,42,43)"));
   }
 
   @Test
-  public void testChangesetIdRange() {
+  void testChangesetIdRange() {
     testContribution(parser.parse("changeset:(41..43)"));
   }
 
   @Test
-  public void testContributorUserId() {
+  void testContributorUserId() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     testContribution(parser.parse("contributor:1"));
   }
 
   @Test
-  public void testContributorUserIdList() {
+  void testContributorUserIdList() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     testContribution(parser.parse("contributor:(1,2,3)"));
   }
 
   @Test
-  public void testContributorUserIdRange() {
+  void testContributorUserIdRange() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     testContribution(parser.parse("contributor:(1..2)"));
   }
 
   @Test
-  public void testAndOperator() {
+  void testAndOperator() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     testContribution(parser.parse("contributor:1 and type:node"));
   }
 
   @Test
-  public void testOrOperator() {
+  void testOrOperator() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     testContribution(parser.parse("contributor:1 or foo=doesntexist"));
   }

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMContributionTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMContributionTest.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -11,7 +11,7 @@ import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.celliterator.ContributionType;
 import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
@@ -1,15 +1,16 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osh.OSHEntity;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.jetbrains.annotations.NotNull;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
 
@@ -86,48 +87,64 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
     fail();
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testChangesetId() {
-    testFailWithSnapshot(parser.parse("changeset:42"));
+    assertThrows(IllegalStateException.class, () -> {
+      testFailWithSnapshot(parser.parse("changeset:42"));
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testChangesetIdList() {
-    testFailWithSnapshot(parser.parse("changeset:(41,42,43)"));
+    assertThrows(IllegalStateException.class, () -> {
+      testFailWithSnapshot(parser.parse("changeset:(41,42,43)"));
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testChangesetIdRange() {
-    testFailWithSnapshot(parser.parse("changeset:(41..43)"));
+    assertThrows(IllegalStateException.class, () -> {
+      testFailWithSnapshot(parser.parse("changeset:(41..43)"));
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testContributorUserId() {
     FilterParser parser = new FilterParser(tagTranslator, true);
-    testFailWithSnapshot(parser.parse("contributor:1"));
+    assertThrows(IllegalStateException.class, () -> {
+      testFailWithSnapshot(parser.parse("contributor:1"));
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testContributorUserIdList() {
     FilterParser parser = new FilterParser(tagTranslator, true);
-    testFailWithSnapshot(parser.parse("contributor:(1,2,3)"));
+    assertThrows(IllegalStateException.class, () -> {
+      testFailWithSnapshot(parser.parse("contributor:(1,2,3)"));
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testContributorUserIdRange() {
     FilterParser parser = new FilterParser(tagTranslator, true);
-    testFailWithSnapshot(parser.parse("contributor:(1..3)"));
+    assertThrows(IllegalStateException.class, () -> {
+      testFailWithSnapshot(parser.parse("contributor:(1..3)"));
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testAndOperator() {
     FilterParser parser = new FilterParser(tagTranslator, true);
-    testFailWithSnapshot(parser.parse("contributor:1 and type:node"));
+    assertThrows(IllegalStateException.class, () -> {
+      testFailWithSnapshot(parser.parse("contributor:1 and type:node"));
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testOrOperator() {
     FilterParser parser = new FilterParser(tagTranslator, true);
-    testFailWithSnapshot(parser.parse("contributor:1 or foo=doesntexist"));
+    assertThrows(IllegalStateException.class, () -> {
+      testFailWithSnapshot(parser.parse("contributor:1 or foo=doesntexist"));
+    });
   }
 }

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
@@ -17,7 +17,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 /**
  * Tests the parsing of filters and the application to OSM entity snapshots.
  */
-public class ApplyOSMEntitySnapshotTest extends FilterTest {
+class ApplyOSMEntitySnapshotTest extends FilterTest {
   private final GeometryFactory gf = new GeometryFactory();
 
   private static class TestOSMEntitySnapshot implements OSMEntitySnapshot {
@@ -62,7 +62,7 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
   }
 
   @Test
-  public void testBasicFallback() {
+  void testBasicFallback() {
     FilterExpression expression = parser.parse("geometry:point");
     assertTrue(expression.applyOSMEntitySnapshot(new TestOSMEntitySnapshot(
         createTestOSMEntityNode(), gf.createPoint())));
@@ -73,7 +73,7 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
   }
 
   @Test
-  public void testNegatableFilter() {
+  void testNegatableFilter() {
     FilterExpression expression = parser.parse("id:(1,2)");
     var testObject = new TestOSMEntitySnapshot(createTestOSMEntityNode(), gf.createPoint());
     assertTrue(expression.applyOSMEntitySnapshot(testObject));
@@ -88,28 +88,28 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
   }
 
   @Test()
-  public void testChangesetId() {
+  void testChangesetId() {
     assertThrows(IllegalStateException.class, () -> {
       testFailWithSnapshot(parser.parse("changeset:42"));
     });
   }
 
   @Test()
-  public void testChangesetIdList() {
+  void testChangesetIdList() {
     assertThrows(IllegalStateException.class, () -> {
       testFailWithSnapshot(parser.parse("changeset:(41,42,43)"));
     });
   }
 
   @Test()
-  public void testChangesetIdRange() {
+  void testChangesetIdRange() {
     assertThrows(IllegalStateException.class, () -> {
       testFailWithSnapshot(parser.parse("changeset:(41..43)"));
     });
   }
 
   @Test()
-  public void testContributorUserId() {
+  void testContributorUserId() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     assertThrows(IllegalStateException.class, () -> {
       testFailWithSnapshot(parser.parse("contributor:1"));
@@ -117,7 +117,7 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
   }
 
   @Test()
-  public void testContributorUserIdList() {
+  void testContributorUserIdList() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     assertThrows(IllegalStateException.class, () -> {
       testFailWithSnapshot(parser.parse("contributor:(1,2,3)"));
@@ -125,7 +125,7 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
   }
 
   @Test()
-  public void testContributorUserIdRange() {
+  void testContributorUserIdRange() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     assertThrows(IllegalStateException.class, () -> {
       testFailWithSnapshot(parser.parse("contributor:(1..3)"));
@@ -133,7 +133,7 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
   }
 
   @Test()
-  public void testAndOperator() {
+  void testAndOperator() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     assertThrows(IllegalStateException.class, () -> {
       testFailWithSnapshot(parser.parse("contributor:1 and type:node"));
@@ -141,7 +141,7 @@ public class ApplyOSMEntitySnapshotTest extends FilterTest {
   }
 
   @Test()
-  public void testOrOperator() {
+  void testOrOperator() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     assertThrows(IllegalStateException.class, () -> {
       testFailWithSnapshot(parser.parse("contributor:1 or foo=doesntexist"));

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
@@ -25,7 +25,7 @@ class ApplyOSMEntitySnapshotTest extends FilterTest {
     private final OSMEntity entity;
     private final Geometry geometry;
 
-    public TestOSMEntitySnapshot(OSMEntity entity, Geometry geometry) {
+    TestOSMEntitySnapshot(OSMEntity entity, Geometry geometry) {
       this.entity = entity;
       this.geometry = geometry;
     }

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
@@ -1,12 +1,12 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMGeometryTest.java
@@ -13,11 +13,11 @@ import org.locationtech.jts.geom.GeometryFactory;
 /**
  * Tests the application of filters to OSM geometries.
  */
-public class ApplyOSMGeometryTest extends FilterTest {
+class ApplyOSMGeometryTest extends FilterTest {
   private final GeometryFactory gf = new GeometryFactory();
 
   @Test
-  public void testGeometryTypeFilterPoint() {
+  void testGeometryTypeFilterPoint() {
     FilterExpression expression = parser.parse("geometry:point");
     assertTrue(expression.applyOSMGeometry(createTestOSMEntityNode(), gf.createPoint()));
     // negated
@@ -25,7 +25,7 @@ public class ApplyOSMGeometryTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterLine() {
+  void testGeometryTypeFilterLine() {
     FilterExpression expression = parser.parse("geometry:line");
     OSMEntity validWay = createTestOSMEntityWay(new long[]{1, 2, 3, 4, 1});
     assertTrue(expression.applyOSMGeometry(validWay, gf.createLineString()));
@@ -33,7 +33,7 @@ public class ApplyOSMGeometryTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterPolygon() {
+  void testGeometryTypeFilterPolygon() {
     FilterExpression expression = parser.parse("geometry:polygon");
     OSMEntity validWay = createTestOSMEntityWay(new long[]{1, 2, 3, 4, 1});
     assertTrue(expression.applyOSMGeometry(validWay, gf.createPolygon()));
@@ -47,7 +47,7 @@ public class ApplyOSMGeometryTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterOther() {
+  void testGeometryTypeFilterOther() {
     FilterExpression expression = parser.parse("geometry:other");
     OSMEntity validRelation = createTestOSMEntityRelation();
     assertTrue(expression.applyOSMGeometry(validRelation, gf.createGeometryCollection()));
@@ -66,7 +66,7 @@ public class ApplyOSMGeometryTest extends FilterTest {
   }
 
   @Test
-  public void testAndOperator() {
+  void testAndOperator() {
     FilterExpression expression = parser.parse("geometry:point and name=*");
     assertTrue(expression.applyOSMGeometry(
         createTestOSMEntityNode("name", "FIXME"),
@@ -83,7 +83,7 @@ public class ApplyOSMGeometryTest extends FilterTest {
   }
 
   @Test
-  public void testOrOperator() {
+  void testOrOperator() {
     FilterExpression expression = parser.parse("geometry:point or geometry:polygon");
     assertTrue(expression.applyOSMGeometry(
         createTestOSMEntityNode(),
@@ -100,7 +100,7 @@ public class ApplyOSMGeometryTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryFilterArea() {
+  void testGeometryFilterArea() {
     FilterExpression expression = parser.parse("area:(1..2)");
     OSMEntity entity = createTestOSMEntityWay(new long[] {1, 2, 3, 4, 1});
     assertFalse(expression.applyOSMGeometry(entity,
@@ -128,7 +128,7 @@ public class ApplyOSMGeometryTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryFilterLength() {
+  void testGeometryFilterLength() {
     FilterExpression expression = parser.parse("length:(1..2)");
     OSMEntity entity = createTestOSMEntityWay(new long[] {1, 2});
     assertFalse(expression.applyOSMGeometry(entity,

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the application of filters to OSM entities.

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMTest.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the application of filters to OSM entities.
  */
-public class ApplyOSMTest extends FilterTest {
+class ApplyOSMTest extends FilterTest {
   @Test
-  public void testTagFilterEquals() {
+  void testTagFilterEquals() {
     FilterExpression expression = parser.parse("highway=residential");
     assertTrue(expression.applyOSM(createTestOSMEntityNode("highway", "residential")));
     assertFalse(expression.applyOSM(createTestOSMEntityNode("highway", "track")));
@@ -18,14 +18,14 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterEqualsAny() {
+  void testTagFilterEqualsAny() {
     FilterExpression expression = parser.parse("highway=*");
     assertTrue(expression.applyOSM(createTestOSMEntityNode("highway", "residential")));
     assertFalse(expression.applyOSM(createTestOSMEntityNode("building", "yes")));
   }
 
   @Test
-  public void testTagFilterNotEquals() {
+  void testTagFilterNotEquals() {
     FilterExpression expression = parser.parse("highway!=residential");
     assertFalse(expression.applyOSM(createTestOSMEntityNode("highway", "residential")));
     assertTrue(expression.applyOSM(createTestOSMEntityNode("highway", "track")));
@@ -33,14 +33,14 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEqualsAny() {
+  void testTagFilterNotEqualsAny() {
     FilterExpression expression = parser.parse("highway!=*");
     assertFalse(expression.applyOSM(createTestOSMEntityNode("highway", "track")));
     assertTrue(expression.applyOSM(createTestOSMEntityNode("building", "yes")));
   }
 
   @Test
-  public void testTagFilterEqualsAnyOf() {
+  void testTagFilterEqualsAnyOf() {
     FilterExpression expression = parser.parse("highway in (residential, track)");
     assertTrue(expression.applyOSM(createTestOSMEntityNode("highway", "residential")));
     assertTrue(expression.applyOSM(createTestOSMEntityNode("highway", "track")));
@@ -56,7 +56,7 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEqualsAnyOf() {
+  void testTagFilterNotEqualsAnyOf() {
     FilterExpression expression = parser.parse("highway in (residential, track)").negate();
     assertFalse(expression.applyOSM(createTestOSMEntityNode("highway", "residential")));
     assertFalse(expression.applyOSM(createTestOSMEntityNode("highway", "track")));
@@ -72,31 +72,31 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterEquals() {
+  void testIdFilterEquals() {
     assertTrue(parser.parse("id:1").applyOSM(createTestOSMEntityNode()));
     assertFalse(parser.parse("id:2").applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testIdFilterNotEquals() {
+  void testIdFilterNotEquals() {
     assertFalse(parser.parse("id:1").negate().applyOSM(createTestOSMEntityNode()));
     assertTrue(parser.parse("id:2").negate().applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testIdFilterEqualsAnyOf() {
+  void testIdFilterEqualsAnyOf() {
     assertTrue(parser.parse("id:(1,2,3)").applyOSM(createTestOSMEntityNode()));
     assertFalse(parser.parse("id:(2,3)").applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testIdFilterNotEqualsAnyOf() {
+  void testIdFilterNotEqualsAnyOf() {
     assertFalse(parser.parse("id:(1,2,3)").negate().applyOSM(createTestOSMEntityNode()));
     assertTrue(parser.parse("id:(2,3)").negate().applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testIdFilterInRange() {
+  void testIdFilterInRange() {
     assertTrue(parser.parse("id:(1..3)").applyOSM(createTestOSMEntityNode()));
     assertFalse(parser.parse("id:(2..3)").applyOSM(createTestOSMEntityNode()));
     assertTrue(parser.parse("id:(1..)").applyOSM(createTestOSMEntityNode()));
@@ -106,7 +106,7 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterNotInRange() {
+  void testIdFilterNotInRange() {
     assertFalse(parser.parse("id:(1..3)").negate().applyOSM(createTestOSMEntityNode()));
     assertTrue(parser.parse("id:(2..3)").negate().applyOSM(createTestOSMEntityNode()));
     assertFalse(parser.parse("id:(1..)").negate().applyOSM(createTestOSMEntityNode()));
@@ -116,13 +116,13 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testTypeFilter() {
+  void testTypeFilter() {
     assertTrue(parser.parse("type:node").applyOSM(createTestOSMEntityNode()));
     assertFalse(parser.parse("type:way").applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testAndOperator() {
+  void testAndOperator() {
     FilterExpression expression = parser.parse("highway=residential and name=*");
     assertTrue(expression.applyOSM(createTestOSMEntityNode(
         "highway", "residential",
@@ -138,7 +138,7 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testOrOperator() {
+  void testOrOperator() {
     FilterExpression expression = parser.parse("highway=residential or name=*");
     assertTrue(expression.applyOSM(createTestOSMEntityNode("highway", "residential")));
     assertTrue(expression.applyOSM(createTestOSMEntityNode("name", "FIXME")));
@@ -146,7 +146,7 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterPoint() {
+  void testGeometryTypeFilterPoint() {
     FilterExpression expression = parser.parse("geometry:point");
     assertTrue(expression.applyOSM(createTestOSMEntityNode()));
     assertFalse(expression.applyOSM(createTestOSMEntityWay(new long[] {})));
@@ -154,7 +154,7 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterLine() {
+  void testGeometryTypeFilterLine() {
     FilterExpression expression = parser.parse("geometry:line");
     assertTrue(expression.applyOSM(createTestOSMEntityWay(new long[] {})));
     assertTrue(expression.applyOSM(createTestOSMEntityWay(new long[] {1, 2, 3, 4, 1})));
@@ -163,7 +163,7 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterPolygon() {
+  void testGeometryTypeFilterPolygon() {
     FilterExpression expression = parser.parse("geometry:polygon");
     assertTrue(expression.applyOSM(createTestOSMEntityWay(new long[] {1, 2, 3, 1})));
     assertFalse(expression.applyOSM(createTestOSMEntityWay(new long[] {1, 2, 3, 4})));
@@ -175,7 +175,7 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterOther() {
+  void testGeometryTypeFilterOther() {
     FilterExpression expression = parser.parse("geometry:other");
     assertFalse(expression.applyOSM(createTestOSMEntityNode()));
     assertTrue(expression.applyOSM(createTestOSMEntityWay(new long[] {})));
@@ -183,44 +183,44 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testConstant() {
+  void testConstant() {
     FilterExpression expression = parser.parse("");
     assertTrue(expression.applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testGeometryFilterArea() {
+  void testGeometryFilterArea() {
     FilterExpression expression = parser.parse("area:(1..2)");
     assertTrue(expression.applyOSM(createTestOSMEntityWay(new long[] {})));
   }
 
   @Test
-  public void testGeometryFilterLength() {
+  void testGeometryFilterLength() {
     FilterExpression expression = parser.parse("length:(1..2)");
     assertTrue(expression.applyOSM(createTestOSMEntityWay(new long[] {})));
   }
 
   @Test
-  public void testChangesetId() {
+  void testChangesetId() {
     FilterExpression expression = parser.parse("changeset:42");
     assertTrue(expression.applyOSM(createTestOSMEntityNode()));
     assertTrue(expression.negate().applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testChangesetIdList() {
+  void testChangesetIdList() {
     FilterExpression expression = parser.parse("changeset:(1,2,3)");
     assertTrue(expression.applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testChangesetIdRange() {
+  void testChangesetIdRange() {
     FilterExpression expression = parser.parse("changeset:(10..12)");
     assertTrue(expression.applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testContributorUserId() {
+  void testContributorUserId() {
     var parser = new FilterParser(tagTranslator, true);
     FilterExpression expression = parser.parse("contributor:1");
     assertTrue(expression.applyOSM(createTestOSMEntityNode()));
@@ -228,14 +228,14 @@ public class ApplyOSMTest extends FilterTest {
   }
 
   @Test
-  public void testContributorUserIdList() {
+  void testContributorUserIdList() {
     var parser = new FilterParser(tagTranslator, true);
     FilterExpression expression = parser.parse("contributor:(1,2,3)");
     assertTrue(expression.applyOSM(createTestOSMEntityNode()));
   }
 
   @Test
-  public void testContributorUserIdRange() {
+  void testContributorUserIdRange() {
     var parser = new FilterParser(tagTranslator, true);
     FilterExpression expression = parser.parse("contributor:(10..12)");
     assertTrue(expression.applyOSM(createTestOSMEntityNode()));

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterByTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterByTest.java
@@ -12,12 +12,12 @@ import org.locationtech.jts.geom.GeometryFactory;
 /**
  * Tests helper methods for creating filters from lambda functions.
  */
-public class FilterByTest extends FilterTest {
+class FilterByTest extends FilterTest {
   private final GeometryFactory gf = new GeometryFactory();
   private final OSMNode testOSMEntity = createTestOSMEntityNode();
   private final OSHNode testOSHEntity = createTestOSHEntityNode(testOSMEntity);
 
-  public FilterByTest() throws IOException {
+  FilterByTest() throws IOException {
   }
 
   @Test

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterByTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterByTest.java
@@ -1,12 +1,12 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import org.heigit.ohsome.oshdb.osh.OSHNode;
 import org.heigit.ohsome.oshdb.osm.OSMNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.GeometryFactory;
 
 /**

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterByTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterByTest.java
@@ -21,7 +21,7 @@ public class FilterByTest extends FilterTest {
   }
 
   @Test
-  public void testFilterByOSHEntity() {
+  void testFilterByOSHEntity() {
     FilterExpression expression;
     expression = Filter.byOSHEntity(e -> e.getId() == 1);
     assertTrue(expression.applyOSH(testOSHEntity) && expression.applyOSM(testOSMEntity));
@@ -30,7 +30,7 @@ public class FilterByTest extends FilterTest {
   }
 
   @Test
-  public void testFilterByOSMEntity() {
+  void testFilterByOSMEntity() {
     FilterExpression expression;
     expression = Filter.byOSMEntity(e -> e.getVersion() == 1);
     assertTrue(expression.applyOSH(testOSHEntity) && expression.applyOSM(testOSMEntity));
@@ -39,7 +39,7 @@ public class FilterByTest extends FilterTest {
   }
 
   @Test
-  public void testFilterByOSMEntityApplyGeometryFallback() {
+  void testFilterByOSMEntityApplyGeometryFallback() {
     FilterExpression expression = Filter.byOSMEntity(e -> e.getVersion() == 1);
     assertTrue(expression.applyOSMGeometry(testOSMEntity, gf.createPoint()));
     assertFalse(expression.negate().applyOSMGeometry(testOSMEntity, gf.createPoint()));

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterTest.java
@@ -20,8 +20,9 @@ import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.osm.OSMWay;
 import org.heigit.ohsome.oshdb.util.exceptions.OSHDBKeytablesNotFoundException;
 import org.heigit.ohsome.oshdb.util.tagtranslator.TagTranslator;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
 
 /**
  * Tests the parsing of filters and the application to OSM entities.
@@ -30,7 +31,7 @@ abstract class FilterTest {
   protected FilterParser parser;
   protected TagTranslator tagTranslator;
 
-  @Before
+  @BeforeEach
   public void setup() throws SQLException, ClassNotFoundException, OSHDBKeytablesNotFoundException {
     Class.forName("org.h2.Driver");
     this.tagTranslator = new TagTranslator(DriverManager.getConnection(
@@ -40,7 +41,7 @@ abstract class FilterTest {
     this.parser = new FilterParser(this.tagTranslator);
   }
 
-  @After
+  @AfterEach
   public void teardown() throws SQLException {
     this.tagTranslator.getConnection().close();
   }

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/FilterTest.java
@@ -23,7 +23,6 @@ import org.heigit.ohsome.oshdb.util.tagtranslator.TagTranslator;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
-
 /**
  * Tests the parsing of filters and the application to OSM entities.
  */
@@ -32,7 +31,7 @@ abstract class FilterTest {
   protected TagTranslator tagTranslator;
 
   @BeforeEach
-  public void setup() throws SQLException, ClassNotFoundException, OSHDBKeytablesNotFoundException {
+  void setup() throws SQLException, ClassNotFoundException, OSHDBKeytablesNotFoundException {
     Class.forName("org.h2.Driver");
     this.tagTranslator = new TagTranslator(DriverManager.getConnection(
         "jdbc:h2:./src/test/resources/keytables;ACCESS_MODE_DATA=r",
@@ -42,7 +41,7 @@ abstract class FilterTest {
   }
 
   @AfterEach
-  public void teardown() throws SQLException {
+  void teardown() throws SQLException {
     this.tagTranslator.getConnection().close();
   }
 

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NegateTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NegateTest.java
@@ -20,7 +20,7 @@ import org.locationtech.jts.geom.GeometryFactory;
  */
 public class NegateTest extends FilterTest {
   @Test
-  public void testTagFilterEquals() {
+  void testTagFilterEquals() {
     FilterExpression expression = TagFilter.fromSelector(
         TagFilter.Type.EQUALS,
         new OSMTag("highway", "residential"),
@@ -32,7 +32,7 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEquals() {
+  void testTagFilterNotEquals() {
     FilterExpression expression = TagFilter.fromSelector(
         TagFilter.Type.NOT_EQUALS,
         new OSMTag("highway", "residential"),
@@ -44,7 +44,7 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterEqualsAny() {
+  void testTagFilterEqualsAny() {
     FilterExpression expression = TagFilter.fromSelector(
         TagFilter.Type.EQUALS,
         new OSMTagKey("highway"),
@@ -56,7 +56,7 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEqualsAny() {
+  void testTagFilterNotEqualsAny() {
     FilterExpression expression = TagFilter.fromSelector(
         TagFilter.Type.NOT_EQUALS,
         new OSMTagKey("highway"),
@@ -68,7 +68,7 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterEqualsAnyOf() {
+  void testTagFilterEqualsAnyOf() {
     OSHDBTag tag1 = tagTranslator.getOSHDBTagOf("highway", "residential");
     OSHDBTag tag2 = tagTranslator.getOSHDBTagOf("highway", "track");
     FilterExpression expression = new TagFilterEqualsAnyOf(Arrays.asList(tag1, tag2));
@@ -77,7 +77,7 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEqualsAnyOf() {
+  void testTagFilterNotEqualsAnyOf() {
     OSHDBTag tag1 = tagTranslator.getOSHDBTagOf("highway", "residential");
     OSHDBTag tag2 = tagTranslator.getOSHDBTagOf("highway", "track");
     FilterExpression expression = new TagFilterNotEqualsAnyOf(Arrays.asList(tag1, tag2));
@@ -86,21 +86,21 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testIdEqualsFilter() {
+  void testIdEqualsFilter() {
     FilterExpression expression = new IdFilterEquals(1);
     FilterExpression negation = expression.negate();
     assertTrue(negation instanceof IdFilterNotEquals);
   }
 
   @Test
-  public void testIdNotEqualsFilter() {
+  void testIdNotEqualsFilter() {
     FilterExpression expression = new IdFilterNotEquals(1);
     FilterExpression negation = expression.negate();
     assertTrue(negation instanceof IdFilterEquals);
   }
 
   @Test
-  public void testIdEqualsAnyOfFilter() {
+  void testIdEqualsAnyOfFilter() {
     FilterExpression expression = new IdFilterEqualsAnyOf(Collections.singletonList(1L));
     FilterExpression negation = expression.negate();
     OSMEntity testEntity = createTestOSMEntityNode();
@@ -110,7 +110,7 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testIdInRangeFilter() {
+  void testIdInRangeFilter() {
     FilterExpression expression = new IdFilterRange(new IdRange(1, 3));
     FilterExpression negation = expression.negate();
     OSMEntity testEntity = createTestOSMEntityNode();
@@ -129,14 +129,14 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testTypeFilter() {
+  void testTypeFilter() {
     FilterExpression expression = new TypeFilter(OSMType.NODE);
     FilterExpression negation = expression.negate();
     testAllOSMTypes(expression, negation);
   }
 
   @Test
-  public void testAndOperator() {
+  void testAndOperator() {
     FilterExpression sub1 = new TypeFilter(OSMType.NODE);
     FilterExpression sub2 = new TypeFilter(OSMType.WAY);
     FilterExpression expression = BinaryOperator.fromOperator(sub1, BinaryOperator.Type.AND, sub2);
@@ -148,7 +148,7 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testOrOperator() {
+  void testOrOperator() {
     FilterExpression sub1 = new TypeFilter(OSMType.NODE);
     FilterExpression sub2 = new TypeFilter(OSMType.WAY);
     FilterExpression expression = BinaryOperator.fromOperator(sub1, BinaryOperator.Type.OR, sub2);
@@ -177,35 +177,35 @@ public class NegateTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypePoint() {
+  void testGeometryTypePoint() {
     GeometryTypeFilter expression = new GeometryTypeFilter(GeometryType.POINT, tagTranslator);
     FilterExpression negation = expression.negate();
     testAllGeometryTypes(expression, negation);
   }
 
   @Test
-  public void testGeometryTypeLine() {
+  void testGeometryTypeLine() {
     GeometryTypeFilter expression = new GeometryTypeFilter(GeometryType.LINE, tagTranslator);
     FilterExpression negation = expression.negate();
     testAllGeometryTypes(expression, negation);
   }
 
   @Test
-  public void testGeometryTypePolygon() {
+  void testGeometryTypePolygon() {
     GeometryTypeFilter expression = new GeometryTypeFilter(GeometryType.POLYGON, tagTranslator);
     FilterExpression negation = expression.negate();
     testAllGeometryTypes(expression, negation);
   }
 
   @Test
-  public void testGeometryTypeOther() {
+  void testGeometryTypeOther() {
     GeometryTypeFilter expression = new GeometryTypeFilter(GeometryType.OTHER, tagTranslator);
     FilterExpression negation = expression.negate();
     testAllGeometryTypes(expression, negation);
   }
 
   @Test
-  public void testConstant() {
+  void testConstant() {
     ConstantFilter expression = new ConstantFilter(true);
     FilterExpression negation = expression.negate();
     assertTrue(negation instanceof ConstantFilter);

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NegateTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NegateTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -12,7 +12,7 @@ import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.tagtranslator.OSMTag;
 import org.heigit.ohsome.oshdb.util.tagtranslator.OSMTagKey;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.GeometryFactory;
 
 /**

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NegateTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NegateTest.java
@@ -18,7 +18,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 /**
  * Tests for negation of filters.
  */
-public class NegateTest extends FilterTest {
+class NegateTest extends FilterTest {
   @Test
   void testTagFilterEquals() {
     FilterExpression expression = TagFilter.fromSelector(

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NormalizeTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NormalizeTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests for normalization of filters.
  */
-public class NormalizeTest {
+class NormalizeTest {
   @Test
   void testAndOperator() {
     FilterExpression sub1 = new TypeFilter(OSMType.NODE);

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NormalizeTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NormalizeTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
  */
 public class NormalizeTest {
   @Test
-  public void testAndOperator() {
+  void testAndOperator() {
     FilterExpression sub1 = new TypeFilter(OSMType.NODE);
     FilterExpression sub2 = new TypeFilter(OSMType.WAY);
     FilterExpression expression = BinaryOperator.fromOperator(sub1, BinaryOperator.Type.AND, sub2);
@@ -21,7 +21,7 @@ public class NormalizeTest {
   }
 
   @Test
-  public void testOrOperator() {
+  void testOrOperator() {
     FilterExpression sub1 = new TypeFilter(OSMType.NODE);
     FilterExpression sub2 = new TypeFilter(OSMType.WAY);
     FilterExpression expression = BinaryOperator.fromOperator(sub1, BinaryOperator.Type.OR, sub2);

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NormalizeTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/NormalizeTest.java
@@ -1,10 +1,10 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 import org.heigit.ohsome.oshdb.osm.OSMType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for normalization of filters.

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ParseTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ParseTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Test;
  */
 public class ParseTest extends FilterTest {
   @Test
-  public void testTagFilterEquals() {
+  void testTagFilterEquals() {
     FilterExpression expression = parser.parse("highway=residential");
     assertTrue(expression instanceof TagFilterEquals);
     OSHDBTag tag = tagTranslator.getOSHDBTagOf("highway", "residential");
@@ -29,7 +29,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterStrings() {
+  void testTagFilterStrings() {
     // tag key with colon; quoted string as value
     assertTrue(parser.parse("addr:street=\"Hauptstraße\"") instanceof TagFilter);
     // whitespace (in string; between key and value, single quotes
@@ -40,7 +40,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterEqualsAny() {
+  void testTagFilterEqualsAny() {
     FilterExpression expression = parser.parse("highway=*");
     assertTrue(expression instanceof TagFilterEqualsAny);
     OSHDBTagKey tag = tagTranslator.getOSHDBTagKeyOf("highway");
@@ -49,7 +49,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEquals() {
+  void testTagFilterNotEquals() {
     FilterExpression expression = parser.parse("highway!=residential");
     assertTrue(expression instanceof TagFilterNotEquals);
     OSHDBTag tag = tagTranslator.getOSHDBTagOf("highway", "residential");
@@ -58,7 +58,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testTagFilterNotEqualsAny() {
+  void testTagFilterNotEqualsAny() {
     FilterExpression expression = parser.parse("highway!=*");
     assertTrue(expression instanceof TagFilterNotEqualsAny);
     OSHDBTagKey tag = tagTranslator.getOSHDBTagKeyOf("highway");
@@ -68,7 +68,7 @@ public class ParseTest extends FilterTest {
 
   @SuppressWarnings("RegExpDuplicateAlternationBranch") // false positive by intellij
   @Test
-  public void testTagFilterEqualsAnyOf() {
+  void testTagFilterEqualsAnyOf() {
     FilterExpression expression = parser.parse("highway in (residential, track)");
     assertTrue(expression instanceof TagFilterEqualsAnyOf);
     OSHDBTag tag1 = tagTranslator.getOSHDBTagOf("highway", "residential");
@@ -81,7 +81,7 @@ public class ParseTest extends FilterTest {
 
   @SuppressWarnings("RegExpDuplicateAlternationBranch") // false positive by intellij
   @Test
-  public void testTagFilterNotEqualsAnyOf() {
+  void testTagFilterNotEqualsAnyOf() {
     FilterExpression expression = parser.parse("not highway in (residential, track)");
     assertTrue(expression instanceof TagFilterNotEqualsAnyOf);
     OSHDBTag tag1 = tagTranslator.getOSHDBTagOf("highway", "residential");
@@ -93,21 +93,21 @@ public class ParseTest extends FilterTest {
   }
 
   @Test()
-  public void testTagFilterEqualsAnyOfCheckEmpty() {
+  void testTagFilterEqualsAnyOfCheckEmpty() {
     assertThrows(IllegalStateException.class, () -> {
       new TagFilterEqualsAnyOf(Collections.emptyList());
     });
   }
 
   @Test()
-  public void testTagFilterNotEqualsAnyOfCheckEmpty() {
+  void testTagFilterNotEqualsAnyOfCheckEmpty() {
     assertThrows(IllegalStateException.class, () -> {
       new TagFilterNotEqualsAnyOf(Collections.emptyList());
     });
   }
 
   @Test()
-  public void testTagFilterEqualsAnyOfCheckMixed() {
+  void testTagFilterEqualsAnyOfCheckMixed() {
     assertThrows(IllegalStateException.class, () -> {
       new TagFilterEqualsAnyOf(Arrays.asList(
           tagTranslator.getOSHDBTagOf("highway", "residential"),
@@ -117,7 +117,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test()
-  public void testTagFilterNotEqualsAnyOfCheckMixed() {
+  void testTagFilterNotEqualsAnyOfCheckMixed() {
     assertThrows(IllegalStateException.class, () -> {
       new TagFilterNotEqualsAnyOf(Arrays.asList(
           tagTranslator.getOSHDBTagOf("highway", "residential"),
@@ -127,7 +127,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterEquals() {
+  void testIdFilterEquals() {
     FilterExpression expression = parser.parse("id:123");
     assertTrue(expression instanceof IdFilterEquals);
     assertEquals(123, ((IdFilterEquals) expression).getId());
@@ -135,7 +135,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testIdTypeFilterEquals() {
+  void testIdTypeFilterEquals() {
     FilterExpression expression = parser.parse("id:node/123");
     assertTrue(expression instanceof AndOperator);
     assertTrue(((AndOperator) expression).op1 instanceof TypeFilter
@@ -145,7 +145,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterNotEquals() {
+  void testIdFilterNotEquals() {
     FilterExpression expression = parser.parse("not id:123");
     assertTrue(expression instanceof IdFilterNotEquals);
     assertEquals(123, ((IdFilterNotEquals) expression).getId());
@@ -153,14 +153,14 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testIdFilterEqualsAnyOf() {
+  void testIdFilterEqualsAnyOf() {
     FilterExpression expression = parser.parse("id:(1,2,3)");
     assertTrue(expression instanceof IdFilterEqualsAnyOf);
     assertEquals("id:in1,2,3", expression.toString());
   }
 
   @Test
-  public void testIdTypeFilterEqualsAnyOf() {
+  void testIdTypeFilterEqualsAnyOf() {
     FilterExpression expression = parser.parse("id:(node/1,way/2)");
     assertTrue(expression instanceof OrOperator);
     assertTrue(((OrOperator) expression).op1 instanceof AndOperator);
@@ -169,14 +169,14 @@ public class ParseTest extends FilterTest {
   }
 
   @Test()
-  public void testIdFilterEqualsAnyOfCheckEmpty() {
+  void testIdFilterEqualsAnyOfCheckEmpty() {
     assertThrows(IllegalStateException.class, () -> {
       new IdFilterEqualsAnyOf(Collections.emptyList());
     });
   }
 
   @Test
-  public void testIdFilterInRange() {
+  void testIdFilterInRange() {
     // complete range
     FilterExpression expression = parser.parse("id:(1..3)");
     assertTrue(expression instanceof IdFilterRange);
@@ -196,7 +196,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testTypeFilter() {
+  void testTypeFilter() {
     FilterExpression expression = parser.parse("type:node");
     assertTrue(expression instanceof TypeFilter);
     assertEquals(OSMType.NODE, ((TypeFilter) expression).getType());
@@ -206,7 +206,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testAndOperator() {
+  void testAndOperator() {
     FilterExpression expression = parser.parse("highway=residential and name=*");
     assertTrue(expression instanceof AndOperator);
     assertTrue(((AndOperator) expression).getLeftOperand() instanceof TagFilter);
@@ -215,7 +215,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testOrOperator() {
+  void testOrOperator() {
     FilterExpression expression = parser.parse("highway=residential or name=*");
     assertTrue(expression instanceof OrOperator);
     assertTrue(((OrOperator) expression).getLeftOperand() instanceof TagFilter);
@@ -224,7 +224,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterPoint() {
+  void testGeometryTypeFilterPoint() {
     FilterExpression expression = parser.parse("geometry:point");
     assertTrue(expression instanceof GeometryTypeFilter);
     assertEquals(GeometryType.POINT, ((GeometryTypeFilter) expression).getGeometryType());
@@ -236,7 +236,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterLine() {
+  void testGeometryTypeFilterLine() {
     FilterExpression expression = parser.parse("geometry:line");
     assertTrue(expression instanceof GeometryTypeFilter);
     assertEquals(GeometryType.LINE, ((GeometryTypeFilter) expression).getGeometryType());
@@ -248,7 +248,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterPolygon() {
+  void testGeometryTypeFilterPolygon() {
     FilterExpression expression = parser.parse("geometry:polygon");
     assertTrue(expression instanceof GeometryTypeFilter);
     assertEquals(GeometryType.POLYGON, ((GeometryTypeFilter) expression).getGeometryType());
@@ -260,7 +260,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryTypeFilterOther() {
+  void testGeometryTypeFilterOther() {
     FilterExpression expression = parser.parse("geometry:other");
     assertTrue(expression instanceof GeometryTypeFilter);
     assertEquals(GeometryType.OTHER, ((GeometryTypeFilter) expression).getGeometryType());
@@ -272,14 +272,14 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testPaddingWhitespace() {
+  void testPaddingWhitespace() {
     // allow extra whitespace at start/end of filter
     FilterExpression expression = parser.parse(" type:node ");
     assertTrue(expression instanceof TypeFilter);
   }
 
   @Test
-  public void testParentheses() {
+  void testParentheses() {
     FilterExpression expression =
         parser.parse("type:way and (highway=residential or highway=track)");
     assertTrue(expression instanceof AndOperator);
@@ -297,7 +297,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testEmptyFilter() {
+  void testEmptyFilter() {
     forEmptyFilter("");
     forEmptyFilter(" ");
   }
@@ -310,7 +310,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryFilterArea() {
+  void testGeometryFilterArea() {
     FilterExpression expression = parser.parse("area:(1..10)");
     assertTrue(expression instanceof GeometryFilterArea);
     assertEquals(1.0, ((GeometryFilterArea) expression).getRange().getFromValue(), 1E-10);
@@ -333,13 +333,13 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testGeometryFilterLength() {
+  void testGeometryFilterLength() {
     FilterExpression expression = parser.parse("length:(1..10)");
     assertTrue(expression instanceof GeometryFilterLength);
   }
 
   @Test
-  public void testChangesetIdFilter() {
+  void testChangesetIdFilter() {
     FilterExpression expression = parser.parse("changeset:42");
     assertTrue(expression instanceof ChangesetIdFilterEquals);
     assertEquals(42, ((ChangesetIdFilterEquals) expression).getChangesetId());
@@ -347,7 +347,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testChangesetIdListFilter() {
+  void testChangesetIdListFilter() {
     FilterExpression expression = parser.parse("changeset:(1,2,3)");
     assertTrue(expression instanceof ChangesetIdFilterEqualsAnyOf);
     assertEquals(List.of(1L, 2L, 3L), new ArrayList<>(
@@ -356,14 +356,14 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testChangesetIdRangeFilter() {
+  void testChangesetIdRangeFilter() {
     FilterExpression expression = parser.parse("changeset:(10..12)");
     assertTrue(expression instanceof ChangesetIdFilterRange);
     assertEquals("changeset:in-range10..12", expression.toString());
   }
 
   @Test
-  public void testContributorIdFilterEnabled() {
+  void testContributorIdFilterEnabled() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     FilterExpression expression = parser.parse("contributor:1" /* Steve <3 */);
     assertTrue(expression instanceof ContributorUserIdFilterEquals);
@@ -372,7 +372,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testContributorUserIdListFilter() {
+  void testContributorUserIdListFilter() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     FilterExpression expression = parser.parse("contributor:(1,2,3)");
     assertTrue(expression instanceof ContributorUserIdFilterEqualsAnyOf);
@@ -382,7 +382,7 @@ public class ParseTest extends FilterTest {
   }
 
   @Test
-  public void testContributorUserIdRangeFilter() {
+  void testContributorUserIdRangeFilter() {
     FilterParser parser = new FilterParser(tagTranslator, true);
     FilterExpression expression = parser.parse("contributor:(10..12)");
     assertTrue(expression instanceof ContributorUserIdFilterRange);
@@ -391,7 +391,7 @@ public class ParseTest extends FilterTest {
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test()
-  public void testContributorIdFilterNotEnabled() {
+  void testContributorIdFilterNotEnabled() {
     assertThrows(ParserException.class, () -> {
       parser.parse("contributor:0");
     });

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ParseTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ParseTest.java
@@ -1,9 +1,8 @@
 package org.heigit.ohsome.oshdb.filter;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -14,7 +13,7 @@ import org.heigit.ohsome.oshdb.filter.GeometryTypeFilter.GeometryType;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
 import org.jparsec.error.ParserException;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the parsing of filters and the application to OSM entities.
@@ -93,30 +92,38 @@ public class ParseTest extends FilterTest {
     ));
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testTagFilterEqualsAnyOfCheckEmpty() {
-    new TagFilterEqualsAnyOf(Collections.emptyList());
+    assertThrows(IllegalStateException.class, () -> {
+      new TagFilterEqualsAnyOf(Collections.emptyList());
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testTagFilterNotEqualsAnyOfCheckEmpty() {
-    new TagFilterNotEqualsAnyOf(Collections.emptyList());
+    assertThrows(IllegalStateException.class, () -> {
+      new TagFilterNotEqualsAnyOf(Collections.emptyList());
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testTagFilterEqualsAnyOfCheckMixed() {
-    new TagFilterEqualsAnyOf(Arrays.asList(
-        tagTranslator.getOSHDBTagOf("highway", "residential"),
-        tagTranslator.getOSHDBTagOf("building", "yes")
-    ));
+    assertThrows(IllegalStateException.class, () -> {
+      new TagFilterEqualsAnyOf(Arrays.asList(
+          tagTranslator.getOSHDBTagOf("highway", "residential"),
+          tagTranslator.getOSHDBTagOf("building", "yes")
+      ));
+    });
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testTagFilterNotEqualsAnyOfCheckMixed() {
-    new TagFilterNotEqualsAnyOf(Arrays.asList(
-        tagTranslator.getOSHDBTagOf("highway", "residential"),
-        tagTranslator.getOSHDBTagOf("building", "yes")
-    ));
+    assertThrows(IllegalStateException.class, () -> {
+      new TagFilterNotEqualsAnyOf(Arrays.asList(
+          tagTranslator.getOSHDBTagOf("highway", "residential"),
+          tagTranslator.getOSHDBTagOf("building", "yes")
+      ));
+    });
   }
 
   @Test
@@ -161,9 +168,11 @@ public class ParseTest extends FilterTest {
     assertEquals("type:node and id:1 or type:way and id:2", expression.toString());
   }
 
-  @Test(expected = IllegalStateException.class)
+  @Test()
   public void testIdFilterEqualsAnyOfCheckEmpty() {
-    new IdFilterEqualsAnyOf(Collections.emptyList());
+    assertThrows(IllegalStateException.class, () -> {
+      new IdFilterEqualsAnyOf(Collections.emptyList());
+    });
   }
 
   @Test
@@ -380,10 +389,11 @@ public class ParseTest extends FilterTest {
     assertEquals("contributor:in-range10..12", expression.toString());
   }
 
-  @Test(expected = ParserException.class)
   @SuppressWarnings("ResultOfMethodCallIgnored")
+  @Test()
   public void testContributorIdFilterNotEnabled() {
-    parser.parse("contributor:0");
-    fail();
+    assertThrows(ParserException.class, () -> {
+      parser.parse("contributor:0");
+    });
   }
 }

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ParseTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ParseTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the parsing of filters and the application to OSM entities.
  */
-public class ParseTest extends FilterTest {
+class ParseTest extends FilterTest {
   @Test
   void testTagFilterEquals() {
     FilterExpression expression = parser.parse("highway=residential");

--- a/oshdb-oshpbf-parser/pom.xml
+++ b/oshdb-oshpbf-parser/pom.xml
@@ -33,11 +33,5 @@
       <artifactId>rxjava</artifactId>
       <version>${rxjava2.version}</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/oshdb-oshpbf-parser/pom.xml
+++ b/oshdb-oshpbf-parser/pom.xml
@@ -35,8 +35,9 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 </project>

--- a/oshdb-util/pom.xml
+++ b/oshdb-util/pom.xml
@@ -33,9 +33,26 @@
       <groupId>com.googlecode.json-simple</groupId>
       <artifactId>json-simple</artifactId>
       <version>${googlejson.version}</version>
+      <exclusions>
+        <!-- 
+        json-simple in release 1.1.1 include junit unfortunately in compile scope. 
+        In the newest version
+        https://github.com/fangyidong/json-simple
+        , it is reduce to test, which makes more sense!
+         -->
+        <exclusion>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- TEST dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>

--- a/oshdb-util/pom.xml
+++ b/oshdb-util/pom.xml
@@ -49,11 +49,6 @@
 
     <!-- TEST dependencies -->
     <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
       <scope>test</scope>

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -29,7 +29,7 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on nodes.
  */
-public class IterateByContributionNodesTest {
+class IterateByContributionNodesTest {
   private final GridOSHNodes oshdbDataGridCell;
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
@@ -38,14 +38,14 @@ public class IterateByContributionNodesTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * {@link GridOSHNodes}.
    */
-  public IterateByContributionNodesTest() throws IOException {
+  IterateByContributionNodesTest() throws IOException {
     osmXmlTestData.add("./src/test/resources/different-timestamps/node.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     oshdbDataGridCell = GridOSHFactory.getGridOSHNodes(osmXmlTestData);
   }
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // node 1: creation and two geometry changes, but no tag changes
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -85,7 +85,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // node 2: creation and two tag changes, but no geometry changes
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -121,7 +121,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // node 3: creation and 4 visible changes, but no geometry and no tag changes
 
     List<IterateAllEntry> result = (new CellIterator(
@@ -163,7 +163,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testMultipleChanges() {
+  void testMultipleChanges() {
     // node 4: creation and 5 changes:
     // tag and geometry,
     // visible = false,
@@ -218,7 +218,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testBboxMinAndMaxNotCorrect() {
+  void testBboxMinAndMaxNotCorrect() {
     // node 1: creation and two geometry changes, but no tag changes
     // OSHDBBoundingBox: MinLon and MinLat as well as MaxLon and MaxLat incorrect
     List<IterateAllEntry> result = (new CellIterator(
@@ -238,7 +238,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testBboxMinExactlyAtDataMinMaxExcluded() {
+  void testBboxMinExactlyAtDataMinMaxExcluded() {
     // node 1: creation and two geometry changes, but no tag changes
     // OSHDBBoundingBox: MinLon and MinLat like Version 1, MaxLon and MaxLat incorrect
     List<IterateAllEntry> result = (new CellIterator(
@@ -258,7 +258,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testBboxMaxExactlyAtDataMaxMinExcluded() {
+  void testBboxMaxExactlyAtDataMaxMinExcluded() {
     // node 1: creation and two geometry changes, but no tag changes
     // OSHDBBoundingBox: MinLon and MinLat incorrect, MaxLon and MaxLat like Version 3
     List<IterateAllEntry> result = (new CellIterator(
@@ -278,7 +278,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testBboxMinMaxExactlyAtDataMinMax() {
+  void testBboxMinMaxExactlyAtDataMinMax() {
     // node 1: creation and two geometry changes, but no tag changes
     // OSHDBBoundingBox: MinLon and MinLat like Version 1, MaxLon and MaxLat like Version 3
     List<IterateAllEntry> result = (new CellIterator(
@@ -298,7 +298,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testTagChangeTagFilterWithSuccess() {
+  void testTagChangeTagFilterWithSuccess() {
     // node: creation then tag changes, but no geometry changes
     // check if results are correct if we filter for a special tag
     List<IterateAllEntry> result = (new CellIterator(
@@ -335,7 +335,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testTagChangeTagFilterDisused() {
+  void testTagChangeTagFilterDisused() {
     // check if results are correct if we filter for a special tag
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -367,7 +367,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testMoreComplicatedFilter() {
+  void testMoreComplicatedFilter() {
     // check if results are correct if we filter for a special tag
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -399,7 +399,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testTagChangeTagFilterWithoutSuccess() {
+  void testTagChangeTagFilterWithoutSuccess() {
     // check if results are correct if we filter for a special tag
     // tag not in data
     List<IterateAllEntry> result = (new CellIterator(
@@ -419,7 +419,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataPartly() {
+  void testPolygonIntersectingDataPartly() {
     // lon lat changes, so that node in v2 is outside bbox
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -447,7 +447,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testTagFilterAndPolygonIntersectingDataPartly() {
+  void testTagFilterAndPolygonIntersectingDataPartly() {
     // lon lat changes, so that node in v2 is outside bbox
     final GeometryFactory geometryFactory = new GeometryFactory();
     // create clipping polygon for area of interest
@@ -478,7 +478,7 @@ public class IterateByContributionNodesTest {
   }
 
   @Test
-  public void testCoordinatesRelativeToPolygon() throws IOException {
+  void testCoordinatesRelativeToPolygon() throws IOException {
     // different cases of relative position between node coordinate(s) and cell bbox / query polygon
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[4];

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -19,7 +19,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
@@ -26,7 +26,7 @@ import org.locationtech.jts.geom.Polygon;
  * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on special situations
  * which are related to OSHDB grid cells.
  */
-public class IterateByContributionNotOsmTypeSpecificTest {
+class IterateByContributionNotOsmTypeSpecificTest {
 
   TagInterpreter areaDecider;
   private final List<OSHRelation> oshRelations;
@@ -35,7 +35,7 @@ public class IterateByContributionNotOsmTypeSpecificTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * a list of {@link OSHRelation OSHRelations}.
    */
-  public IterateByContributionNotOsmTypeSpecificTest() throws IOException {
+  IterateByContributionNotOsmTypeSpecificTest() throws IOException {
     OSMXmlReader osmXmlTestData = new OSMXmlReader();
     osmXmlTestData.add("./src/test/resources/different-timestamps/polygon.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
@@ -44,7 +44,7 @@ public class IterateByContributionNotOsmTypeSpecificTest {
   }
 
   @Test
-  public void testCellOutsidePolygon() throws IOException {
+  void testCellOutsidePolygon() throws IOException {
     final GridOSHRelations oshdbDataGridCell = GridOSHRelations.compact(69120, 12, 0, 0, 0, 0,
         Collections.emptyList());
 
@@ -74,7 +74,7 @@ public class IterateByContributionNotOsmTypeSpecificTest {
   }
 
   @Test
-  public void testCellCoveringPolygon() throws IOException {
+  void testCellCoveringPolygon() throws IOException {
     final GridOSHRelations oshdbDataGridCell = GridOSHRelations.compact(0, 0, 0, 0, 0, 0,
         oshRelations);
 
@@ -104,7 +104,7 @@ public class IterateByContributionNotOsmTypeSpecificTest {
   }
 
   @Test
-  public void testCellFullyInsidePolygon() throws IOException {
+  void testCellFullyInsidePolygon() throws IOException {
     final GridOSHRelations oshdbDataGridCell = GridOSHRelations.compact(69120, 12, 0, 0, 0, 0,
         oshRelations);
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -17,7 +17,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -29,7 +29,6 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on relations.
  */
-@SuppressWarnings("javadoc")
 class IterateByContributionRelationsTest {
   private GridOSHRelations oshdbDataGridCell;
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -134,24 +134,21 @@ public class IterateByContributionRelationsTest {
   @Test
   public void testWaysNotExistent() {
     // relation with two ways, both missing
-    try {
+    assertDoesNotThrow(() -> {
       (new CellIterator(
-          new OSHDBTimestamps(
-              "2000-01-01T00:00:00Z",
-              "2020-01-01T00:00:00Z"
-          ).get(),
-          OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
-          areaDecider,
-          oshEntity -> oshEntity.getId() == 502,
-          osmEntity -> true,
-          false
-      )).iterateByContribution(
-          oshdbDataGridCell
-      ).collect(Collectors.toList());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+            new OSHDBTimestamps(
+                "2000-01-01T00:00:00Z",
+                "2020-01-01T00:00:00Z"
+            ).get(),
+            OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
+            areaDecider,
+            oshEntity -> oshEntity.getId() == 502,
+            osmEntity -> true,
+            false
+        )).iterateByContribution(
+            oshdbDataGridCell
+        ).collect(Collectors.toList());
+    });
   }
 
   @Test
@@ -342,7 +339,7 @@ public class IterateByContributionRelationsTest {
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
-    try {
+    assertDoesNotThrow(() -> {
       (new CellIterator(
           new OSHDBTimestamps(
               "2000-01-01T00:00:00Z",
@@ -356,10 +353,7 @@ public class IterateByContributionRelationsTest {
       )).iterateByContribution(
           oshdbDataGridCell
       ).collect(Collectors.toList());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -30,7 +30,7 @@ import org.locationtech.jts.geom.Polygon;
  * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on relations.
  */
 @SuppressWarnings("javadoc")
-public class IterateByContributionRelationsTest {
+class IterateByContributionRelationsTest {
   private GridOSHRelations oshdbDataGridCell;
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
@@ -40,7 +40,7 @@ public class IterateByContributionRelationsTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * {@link GridOSHRelations}.
    */
-  public IterateByContributionRelationsTest() throws IOException {
+  IterateByContributionRelationsTest() throws IOException {
     // read osm xml data
     osmXmlTestData.add("./src/test/resources/different-timestamps/polygon.osm");
     // used to provide information needed to create actual geometries from OSM data
@@ -51,7 +51,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // relation: creation and two geometry changes, but no tag changes
     // relation getting more ways, one disappears
     List<IterateAllEntry> result = (new CellIterator(
@@ -98,7 +98,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // relation: creation and 2 visible changes, but no geometry and no tag changes
     // relation visible tag changed
     List<IterateAllEntry> result = (new CellIterator(
@@ -132,7 +132,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testWaysNotExistent() {
+  void testWaysNotExistent() {
     // relation with two ways, both missing
     assertDoesNotThrow(() -> {
       (new CellIterator(
@@ -152,7 +152,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // relation: creation and two tag changes
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -185,7 +185,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeRefsInWays() {
+  void testGeometryChangeOfNodeRefsInWays() {
     // relation: creation and geometry change of ways, but no tag changes
     // relation, way 109 -inner- and 110 -outer- ways changed node refs-
     List<IterateAllEntry> result = (new CellIterator(
@@ -225,7 +225,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInWay() {
+  void testGeometryChangeOfNodeCoordinatesInWay() {
     // relation: creation
     // relation, way 112 -outer- changed node coordinates
     List<IterateAllEntry> result = (new CellIterator(
@@ -264,7 +264,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
+  void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
     // relation: creation
     // relation, with node members, nodes and nodes in way changed coordinates
     List<IterateAllEntry> result = (new CellIterator(
@@ -304,7 +304,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testGeometryCollection() {
+  void testGeometryCollection() {
     // relation, not valid, should be geometryCollection
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -337,7 +337,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testNodesOfWaysNotExistent() {
+  void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
     assertDoesNotThrow(() -> {
       (new CellIterator(
@@ -357,7 +357,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testVisibleChangeOfNodeInWay() {
+  void testVisibleChangeOfNodeInWay() {
     // relation, way member: node 52 changes visible tag
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -414,7 +414,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testTagChangeOfNodeInWay() {
+  void testTagChangeOfNodeInWay() {
     // relation, way member: node 53 changes tags-
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -441,7 +441,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testVisibleChangeOfWay() {
+  void testVisibleChangeOfWay() {
     // relation, way member: way 119 changes visible tag-
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -477,7 +477,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testVisibleChangeOfOneWayOfOuterRing() {
+  void testVisibleChangeOfOneWayOfOuterRing() {
     // relation, 2 way members making outer ring: way 120 changes visible tag later, 121 not
     // ways together making outer ring
     List<IterateAllEntry> result = (new CellIterator(
@@ -512,7 +512,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testTagChangeOfWay() {
+  void testTagChangeOfWay() {
     // relation, way member: way 122 changes tags
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -542,7 +542,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testOneOfTwoPolygonDisappears() {
+  void testOneOfTwoPolygonDisappears() {
     // relation, at the beginning two polygons, one disappears later
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -577,7 +577,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testWaySplitUpInTwo() {
+  void testWaySplitUpInTwo() {
     // relation, at the beginning one way, split up later
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -618,7 +618,7 @@ public class IterateByContributionRelationsTest {
 
 
   @Test
-  public void testPolygonIntersectingDataPartly() {
+  void testPolygonIntersectingDataPartly() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -646,7 +646,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataOnlyAtBorderLine() {
+  void testPolygonIntersectingDataOnlyAtBorderLine() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -674,7 +674,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataCompletely() {
+  void testPolygonIntersectingDataCompletely() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -702,7 +702,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testPolygonNotIntersectingData() {
+  void testPolygonNotIntersectingData() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -730,7 +730,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testNodeChangeOutsideBbox() {
+  void testNodeChangeOutsideBbox() {
     // relation: 2 ways, each has 5 points, making 1 polygon
     // nodes outside bbox have lon lat change in 2009 and 2011, the latest one affects geometry of
     // polygon inside bbox
@@ -760,7 +760,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataCompletelyTimeIntervalAfterChanges() {
+  void testPolygonIntersectingDataCompletelyTimeIntervalAfterChanges() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -788,7 +788,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterChanges() {
+  void testTimeIntervalAfterChanges() {
 
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -807,7 +807,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testBboxOutsidePolygon() {
+  void testBboxOutsidePolygon() {
     // OSM Polygon coordinates between: minLon 10, maxLon 41, minLat 10, maxLat 45
     // OSHDBBoundingBox outside this coordinates
 
@@ -829,7 +829,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testUnclippedGeom() {
+  void testUnclippedGeom() {
     // relation: 2 ways, each has 5 points, making 1 polygon
     // geometry change of nodes of relation 2009 and 2011
     // OSHDBBoundingBox covers only left side of polygon
@@ -863,7 +863,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testSelfIntersectingPolygonClipped() {
+  void testSelfIntersectingPolygonClipped() {
     // Polygon with self crossing way
     // partly intersected by bbox polygon
     // happy if it works without crashing
@@ -893,7 +893,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testMembersDisappear() {
+  void testMembersDisappear() {
     // relation with one way member(nodes of way have changes in 2009 and 2011), in version 2 member
     // is deleted
     List<IterateAllEntry> result = (new CellIterator(
@@ -919,7 +919,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInVersion2() {
+  void testTimeIntervalAfterDeletionInVersion2() {
     // relation in second version visible = false, time interval includes version 3
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -943,7 +943,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInCurrentVersion() {
+  void testTimeIntervalAfterDeletionInCurrentVersion() {
     // relation in first and third version visible = false, time interval includes version 3
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -967,7 +967,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testExcludingVersion2() {
+  void testExcludingVersion2() {
     // relation in second version visible = false, time interval includes version 3
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -992,7 +992,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testMembersDisappearClipped() {
+  void testMembersDisappearClipped() {
     // relation with one way member(nodes of way have changes in 2009 and 2011), in version 2 member
     // is deleted
     final GeometryFactory geometryFactory = new GeometryFactory();
@@ -1031,7 +1031,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInVersion2Clipped() {
+  void testTimeIntervalAfterDeletionInVersion2Clipped() {
     // relation in second version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -1065,7 +1065,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInCurrentVersionClipped() {
+  void testTimeIntervalAfterDeletionInCurrentVersionClipped() {
     // relation in first and third version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -1098,7 +1098,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testExcludingVersion2Clipped() {
+  void testExcludingVersion2Clipped() {
     // relation in second version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -1132,7 +1132,7 @@ public class IterateByContributionRelationsTest {
   }
 
   @Test
-  public void testClippingPolygonIsVeryBig() {
+  void testClippingPolygonIsVeryBig() {
     // relation with two way members(nodes of ways have changes in 2009 and 2011)
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
@@ -27,14 +27,14 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method.
  */
-public class IterateByContributionTest {
+class IterateByContributionTest {
   private static Connection conn;
 
   /**
    * Set up of test framework, loading H2 driver and connection via jdbc.
    */
   @BeforeAll
-  public static void setUpClass() throws ClassNotFoundException, SQLException {
+  static void setUpClass() throws ClassNotFoundException, SQLException {
     // load H2-support
     Class.forName("org.h2.Driver");
 
@@ -47,16 +47,15 @@ public class IterateByContributionTest {
   }
 
   @AfterAll
-  public static void breakDownClass() throws SQLException {
+  static void breakDownClass() throws SQLException {
     IterateByContributionTest.conn.close();
   }
 
-  public IterateByContributionTest() {
-  }
+  IterateByContributionTest() {}
 
   @SuppressWarnings({"SqlDialectInspection", "SqlNoDataSourceInspection"})
   @Test
-  public void testIssue108() throws SQLException, IOException, ClassNotFoundException,
+  void testIssue108() throws SQLException, IOException, ClassNotFoundException,
       ParseException, OSHDBKeytablesNotFoundException {
     ResultSet oshCellsRawData = conn.prepareStatement(
         "select data from " + TableNames.T_NODES).executeQuery();

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
@@ -20,9 +20,9 @@ import org.heigit.ohsome.oshdb.util.exceptions.OSHDBKeytablesNotFoundException;
 import org.heigit.ohsome.oshdb.util.taginterpreter.DefaultTagInterpreter;
 import org.heigit.ohsome.oshdb.util.tagtranslator.TagTranslator;
 import org.json.simple.parser.ParseException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method.
@@ -33,7 +33,7 @@ public class IterateByContributionTest {
   /**
    * Set up of test framework, loading H2 driver and connection via jdbc.
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws ClassNotFoundException, SQLException {
     // load H2-support
     Class.forName("org.h2.Driver");
@@ -46,7 +46,7 @@ public class IterateByContributionTest {
     );
   }
 
-  @AfterClass
+  @AfterAll
   public static void breakDownClass() throws SQLException {
     IterateByContributionTest.conn.close();
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
@@ -29,7 +29,7 @@ import org.locationtech.jts.geom.Polygon;
  * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on relations except
  * multipolygon relations.
  */
-public class IterateByContributionTypeNotMultipolygonTest {
+class IterateByContributionTypeNotMultipolygonTest {
   private GridOSHRelations oshdbDataGridCell;
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
@@ -38,14 +38,14 @@ public class IterateByContributionTypeNotMultipolygonTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * {@link GridOSHRelations}.
    */
-  public IterateByContributionTypeNotMultipolygonTest() throws IOException {
+  IterateByContributionTypeNotMultipolygonTest() throws IOException {
     osmXmlTestData.add("./src/test/resources/different-timestamps/type-not-multipolygon.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     oshdbDataGridCell = GridOSHFactory.getGridOSHRelations(osmXmlTestData);
   }
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // relation: creation and two geometry changes, but no tag changes
     // relation getting more ways, one disappears
     List<IterateAllEntry> result = (new CellIterator(
@@ -85,7 +85,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // relation: creation and 2 visible changes, but no geometry and no tag changes
     // relation visible tag changed
     List<IterateAllEntry> result = (new CellIterator(
@@ -119,7 +119,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testWaysNotExistent() {
+  void testWaysNotExistent() {
     // relation with two ways, both missing
     assertDoesNotThrow(() -> {
       (new CellIterator(
@@ -139,7 +139,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // relation: creation and two tag changes
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -172,7 +172,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeRefsInWays() {
+  void testGeometryChangeOfNodeRefsInWays() {
     // relation: creation and geometry change of ways, but no tag changes
     // relation, way 109 -inner- and 110 -outer- ways changed node refs-
     List<IterateAllEntry> result = (new CellIterator(
@@ -212,7 +212,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInWay() {
+  void testGeometryChangeOfNodeCoordinatesInWay() {
     // relation: creation
     // relation, way 112 -outer- changed node coordinates
     List<IterateAllEntry> result = (new CellIterator(
@@ -252,7 +252,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
+  void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
     // relation: creation
     // relation, with node members, nodes and nodes in way changed coordinates
     List<IterateAllEntry> result = (new CellIterator(
@@ -292,7 +292,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testGeometryCollection() {
+  void testGeometryCollection() {
     // relation, not valid, should be geometryCollection
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -325,7 +325,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testNodesOfWaysNotExistent() {
+  void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
     assertDoesNotThrow(() -> {
       (new CellIterator(
@@ -345,7 +345,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testVisibleChangeOfNodeInWay() {
+  void testVisibleChangeOfNodeInWay() {
     // relation, way member: node 52 changes visible tag
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -402,7 +402,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTagChangeOfNodeInWay() {
+  void testTagChangeOfNodeInWay() {
     // relation, way member: node 53 changes tags-
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -429,7 +429,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testVisibleChangeOfWay() {
+  void testVisibleChangeOfWay() {
     // relation, way member: way 119 changes visible tag-
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -456,7 +456,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testVisibleChangeOfOneWayOfOuterRing() {
+  void testVisibleChangeOfOneWayOfOuterRing() {
     // relation, 2 way members making outer ring: way 120 changes visible tag later, 121 not
     // ways together making outer ring
     List<IterateAllEntry> result = (new CellIterator(
@@ -491,7 +491,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTagChangeOfWay() {
+  void testTagChangeOfWay() {
     // relation, way member: way 122 changes tags
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -521,7 +521,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testOneOfTwoPolygonDisappears() {
+  void testOneOfTwoPolygonDisappears() {
     // relation, at the beginning two polygons, one disappears later
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -556,7 +556,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testWaySplitUpInTwo() {
+  void testWaySplitUpInTwo() {
     // relation, at the beginning one way, split up later
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -597,7 +597,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
 
 
   @Test
-  public void testPolygonIntersectingDataPartly() {
+  void testPolygonIntersectingDataPartly() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -625,7 +625,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataCompletely() {
+  void testPolygonIntersectingDataCompletely() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -653,7 +653,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testPolygonNotIntersectingData() {
+  void testPolygonNotIntersectingData() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -681,7 +681,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testNodeChangeOutsideBbox() {
+  void testNodeChangeOutsideBbox() {
     // relation: 2 ways, each has 5 points, making polygon
     // nodes outside bbox have lon lat change in 2009 and 2011, the latest one affects geometry of
     // polygon inside bbox
@@ -712,7 +712,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataCompletelyTimeIntervalAfterChanges() {
+  void testPolygonIntersectingDataCompletelyTimeIntervalAfterChanges() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -740,7 +740,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTimeIntervalAfterChanges() {
+  void testTimeIntervalAfterChanges() {
 
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -759,7 +759,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testBboxOutsidePolygon() {
+  void testBboxOutsidePolygon() {
     // OSM Polygon coordinates between: minLon 10, maxLon 41, minLat 10, maxLat 45
     // OSHDBBoundingBox outside this coordinates
 
@@ -780,7 +780,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testSelfIntersectingPolygonClipped() {
+  void testSelfIntersectingPolygonClipped() {
     // Polygon with self crossing way
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -810,7 +810,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testMembersDisappear() {
+  void testMembersDisappear() {
     // relation with one way member(nodes of way have changes in 2009 and 2011), in version 2 member
     // is deleted
     List<IterateAllEntry> result = (new CellIterator(
@@ -835,7 +835,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testMembersDisappearAndPreviousIsNull() {
+  void testMembersDisappearAndPreviousIsNull() {
     // relation in last version without members, previous version visible=false
     // time interval includes only last version
     List<IterateAllEntry> result = (new CellIterator(
@@ -855,7 +855,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInCurrentVersionClipped() {
+  void testTimeIntervalAfterDeletionInCurrentVersionClipped() {
     // relation in first and third version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -121,7 +121,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   @Test
   public void testWaysNotExistent() {
     // relation with two ways, both missing
-    try {
+    assertDoesNotThrow(() -> {
       (new CellIterator(
           new OSHDBTimestamps(
               "2000-01-01T00:00:00Z",
@@ -135,10 +135,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
       )).iterateByContribution(
           oshdbDataGridCell
       ).collect(Collectors.toList());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -330,7 +327,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
-    try {
+    assertDoesNotThrow(() -> {
       (new CellIterator(
           new OSHDBTimestamps(
               "2000-01-01T00:00:00Z",
@@ -344,10 +341,7 @@ public class IterateByContributionTypeNotMultipolygonTest {
       )).iterateByContribution(
           oshdbDataGridCell
       ).collect(Collectors.toList());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
@@ -25,7 +25,7 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on ways.
  */
-public class IterateByContributionWaysTest {
+class IterateByContributionWaysTest {
   private GridOSHWays oshdbDataGridCell;
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
@@ -34,14 +34,14 @@ public class IterateByContributionWaysTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * {@link GridOSHWays}.
    */
-  public IterateByContributionWaysTest() throws IOException {
+  IterateByContributionWaysTest() throws IOException {
     osmXmlTestData.add("./src/test/resources/different-timestamps/way.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     oshdbDataGridCell = GridOSHFactory.getGridOSHWays(osmXmlTestData);
   }
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // way: creation and two geometry changes, but no tag changes
     // way getting more nodes, one disappears
     List<IterateAllEntry> result = (new CellIterator(
@@ -90,7 +90,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeInWay() {
+  void testGeometryChangeOfNodeInWay() {
     // way: creation and geometry change of nodes, but no tag changes
     // way with two then 3 nodes, first two nodes changed lat lon
     List<IterateAllEntry> result = (new CellIterator(
@@ -141,7 +141,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // way: creation and 2 visible changes, but no geometry and no tag changes
     // way visible tag changed
     List<IterateAllEntry> result = (new CellIterator(
@@ -175,7 +175,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // way: creation and two tag changes, one geometry change
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -223,7 +223,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testMultipleChangesOnNodesOfWay() {
+  void testMultipleChangesOnNodesOfWay() {
     // way: nodes have different changes
     // node 12: tag change
     // node 13: visible change
@@ -270,7 +270,7 @@ public class IterateByContributionWaysTest {
 
 
   @Test
-  public void testMultipleChanges() {
+  void testMultipleChanges() {
     // way and nodes have different changes
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -317,7 +317,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testPolygonAreaYesTagDisappears() {
+  void testPolygonAreaYesTagDisappears() {
     // way seems to be polygon with area=yes, later linestring because area=yes deleted
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -357,7 +357,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testPolygonAreaYesNodeDisappears() {
+  void testPolygonAreaYesNodeDisappears() {
     // way seems to be polygon with area=yes, later linestring because one node deleted
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -397,7 +397,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testTimestampInclusion() {
+  void testTimestampInclusion() {
     // rule for contributions that fall exactly at time interval limits:
     // start timestamp: included, end timestamp: excluded
     List<IterateAllEntry> result = (new CellIterator(
@@ -419,7 +419,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testTwoNodesChangedAtSameTimeDifferentChangesets() {
+  void testTwoNodesChangedAtSameTimeDifferentChangesets() {
     // way with two nodes, nodes changed lat lon, both at same time, different changesets
     // which changeset is shown in result.get(1).changeset? -> from node 20, not 21
     List<IterateAllEntry> result = (new CellIterator(
@@ -450,7 +450,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testNodeChangeOutsideBboxIsNotGeometryChange() {
+  void testNodeChangeOutsideBboxIsNotGeometryChange() {
     // way: creation and one geometry change, but no tag changes
     // node 23 outside bbox with lon lat change
     List<IterateAllEntry> result = (new CellIterator(
@@ -477,7 +477,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testNodeChangeOutsideBboxAffectsPartOfLineStringInBbox() {
+  void testNodeChangeOutsideBboxAffectsPartOfLineStringInBbox() {
     // way: creation and one geometry change, but no tag changes
     // node 23 outside bbox with lon lat change, way between 24 and 25 intersects bbox
     // Node 25 outside bbox with lonlat change, way between 24 and 25 changes
@@ -509,7 +509,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testTagChangeOfNodeInWay() {
+  void testTagChangeOfNodeInWay() {
     // way: creation and geometry change of nodes, but no tag changes
     // way with two then 3 nodes, first two nodes changed lat lon
     List<IterateAllEntry> result = (new CellIterator(
@@ -536,7 +536,7 @@ public class IterateByContributionWaysTest {
   }
 
   @Test
-  public void testNodeRefsDeletedInVersion2() {
+  void testNodeRefsDeletedInVersion2() {
     // way with three nodes,  node refs deleted in version 2
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
@@ -17,7 +17,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Polygon;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
@@ -37,7 +37,7 @@ import org.locationtech.jts.geom.Polygon;
  * Tests the {@link CellIterator#iterateByTimestamps(GridOSHEntity)} method on special situations
  * which are related to OSHDB grid cells.
  */
-public class IterateByTimestampNotOsmTypeSpecificTest {
+class IterateByTimestampNotOsmTypeSpecificTest {
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
   private final List<OSHRelation> oshRelations = new ArrayList<>();
@@ -46,7 +46,7 @@ public class IterateByTimestampNotOsmTypeSpecificTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * a list of {@link OSHRelation OSHRelations}.
    */
-  public IterateByTimestampNotOsmTypeSpecificTest() throws IOException {
+  IterateByTimestampNotOsmTypeSpecificTest() throws IOException {
     osmXmlTestData.add("./src/test/resources/different-timestamps/not-osm-type-specific.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     Map<Long, OSHNode> oshNodes = new TreeMap<>();
@@ -82,7 +82,7 @@ public class IterateByTimestampNotOsmTypeSpecificTest {
   }
 
   @Test
-  public void testCellOutsidePolygon() throws IOException {
+  void testCellOutsidePolygon() throws IOException {
     // GridOSHRelations cell-bbox is not covering query polygon
     final GridOSHRelations oshdbDataGridCell = GridOSHRelations.compact(69120, 12, 0, 0, 0, 0,
         oshRelations);
@@ -113,7 +113,7 @@ public class IterateByTimestampNotOsmTypeSpecificTest {
   }
 
   @Test
-  public void testCellCoveringPolygon() throws IOException {
+  void testCellCoveringPolygon() throws IOException {
     // GridOSHRelations cell-bbox is completely covering query polygon
     final GridOSHRelations oshdbDataGridCell = GridOSHRelations.compact(0, 0, 0, 0, 0, 0,
         oshRelations);
@@ -143,7 +143,7 @@ public class IterateByTimestampNotOsmTypeSpecificTest {
   }
 
   @Test
-  public void testCellFullyInsidePolygon() throws IOException {
+  void testCellFullyInsidePolygon() throws IOException {
     // GridOSHRelations cell-bbox is inside query polygon
     final GridOSHRelations oshdbDataGridCell = GridOSHRelations.compact(69120, 12, 0, 0, 0, 0,
         oshRelations);

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -28,7 +28,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -26,7 +26,7 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link CellIterator#iterateByTimestamps(GridOSHEntity)} method on OSM nodes.
  */
-public class IterateByTimestampsNodesTest {
+class IterateByTimestampsNodesTest {
   private final GridOSHNodes oshdbDataGridCell;
   private final OSMXmlReader osmXmlTestData = new OSMXmlReader();
   TagInterpreter areaDecider;
@@ -35,7 +35,7 @@ public class IterateByTimestampsNodesTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * {@link GridOSHNodes}.
    */
-  public IterateByTimestampsNodesTest() throws IOException {
+  IterateByTimestampsNodesTest() throws IOException {
     osmXmlTestData.add("./src/test/resources/different-timestamps/node.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
     oshdbDataGridCell = GridOSHFactory.getGridOSHNodes(osmXmlTestData);
@@ -43,7 +43,7 @@ public class IterateByTimestampsNodesTest {
 
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // node 1: creation and two geometry changes, but no tag changes
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -69,7 +69,7 @@ public class IterateByTimestampsNodesTest {
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // node 2: creation and two tag changes, but no geometry changes
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -101,7 +101,7 @@ public class IterateByTimestampsNodesTest {
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // node 3: creation and 4 visible changes, but no geometry and no tag changes
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -122,7 +122,7 @@ public class IterateByTimestampsNodesTest {
   }
 
   @Test
-  public void testMultipleChanges() {
+  void testMultipleChanges() {
     // node 4: creation and 5 changes:
     // tag and geometry,
     // visible = false,
@@ -171,7 +171,7 @@ public class IterateByTimestampsNodesTest {
   }
 
   @Test
-  public void testTagChangeTagFilterWithSuccess() {
+  void testTagChangeTagFilterWithSuccess() {
     // node: creation then tag changes, but no geometry changes
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -191,7 +191,7 @@ public class IterateByTimestampsNodesTest {
   }
 
   @Test
-  public void testTagChangeTagFilterWithoutSuccess() {
+  void testTagChangeTagFilterWithoutSuccess() {
     // node: creation then tag changes, but no geometry changes
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -211,7 +211,7 @@ public class IterateByTimestampsNodesTest {
   }
 
   @Test
-  public void testTagFilterAndPolygonIntersectingDataPartly() {
+  void testTagFilterAndPolygonIntersectingDataPartly() {
     // lon lat changes, so that node in v2 is outside bbox
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -240,7 +240,7 @@ public class IterateByTimestampsNodesTest {
   }
 
   @Test
-  public void testCoordinatesRelativeToPolygon() throws IOException {
+  void testCoordinatesRelativeToPolygon() throws IOException {
     //different cases of relative position between node coordinate(s) and cell bbox / query polygon
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[4];

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -28,7 +28,7 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link CellIterator#iterateByTimestamps(GridOSHEntity)} method on OSM relations.
  */
-public class IterateByTimestampsRelationsTest {
+class IterateByTimestampsRelationsTest {
   private final GridOSHRelations oshdbDataGridCell;
   TagInterpreter areaDecider;
 
@@ -36,7 +36,7 @@ public class IterateByTimestampsRelationsTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * {@link GridOSHRelations}.
    */
-  public IterateByTimestampsRelationsTest() throws IOException {
+  IterateByTimestampsRelationsTest() throws IOException {
     OSMXmlReader osmXmlTestData = new OSMXmlReader();
     osmXmlTestData.add("./src/test/resources/different-timestamps/polygon.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
@@ -44,7 +44,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // relation: creation and two geometry changes, but no tag changes
     // relation getting more ways, one disappears
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -74,7 +74,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // relation: creation and 2 visible changes, but no geometry and no tag changes
     // relation visible tag changed
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -98,7 +98,7 @@ public class IterateByTimestampsRelationsTest {
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
-  public void testWaysNotExistent() {
+  void testWaysNotExistent() {
     // relation with two ways, both missing
     assertDoesNotThrow(() -> {
       (new CellIterator(
@@ -119,7 +119,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // relation: creation and two tag changes
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -141,7 +141,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeRefsInWays() {
+  void testGeometryChangeOfNodeRefsInWays() {
     // relation: creation and geometry change of ways, but no tag changes
     // relation, way 109 -inner- and 110 -outer- ways changed node refs-
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -173,7 +173,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInWay() {
+  void testGeometryChangeOfNodeCoordinatesInWay() {
     // relation: creation
     // relation, way 112 -outer- changed node coordinates
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -204,7 +204,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
+  void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
     // relation: creation
     // relation, with node members, nodes and nodes in way changed coordinates
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -230,7 +230,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testGeometryCollection() {
+  void testGeometryCollection() {
     // relation, not valid, should be geometryCollection
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -258,7 +258,7 @@ public class IterateByTimestampsRelationsTest {
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
-  public void testNodesOfWaysNotExistent() {
+  void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
     assertDoesNotThrow(() -> {
       (new CellIterator(
@@ -279,7 +279,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testVisibleChangeOfNodeInWay() {
+  void testVisibleChangeOfNodeInWay() {
     // relation, way member: node 52 changes visible tag
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -315,7 +315,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testTagChangeOfNodeInWay() {
+  void testTagChangeOfNodeInWay() {
     // relation, way member: node 53 changes tags-
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -337,7 +337,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testVisibleChangeOfWay() {
+  void testVisibleChangeOfWay() {
     // relation, way member: way 119 changes visible tag-
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -361,7 +361,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testVisibleChangeOfOneWayOfOuterRing() {
+  void testVisibleChangeOfOneWayOfOuterRing() {
     // relation, 2 way members making outer ring: way 120 changes visible tag later, 121 not
     // ways together making outer ring
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -388,7 +388,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testTagChangeOfWay() {
+  void testTagChangeOfWay() {
     // relation, way member: way 122 changes tags
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -414,7 +414,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testOneOfTwoPolygonDisappears() {
+  void testOneOfTwoPolygonDisappears() {
     // relation, at the beginning two polygons, one disappears later
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -441,7 +441,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testWaySplitUpInTwo() {
+  void testWaySplitUpInTwo() {
     // relation, at the beginning one way, split up later
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -470,7 +470,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataPartly() {
+  void testPolygonIntersectingDataPartly() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -500,7 +500,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataOnlyAtBorderLine() {
+  void testPolygonIntersectingDataOnlyAtBorderLine() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -529,7 +529,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataCompletely() {
+  void testPolygonIntersectingDataCompletely() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -559,7 +559,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testPolygonNotIntersectingData() {
+  void testPolygonNotIntersectingData() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -589,7 +589,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testNodeChangeOutsideBbox() {
+  void testNodeChangeOutsideBbox() {
     // relation: 2 ways, each has 5 points, making polygon
     // nodes outside bbox have lon lat change in 2009 and 2011, the latest one affects geometry of
     // polygon inside bbox
@@ -612,7 +612,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testPolygonIntersectingDataCompletelyTimeIntervalAfterChanges() {
+  void testPolygonIntersectingDataCompletelyTimeIntervalAfterChanges() {
 
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -642,7 +642,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterChanges() {
+  void testTimeIntervalAfterChanges() {
 
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -662,7 +662,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testBboxOutsidePolygon() {
+  void testBboxOutsidePolygon() {
 
     List<IterateByTimestampEntry> resultPoly = (new CellIterator(
         new OSHDBTimestamps(
@@ -682,7 +682,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testUnclippedGeom() {
+  void testUnclippedGeom() {
     // relation: 2 ways, each has 5 points, making 1 polygon
     // geometry change of nodes of relation 2009 and 2011
     // OSHDBBoundingBox covers only left side of polygon
@@ -713,7 +713,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testSelfIntersectingPolygonClipped() {
+  void testSelfIntersectingPolygonClipped() {
     // Polygon with self crossing way
     // partly intersected by bbox polygon
     // happy if it works without crashing
@@ -744,7 +744,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testMembersDisappear() {
+  void testMembersDisappear() {
     // relation with one way member(nodes of way have changes in 2009 and 2011), in version 2 member
     // is deleted
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -766,7 +766,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInVersion2() {
+  void testTimeIntervalAfterDeletionInVersion2() {
     // relation in second version visible = false, time interval includes version 3
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -787,7 +787,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInCurrentVersion() {
+  void testTimeIntervalAfterDeletionInCurrentVersion() {
     // relation in first and third version visible = false, time interval includes version 3
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -807,7 +807,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testMembersDisappearClipped() {
+  void testMembersDisappearClipped() {
     // relation with one way member(nodes of way have changes in 2009 and 2011), in version 2 member
     // is deleted
     final GeometryFactory geometryFactory = new GeometryFactory();
@@ -838,7 +838,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInVersion2Clipped() {
+  void testTimeIntervalAfterDeletionInVersion2Clipped() {
     // relation in second version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -868,7 +868,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testTimeIntervalAfterDeletionInCurrentVersionClipped() {
+  void testTimeIntervalAfterDeletionInCurrentVersionClipped() {
     // relation in first and third version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -898,7 +898,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testExcludingVersion2Clipped() {
+  void testExcludingVersion2Clipped() {
     // relation in second version visible = false, time interval includes version 3
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];
@@ -928,7 +928,7 @@ public class IterateByTimestampsRelationsTest {
   }
 
   @Test
-  public void testClippingPolygonIsVeryBig() {
+  void testClippingPolygonIsVeryBig() {
     // relation with two way members(nodes of ways have changes in 2009 and 2011)
     final GeometryFactory geometryFactory = new GeometryFactory();
     Coordinate[] coords = new Coordinate[5];

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -17,7 +17,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -100,7 +100,7 @@ public class IterateByTimestampsRelationsTest {
   @Test
   public void testWaysNotExistent() {
     // relation with two ways, both missing
-    try {
+    assertDoesNotThrow(() -> {
       (new CellIterator(
           new OSHDBTimestamps(
               "2000-01-01T00:00:00Z",
@@ -115,10 +115,7 @@ public class IterateByTimestampsRelationsTest {
       )).iterateByTimestamps(
           oshdbDataGridCell
       ).collect(Collectors.toList());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -263,7 +260,7 @@ public class IterateByTimestampsRelationsTest {
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
-    try {
+    assertDoesNotThrow(() -> {
       (new CellIterator(
           new OSHDBTimestamps(
               "2000-01-01T00:00:00Z",
@@ -278,10 +275,7 @@ public class IterateByTimestampsRelationsTest {
       )).iterateByTimestamps(
           oshdbDataGridCell
       ).collect(Collectors.toList());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
@@ -16,7 +16,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Polygon;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -24,7 +24,7 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link CellIterator#iterateByTimestamps(GridOSHEntity)} method on OSM ways.
  */
-public class IterateByTimestampsWaysTest {
+class IterateByTimestampsWaysTest {
 
   private final GridOSHWays oshdbDataGridCell;
   TagInterpreter areaDecider;
@@ -33,7 +33,7 @@ public class IterateByTimestampsWaysTest {
    * Initialize test framework by loading osm XML file and initializing {@link TagInterpreter} and
    * {@link GridOSHWays}.
    */
-  public IterateByTimestampsWaysTest() throws IOException {
+  IterateByTimestampsWaysTest() throws IOException {
     OSMXmlReader osmXmlTestData = new OSMXmlReader();
     osmXmlTestData.add("./src/test/resources/different-timestamps/way.osm");
     areaDecider = new OSMXmlReaderTagInterpreter(osmXmlTestData);
@@ -41,7 +41,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // way: creation and two geometry changes, but no tag changes
     // way getting more nodes, one disappears
 
@@ -77,7 +77,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testGeometryChangeOfNodeInWay() {
+  void testGeometryChangeOfNodeInWay() {
     // way: creation and geometry change of nodes, but no tag changes
     // way with two then 3 nodes, first two nodes changed lat lon
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -107,7 +107,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // way: creation and 2 visible changes, but no geometry and no tag changes
     // way visible tag changed
 
@@ -132,7 +132,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // way: creation and two tag changes, one geometry change
 
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -168,7 +168,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testMultipleChangesOnNodesOfWay() {
+  void testMultipleChangesOnNodesOfWay() {
     // way: nodes have different changes
     // node 12: tag change
     // node 13: visible change
@@ -199,7 +199,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testMultipleChanges() {
+  void testMultipleChanges() {
     // way and nodes have different changes
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -225,7 +225,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testPolygonAreaYesTagDisappears() {
+  void testPolygonAreaYesTagDisappears() {
     // way seems to be polygon with area=yes, later linestring because area=yes deleted
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -255,7 +255,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testPolygonAreaYesNodeDisappears() {
+  void testPolygonAreaYesNodeDisappears() {
     // way seems to be polygon with area=yes, later linestring because one node deleted
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(
@@ -284,7 +284,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testTimestampInclusion() {
+  void testTimestampInclusion() {
     // rule for contributions that fall exactly at time interval limits:
     // start timestamp: included, end timestamp: excluded
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -305,7 +305,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testNodeChangeOutsideBboxIsNotGeometryChange() {
+  void testNodeChangeOutsideBboxIsNotGeometryChange() {
     // way: creation and one geometry change, but no tag changes
     // node 23 outside bbox with lon lat change, should not be change in geometry inside bbox
     List<IterateByTimestampEntry> result = (new CellIterator(
@@ -328,7 +328,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testNodeChangeOutsideBboxAffectsPartOfLineStringInBbox() {
+  void testNodeChangeOutsideBboxAffectsPartOfLineStringInBbox() {
     // way: creation and one geometry change, but no tag changes
     // node 23 outside bbox with lon lat change, way between 24 and 25 intersects bbox
     // Node 25 outside bbox with lonlat change, way between 24 and 25 changes
@@ -355,7 +355,7 @@ public class IterateByTimestampsWaysTest {
   }
 
   @Test
-  public void testNodeRefsDeletedInVersion2() {
+  void testNodeRefsDeletedInVersion2() {
     // way with three nodes,  node refs deleted in version 2
     List<IterateByTimestampEntry> result = (new CellIterator(
         new OSHDBTimestamps(

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/GeoTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/GeoTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.geometry;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/GeoTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/GeoTest.java
@@ -18,7 +18,7 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link Geo} class.
  */
-public class GeoTest {
+class GeoTest {
   private final GeometryFactory gf = new GeometryFactory();
 
   private Coordinate[] constructCoordinates(double...coordValues) {
@@ -36,7 +36,7 @@ public class GeoTest {
   // Geo.areaOf
 
   @Test
-  public void testAreaPolygon() {
+  void testAreaPolygon() {
     LinearRing outer = constructRing(
         0, 0,
         0, 1,
@@ -61,7 +61,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testAreaMultiPolygon() {
+  void testAreaMultiPolygon() {
     Polygon poly1 = gf.createPolygon(constructRing(
         0, 0,
         0, 1,
@@ -82,7 +82,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testAreaGeometryCollection() {
+  void testAreaGeometryCollection() {
     Polygon poly1 = gf.createPolygon(constructRing(
         0, 0,
         0, 1,
@@ -110,7 +110,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testAreaOther() {
+  void testAreaOther() {
     // other geometry types: area should be returned as zero
     // point
     assertEquals(0.0, Geo.areaOf(gf.createPoint(new Coordinate(0, 0))), 1E-22);
@@ -131,7 +131,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testAreaRealFeatures() {
+  void testAreaRealFeatures() {
     final double relativeDelta = 1E-5; // max 0.001 % error
     // use https://www.openstreetmap.org/way/25316219 state 2020-10-29
     double expectedResult = 5797.767; // calculated with QGIS
@@ -155,7 +155,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testAreaNotNegative() {
+  void testAreaNotNegative() {
     Polygon poly = gf.createPolygon(constructRing(
         0, 0,
         0, 1,
@@ -177,7 +177,7 @@ public class GeoTest {
   // Geo.lengthOf
 
   @Test
-  public void testLengthLineString() {
+  void testLengthLineString() {
     LineString line = gf.createLineString(constructCoordinates(
         0, 0,
         1, 1
@@ -188,7 +188,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testLengthMultiLineString() {
+  void testLengthMultiLineString() {
     LineString line1 = gf.createLineString(constructCoordinates(
         0, 0,
         1, 1
@@ -203,7 +203,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testLengthGeometryCollection() {
+  void testLengthGeometryCollection() {
     LineString line1 = gf.createLineString(constructCoordinates(
         0, 0,
         1, 1
@@ -232,7 +232,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testLengthOther() {
+  void testLengthOther() {
     // other geometry types: area should be returned as zero
     // point
     assertEquals(0.0, Geo.lengthOf(gf.createPoint(new Coordinate(0, 0))), 1E-22);
@@ -253,7 +253,7 @@ public class GeoTest {
   }
 
   @Test
-  public void testLengthRealFeatures() {
+  void testLengthRealFeatures() {
     final double relativeDelta = 1E-3; // max 0.1 % error
     // use https://www.openstreetmap.org/way/25316219 state 2020-10-29
     double expectedResult = 330.201; // calculated with QGIS

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -32,7 +32,7 @@ class OSHDBGeometryBuilderTest {
   private final OSMXmlReader testData = new OSMXmlReader();
   private static final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderTest() {
+  OSHDBGeometryBuilderTest() {
     testData.add("./src/test/resources/geometryBuilder.osh");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -1,9 +1,10 @@
 package org.heigit.ohsome.oshdb.util.geometry;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
@@ -14,8 +15,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.FakeTagInterpreterAreaNever
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
@@ -188,7 +188,7 @@ public class OSHDBGeometryBuilderTest {
       new Coordinate(1, 1),
       new Coordinate(0, 1),
       new Coordinate(0, 0)};
-    Assert.assertArrayEquals(test, geometry.getCoordinates());
+    assertArrayEquals(test, geometry.getCoordinates());
 
     // degenerate bbox: point
     bbox = bboxWgs84Coordinates(0.0, 0.0, 0.0, 0.0);
@@ -199,7 +199,7 @@ public class OSHDBGeometryBuilderTest {
       new Coordinate(0, 0),
       new Coordinate(0, 0),
       new Coordinate(0, 0)};
-    Assert.assertArrayEquals(test, geometry.getCoordinates());
+    assertArrayEquals(test, geometry.getCoordinates());
 
     // degenerate bbox: line
     bbox = bboxWgs84Coordinates(0.0, 0.0, 0.0, 1.0);
@@ -210,6 +210,6 @@ public class OSHDBGeometryBuilderTest {
       new Coordinate(0, 1),
       new Coordinate(0, 1),
       new Coordinate(0, 0)};
-    Assert.assertArrayEquals(test, geometry.getCoordinates());
+    assertArrayEquals(test, geometry.getCoordinates());
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderTest.java
@@ -27,7 +27,7 @@ import org.locationtech.jts.io.WKTReader;
 /**
  * Tests the {@link OSHDBGeometryBuilder} class.
  */
-public class OSHDBGeometryBuilderTest {
+class OSHDBGeometryBuilderTest {
 
   private final OSMXmlReader testData = new OSMXmlReader();
   private static final double DELTA = 1E-6;
@@ -37,7 +37,7 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testPointGetGeometry() {
+  void testPointGetGeometry() {
     OSMEntity entity = testData.nodes().get(1L).get(1);
     OSHDBTimestamp timestamp = TimestampParser.toOSHDBTimestamp("2001-01-01");
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, null);
@@ -47,7 +47,7 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testPointGetGeometryClipped() {
+  void testPointGetGeometryClipped() {
     OSMEntity entity = testData.nodes().get(1L).get(1);
     OSHDBTimestamp timestamp = TimestampParser.toOSHDBTimestamp("2001-01-01");
     // by bbox
@@ -68,7 +68,7 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testWayGetGeometry() {
+  void testWayGetGeometry() {
     // linestring
     OSMEntity entity = testData.ways().get(1L).get(0);
     OSHDBTimestamp timestamp = TimestampParser.toOSHDBTimestamp("2001-01-01");
@@ -99,7 +99,7 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testWayGetGeometryIncomplete() {
+  void testWayGetGeometryIncomplete() {
     // linestring with 3 node references, only 2 present
     OSMEntity entity = testData.ways().get(3L).get(0);
     OSHDBTimestamp timestamp = TimestampParser.toOSHDBTimestamp("2001-01-01");
@@ -121,7 +121,7 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testRelationGetGeometry() {
+  void testRelationGetGeometry() {
     // simplest multipolygon
     OSMEntity entity = testData.relations().get(1L).get(0);
     OSHDBTimestamp timestamp = TimestampParser.toOSHDBTimestamp("2001-01-01");
@@ -139,7 +139,7 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testRelationGetGeometryIncomplete() {
+  void testRelationGetGeometryIncomplete() {
     // multipolygon, missing ring
     OSMEntity entity = testData.relations().get(2L).get(0);
     OSHDBTimestamp timestamp = TimestampParser.toOSHDBTimestamp("2001-01-01");
@@ -162,7 +162,7 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testBoundingGetGeometry() throws ParseException {
+  void testBoundingGetGeometry() throws ParseException {
     Polygon clipPoly =
         OSHDBGeometryBuilder.getGeometry(bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0));
     Geometry expectedPolygon = new WKTReader().read(
@@ -172,13 +172,13 @@ public class OSHDBGeometryBuilderTest {
   }
 
   @Test
-  public void testBoundingBoxOf() {
+  void testBoundingBoxOf() {
     OSHDBBoundingBox bbox = OSHDBGeometryBuilder.boundingBoxOf(new Envelope(-180, 180, -90, 90));
     assertEquals("(-180.0000000,-90.0000000,180.0000000,90.0000000)", bbox.toString());
   }
 
   @Test
-  public void testBoundingBoxGetGeometry() {
+  void testBoundingBoxGetGeometry() {
     // regular bbox
     OSHDBBoundingBox bbox = bboxWgs84Coordinates(0.0, 0.0, 1.0, 1.0);
     Polygon geometry = OSHDBGeometryBuilder.getGeometry(bbox);

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryTest.java
@@ -1,0 +1,57 @@
+package org.heigit.ohsome.oshdb.util.geometry;
+
+import static org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser.toOSHDBTimestamp;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import com.google.common.collect.ListMultimap;
+import org.heigit.ohsome.oshdb.OSHDBTimestamp;
+import org.heigit.ohsome.oshdb.osm.OSMEntity;
+import org.heigit.ohsome.oshdb.osm.OSMNode;
+import org.heigit.ohsome.oshdb.osm.OSMRelation;
+import org.heigit.ohsome.oshdb.osm.OSMWay;
+import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
+import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
+import org.locationtech.jts.geom.Geometry;
+
+public abstract class OSHDBGeometryTest {
+  protected final OSMXmlReader testData = new OSMXmlReader();
+  protected final ListMultimap<Long, OSMNode> nodes;
+  protected final ListMultimap<Long, OSMWay> ways;
+  protected final ListMultimap<Long, OSMRelation> relations;
+  protected final TagInterpreter areaDecider;
+
+  protected OSHDBGeometryTest(String testdata) {
+    testData.add(testdata);
+    nodes = testData.nodes();
+    ways = testData.ways();
+    relations = testData.relations();
+    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+  }
+
+  protected OSMNode nodes(long id, int index) {
+    return nodes.get(id).get(index);
+  }
+
+  protected OSMWay ways(long id, int index) {
+    return ways.get(id).get(index);
+  }
+
+  protected OSMRelation relations(long id, int index) {
+    return relations.get(id).get(index);
+  }
+
+  protected Geometry buildGeometry(OSMEntity entity) {
+    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
+    return buildGeometry(entity, timestamp);
+  }
+
+  protected Geometry buildGeometry(OSMEntity entity, String timestamp) {
+    return buildGeometry(entity, toOSHDBTimestamp(timestamp));
+  }
+
+  protected Geometry buildGeometry(OSMEntity entity, OSHDBTimestamp timestamp) {
+    return assertDoesNotThrow(() ->
+      OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider));
+  }
+}

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
@@ -13,11 +13,11 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link FastBboxInPolygon} class.
  */
-public class FastBboxInPolygonTest {
+class FastBboxInPolygonTest {
   /**
    * Returns a {@link MultiPolygon} of four small squares arranged in a square.
    */
-  public static MultiPolygon createSquareSquareMultiPolygon() {
+  static MultiPolygon createSquareSquareMultiPolygon() {
     GeometryFactory gf = new GeometryFactory();
     Polygon poly1 = getGeometry(bboxWgs84Coordinates(-1.5, -1.5, -0.5, -0.5));
     Polygon poly2 = getGeometry(bboxWgs84Coordinates(0.5, -1.5, 1.5, -0.5));
@@ -27,7 +27,7 @@ public class FastBboxInPolygonTest {
   }
 
   @Test
-  public void testBboxInPolygon() {
+  void testBboxInPolygon() {
     Polygon p = FastPointInPolygonTest.createPolygon();
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
@@ -52,7 +52,7 @@ public class FastBboxInPolygonTest {
 
   @Test
   @SuppressWarnings("java:S5961" /* has to test all cases how bbox and polygon can be aligned */)
-  public void testBboxInPolygonWithHole() {
+  void testBboxInPolygonWithHole() {
     Polygon p = FastPointInPolygonTest.createPolygonWithHole();
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
@@ -86,7 +86,7 @@ public class FastBboxInPolygonTest {
 
   @Test
   @SuppressWarnings("java:S5961" /* has to test all cases how bbox and polygon can be aligned */)
-  public void testBboxInMultiPolygon() {
+  void testBboxInMultiPolygon() {
     MultiPolygon p = FastPointInPolygonTest.createMultiPolygon();
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 
@@ -139,7 +139,7 @@ public class FastBboxInPolygonTest {
   }
 
   @Test
-  public void testBboxInSquareSquareMultiPolygon() {
+  void testBboxInSquareSquareMultiPolygon() {
     MultiPolygon p = createSquareSquareMultiPolygon();
     FastBboxInPolygon bip = new FastBboxInPolygon(p);
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxInPolygonTest.java
@@ -2,10 +2,10 @@ package org.heigit.ohsome.oshdb.util.geometry.fip;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder.getGeometry;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
@@ -11,9 +11,9 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link FastBboxOutsidePolygon} class.
  */
-public class FastBboxOutsidePolygonTest {
+class FastBboxOutsidePolygonTest {
   @Test
-  public void testBboxInPolygon() {
+  void testBboxInPolygon() {
     Polygon p = FastPointInPolygonTest.createPolygon();
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
@@ -38,7 +38,7 @@ public class FastBboxOutsidePolygonTest {
 
   @Test
   @SuppressWarnings("java:S5961" /* has to test all cases how bbox and polygon can be aligned */)
-  public void testBboxInPolygonWithHole() {
+  void testBboxInPolygonWithHole() {
     Polygon p = FastPointInPolygonTest.createPolygonWithHole();
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
@@ -72,7 +72,7 @@ public class FastBboxOutsidePolygonTest {
 
   @Test
   @SuppressWarnings("java:S5961" /* has to test all cases how bbox and polygon can be aligned */)
-  public void testBboxInMultiPolygon() {
+  void testBboxInMultiPolygon() {
     MultiPolygon p = FastPointInPolygonTest.createMultiPolygon();
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 
@@ -125,7 +125,7 @@ public class FastBboxOutsidePolygonTest {
   }
 
   @Test
-  public void testBboxInSquareSquareMultiPolygon() {
+  void testBboxInSquareSquareMultiPolygon() {
     MultiPolygon p = FastBboxInPolygonTest.createSquareSquareMultiPolygon();
     FastBboxOutsidePolygon bop = new FastBboxOutsidePolygon(p);
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastBboxOutsidePolygonTest.java
@@ -1,10 +1,10 @@
 package org.heigit.ohsome.oshdb.util.geometry.fip;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPointInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPointInPolygonTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.geometry.fip;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LinearRing;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPointInPolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPointInPolygonTest.java
@@ -13,11 +13,11 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link FastPointInPolygon} class.
  */
-public class FastPointInPolygonTest {
+class FastPointInPolygonTest {
   /**
    * Returns a reversed "Σ"-shaped concave polygon.
    */
-  public static Polygon createPolygon() {
+  static Polygon createPolygon() {
     final GeometryFactory gf = new GeometryFactory();
     Coordinate[] coordinates = new Coordinate[100];
     coordinates[0] = new Coordinate(0, 0);
@@ -36,7 +36,7 @@ public class FastPointInPolygonTest {
   /**
    * Returns a square with a central square hole.
    */
-  public static Polygon createPolygonWithHole() {
+  static Polygon createPolygonWithHole() {
     final GeometryFactory gf = new GeometryFactory();
     Coordinate[] coordinates1 = new Coordinate[5];
     coordinates1[0] = new Coordinate(4, -1);
@@ -58,7 +58,7 @@ public class FastPointInPolygonTest {
   /**
    * Returns a reversed "Σ"-shaped concave polygon next to a square with a central square hole.
    */
-  public static MultiPolygon createMultiPolygon() {
+  static MultiPolygon createMultiPolygon() {
     GeometryFactory gf = new GeometryFactory();
     Polygon poly1 = createPolygon();
     Polygon poly2 = createPolygonWithHole();
@@ -66,7 +66,7 @@ public class FastPointInPolygonTest {
   }
 
   @Test
-  public void testPointInPolygon() {
+  void testPointInPolygon() {
     Polygon p = createPolygon();
     FastPointInPolygon pip = new FastPointInPolygon(p);
 
@@ -81,7 +81,7 @@ public class FastPointInPolygonTest {
   }
 
   @Test
-  public void testPointInPolygonWithHole() {
+  void testPointInPolygonWithHole() {
     Polygon p = createPolygonWithHole();
     FastPointInPolygon pip = new FastPointInPolygon(p);
 
@@ -96,7 +96,7 @@ public class FastPointInPolygonTest {
   }
 
   @Test
-  public void testPointInMultiPolygon() {
+  void testPointInMultiPolygon() {
     MultiPolygon p = createMultiPolygon();
     FastPointInPolygon pip = new FastPointInPolygon(p);
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
@@ -1,10 +1,10 @@
 package org.heigit.ohsome.oshdb.util.geometry.fip;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperationsTest.java
@@ -15,11 +15,11 @@ import org.locationtech.jts.io.WKTReader;
 /**
  * Tests the {@link FastPolygonOperations} class.
  */
-public class FastPolygonOperationsTest {
+class FastPolygonOperationsTest {
   private final GeometryFactory gf = new GeometryFactory();
 
   @Test
-  public void testEmptyGeometryPolygon() {
+  void testEmptyGeometryPolygon() {
     Polygon p = FastPointInPolygonTest.createPolygon();
     FastPolygonOperations pop = new FastPolygonOperations(p);
 
@@ -30,7 +30,7 @@ public class FastPolygonOperationsTest {
   }
 
   @Test
-  public void testNullGeometryPolygon() {
+  void testNullGeometryPolygon() {
     Polygon p = FastPointInPolygonTest.createPolygon();
     FastPolygonOperations pop = new FastPolygonOperations(p);
 
@@ -38,7 +38,7 @@ public class FastPolygonOperationsTest {
   }
 
   @Test
-  public void testBug206() throws ParseException {
+  void testBug206() throws ParseException {
     // see https://github.com/GIScience/oshdb/pull/204
     String polyWkt = "POLYGON ((-0.0473915 51.5539955,-0.0473872 51.5540543,-0.0473811 51.554121,"
         + "-0.0473792 51.5541494,-0.0473193 51.5541485,-0.047305 51.5540903,-0.0472924 51.5540904,"
@@ -76,7 +76,7 @@ public class FastPolygonOperationsTest {
   }
 
   @Test
-  public void testGeometries() throws ParseException {
+  void testGeometries() throws ParseException {
     String polyWkt = "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 9, 9 9, 9 1, 1 1))";
     Polygon poly = (Polygon) (new WKTReader()).read(polyWkt).buffer(0.1, 200);
     FastPolygonOperations pop = new FastPolygonOperations(poly);

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
@@ -22,7 +22,7 @@ class OSHDBGeometryBuilderTestPolygonIncompleteDataTest extends OSHDBGeometryTes
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private static final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderTestPolygonIncompleteDataTest() {
+  OSHDBGeometryBuilderTestPolygonIncompleteDataTest() {
     super("./src/test/resources/incomplete-osm/polygon.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
@@ -1,16 +1,13 @@
 package org.heigit.ohsome.oshdb.util.geometry.incomplete;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
@@ -20,25 +17,21 @@ import org.locationtech.jts.io.WKTReader;
 /**
  * Tests the {@link OSHDBGeometryBuilder} class on incomplete polygons.
  */
-public class OSHDBGeometryBuilderTestPolygonIncompleteDataTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  TagInterpreter areaDecider;
+class OSHDBGeometryBuilderTestPolygonIncompleteDataTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderTestPolygonIncompleteDataTest() {
-    testData.add("./src/test/resources/incomplete-osm/polygon.osm");
-    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/incomplete-osm/polygon.osm");
   }
 
   @Test
-  public void testSomeNodesOfWayNotExistent() throws ParseException {
+  void testSomeNodesOfWayNotExistent() throws ParseException {
     // Valid multipolygon relation with two ways making up an outer ring, in second ring 2 node
     // references to not existing nodes
     //TODO https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/138
-    OSMEntity entity = testData.relations().get(500L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(500L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -53,14 +46,12 @@ public class OSHDBGeometryBuilderTestPolygonIncompleteDataTest {
   }
 
   @Test
-  public void testWayNotExistent() throws ParseException {
+  void testWayNotExistent() throws ParseException {
     // Valid multipolygon relation with two way references, one way does not exist
     //TODO https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/138
-    OSMEntity entity = testData.relations().get(501L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(501L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
-
     assertEquals(6, result.getCoordinates().length, DELTA);
 
     // compare if coordinates of created points equals the coordinates of polygon
@@ -73,11 +64,9 @@ public class OSHDBGeometryBuilderTestPolygonIncompleteDataTest {
   }
 
   @Test
-  public void testAllNodesOfWayNotExistent() {
+  void testAllNodesOfWayNotExistent() {
     // relation with one way with two nodes, both missing
-    OSMEntity entity1 = testData.relations().get(502L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(502L, 0), timestamp);
+    assertNotNull(result);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.util.geometry.incomplete;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -11,7 +11,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.io.ParseException;
@@ -76,11 +76,8 @@ public class OSHDBGeometryBuilderTestPolygonIncompleteDataTest {
   public void testAllNodesOfWayNotExistent() {
     // relation with one way with two nodes, both missing
     OSMEntity entity1 = testData.relations().get(502L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestWayIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestWayIncompleteDataTest.java
@@ -1,16 +1,12 @@
 package org.heigit.ohsome.oshdb.util.geometry.incomplete;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
@@ -18,52 +14,37 @@ import org.locationtech.jts.geom.LineString;
 /**
  * Tests the {@link OSHDBGeometryBuilder} class on incomplete ways.
  */
-public class OSHDBGeometryBuilderTestWayIncompleteDataTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  TagInterpreter areaDecider;
+class OSHDBGeometryBuilderTestWayIncompleteDataTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
   public OSHDBGeometryBuilderTestWayIncompleteDataTest() {
-    testData.add("./src/test/resources/incomplete-osm/way.osm");
-    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/incomplete-osm/way.osm");
   }
 
-
   @Test
-  public void testOneOfNodesNotExistent() {
+  void testOneOfNodesNotExistent() {
     // Way with four node references, one node missing
-    OSMEntity entity1 = testData.ways().get(100L).get(0);
-    Geometry result1 = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
-    assertTrue(result1 instanceof LineString);
-    assertTrue(result1.isValid());
-    assertTrue(result1.getCoordinates().length >= 3);
+    Geometry result = buildGeometry(ways(100L, 0), timestamp);
+    assertTrue(result instanceof LineString);
+    assertTrue(result.isValid());
+    assertTrue(result.getCoordinates().length >= 3);
   }
 
   @Test
-  public void testWayAreaYes() {
+  void testWayAreaYes() {
     // Way with four nodes, area = yes
-    OSMEntity entity1 = testData.ways().get(101L).get(0);
-    Geometry result1 = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
-    assertTrue(result1 instanceof LineString);
-    assertTrue(result1.isValid());
-    assertTrue(result1.getCoordinates().length >= 3);
+    Geometry result = buildGeometry(ways(101L, 0), timestamp);
+    assertTrue(result instanceof LineString);
+    assertTrue(result.isValid());
+    assertTrue(result.getCoordinates().length >= 3);
   }
 
   @Test
-  public void testAllNodesNotExistent() {
+  void testAllNodesNotExistent() {
     // Way with two nodes, both missing
-    OSMEntity entity1 = testData.ways().get(102L).get(0);
-    Geometry result1 = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
-    assertEquals(0, result1.getCoordinates().length);
-    assertTrue(result1.isValid());
+    Geometry result = buildGeometry(ways(102L, 0), timestamp);
+    assertEquals(0, result.getCoordinates().length);
+    assertTrue(result.isValid());
   }
-
-
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestWayIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestWayIncompleteDataTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.util.geometry.incomplete;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -11,7 +11,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 
@@ -34,13 +34,9 @@ public class OSHDBGeometryBuilderTestWayIncompleteDataTest {
   public void testOneOfNodesNotExistent() {
     // Way with four node references, one node missing
     OSMEntity entity1 = testData.ways().get(100L).get(0);
-    Geometry result1 = null;
-    try {
-      result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result1 = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
+    });
     assertTrue(result1 instanceof LineString);
     assertTrue(result1.isValid());
     assertTrue(result1.getCoordinates().length >= 3);
@@ -50,13 +46,9 @@ public class OSHDBGeometryBuilderTestWayIncompleteDataTest {
   public void testWayAreaYes() {
     // Way with four nodes, area = yes
     OSMEntity entity1 = testData.ways().get(101L).get(0);
-    Geometry result1 = null;
-    try {
-      result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result1 = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
+    });
     assertTrue(result1 instanceof LineString);
     assertTrue(result1.isValid());
     assertTrue(result1.getCoordinates().length >= 3);
@@ -66,14 +58,10 @@ public class OSHDBGeometryBuilderTestWayIncompleteDataTest {
   public void testAllNodesNotExistent() {
     // Way with two nodes, both missing
     OSMEntity entity1 = testData.ways().get(102L).get(0);
-    Geometry result1 = null;
-    try {
-      result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-      assertEquals(0, result1.getCoordinates().length);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result1 = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
+    });
+    assertEquals(0, result1.getCoordinates().length);
     assertTrue(result1.isValid());
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestWayIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestWayIncompleteDataTest.java
@@ -18,7 +18,7 @@ class OSHDBGeometryBuilderTestWayIncompleteDataTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
-  public OSHDBGeometryBuilderTestWayIncompleteDataTest() {
+  OSHDBGeometryBuilderTestWayIncompleteDataTest() {
     super("./src/test/resources/incomplete-osm/way.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
@@ -4,11 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
@@ -55,11 +52,10 @@ class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest extends OSHDBGeometryT
   @Test()
   void testInvalidAccess() {
     // A single node, lat lon changed over time
-    OSMEntity entity = testData.nodes().get(1L).get(0);
+    var testNode = nodes(1L, 0);
     // timestamp before oldest timestamp
-    OSHDBTimestamp timestampBefore =  TimestampParser.toOSHDBTimestamp("2007-01-01T00:00:00Z");
     assertThrows(AssertionError.class, () -> {
-      OSHDBGeometryBuilder.getGeometry(entity, timestampBefore, areaDecider);
+      buildGeometry(testNode, "2007-01-01T00:00:00Z");
     });
   }
 
@@ -85,34 +81,28 @@ class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest extends OSHDBGeometryT
   @Test
   void testVisibleChange() {
     // A single node, visible changes
-    OSMEntity entity = testData.nodes().get(3L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(nodes(3L, 0));
     assertTrue(result instanceof Point);
     assertEquals(1.44, ((Point) result).getX(), DELTA);
     assertEquals(1.24, ((Point) result).getY(), DELTA);
-    OSMEntity entity2 = testData.nodes().get(3L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof Point);
-    assertTrue(result2.isEmpty());
-    OSMEntity entity3 = testData.nodes().get(3L).get(2);
-    OSHDBTimestamp timestamp3 = new OSHDBTimestamp(entity3);
-    Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
-    assertTrue(result3 instanceof Point);
-    assertEquals(1.44, ((Point) result3).getX(), DELTA);
-    assertEquals(1.24, ((Point) result3).getY(), DELTA);
-    OSMEntity entity4 = testData.nodes().get(3L).get(3);
-    OSHDBTimestamp timestamp4 = new OSHDBTimestamp(entity4);
-    Geometry result4 = OSHDBGeometryBuilder.getGeometry(entity4, timestamp4, areaDecider);
-    assertTrue(result4 instanceof Point);
-    assertTrue(result4.isEmpty());
-    OSMEntity entity5 = testData.nodes().get(3L).get(4);
-    OSHDBTimestamp timestamp5 = new OSHDBTimestamp(entity5);
-    Geometry result5 = OSHDBGeometryBuilder.getGeometry(entity5, timestamp5, areaDecider);
-    assertTrue(result5 instanceof Point);
-    assertEquals(1.44, ((Point) result5).getX(), DELTA);
-    assertEquals(1.24, ((Point) result5).getY(), DELTA);
+
+    result = buildGeometry(nodes(3L, 1));
+    assertTrue(result instanceof Point);
+    assertTrue(result.isEmpty());
+
+    result = buildGeometry(nodes(3L, 2));
+    assertTrue(result instanceof Point);
+    assertEquals(1.44, ((Point) result).getX(), DELTA);
+    assertEquals(1.24, ((Point) result).getY(), DELTA);
+
+    result = buildGeometry(nodes(3L, 3));
+    assertTrue(result instanceof Point);
+    assertTrue(result.isEmpty());
+
+    result = buildGeometry(nodes(3L, 4));
+    assertTrue(result instanceof Point);
+    assertEquals(1.44, ((Point) result).getX(), DELTA);
+    assertEquals(1.24, ((Point) result).getY(), DELTA);
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
@@ -7,10 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
@@ -18,51 +16,44 @@ import org.locationtech.jts.geom.Point;
 /**
  * Tests the {@link OSHDBGeometryBuilder} class on OSM nodes.
  */
-public class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  TagInterpreter areaDecider;
+class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest extends OSHDBGeometryTest {
   private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest() {
-    testData.add("./src/test/resources/different-timestamps/node.osm");
-    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/different-timestamps/node.osm");
   }
 
-
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // A single node, lat lon changed over time
-    OSMEntity entity = testData.nodes().get(1L).get(0);
+
     // first appearance
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(nodes(1L, 0));
     assertTrue(result instanceof Point);
     assertEquals(1.42, ((Point) result).getX(), DELTA);
     assertEquals(1.22, ((Point) result).getY(), DELTA);
+
     // second
-    OSMEntity entity2 = testData.nodes().get(1L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof Point);
-    assertEquals(1.42, ((Point) result2).getX(), DELTA);
-    assertEquals(1.225, ((Point) result2).getY(), DELTA);
+    result = buildGeometry(nodes(1L, 1));
+    assertTrue(result instanceof Point);
+    assertEquals(1.42, ((Point) result).getX(), DELTA);
+    assertEquals(1.225, ((Point) result).getY(), DELTA);
+
     // last
-    OSMEntity entity3 = testData.nodes().get(1L).get(2);
-    OSHDBTimestamp timestamp3 = new OSHDBTimestamp(entity3);
-    Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
-    assertTrue(result3 instanceof Point);
-    assertEquals(1.425, ((Point) result3).getX(), DELTA);
-    assertEquals(1.23, ((Point) result3).getY(), DELTA);
+    result = buildGeometry(nodes(1L, 2));
+    assertTrue(result instanceof Point);
+    assertEquals(1.425, ((Point) result).getX(), DELTA);
+    assertEquals(1.23, ((Point) result).getY(), DELTA);
+
     // timestamp after newest timestamp
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-01-01T00:00:00Z");
-    Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entity3, timestampAfter, areaDecider);
-    assertTrue(resultAfter instanceof Point);
-    assertEquals(1.425, ((Point) resultAfter).getX(), DELTA);
-    assertEquals(1.23, ((Point) resultAfter).getY(), DELTA);
+    result = buildGeometry(nodes(1L, 2), "2012-01-01T00:00:00Z");
+    assertTrue(result instanceof Point);
+    assertEquals(1.425, ((Point) result).getX(), DELTA);
+    assertEquals(1.23, ((Point) result).getY(), DELTA);
   }
 
   @Test()
-  public void testInvalidAccess() {
+  void testInvalidAccess() {
     // A single node, lat lon changed over time
     OSMEntity entity = testData.nodes().get(1L).get(0);
     // timestamp before oldest timestamp
@@ -73,30 +64,26 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest {
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // A single node, tags changed over time
-    OSMEntity entity = testData.nodes().get(2L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(nodes(2L, 0));
     assertTrue(result instanceof Point);
     assertEquals(1.43, ((Point) result).getX(), DELTA);
     assertEquals(1.24, ((Point) result).getY(), DELTA);
-    OSMEntity entity2 = testData.nodes().get(2L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof Point);
-    assertEquals(1.43, ((Point) result2).getX(), DELTA);
-    assertEquals(1.24, ((Point) result2).getY(), DELTA);
-    OSMEntity entity3 = testData.nodes().get(2L).get(2);
-    OSHDBTimestamp timestamp3 = new OSHDBTimestamp(entity3.getEpochSecond());
-    Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
-    assertTrue(result3 instanceof Point);
-    assertEquals(1.43, ((Point) result3).getX(), DELTA);
-    assertEquals(1.24, ((Point) result3).getY(), DELTA);
+
+    result = buildGeometry(nodes(2L, 1));
+    assertTrue(result instanceof Point);
+    assertEquals(1.43, ((Point) result).getX(), DELTA);
+    assertEquals(1.24, ((Point) result).getY(), DELTA);
+
+    result = buildGeometry(nodes(2L, 2));
+    assertTrue(result instanceof Point);
+    assertEquals(1.43, ((Point) result).getX(), DELTA);
+    assertEquals(1.24, ((Point) result).getY(), DELTA);
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // A single node, visible changes
     OSMEntity entity = testData.nodes().get(3L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
@@ -129,42 +116,35 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest {
   }
 
   @Test
-  public void testMultipleChanges() {
+  void testMultipleChanges() {
     // A single node, various changes over time
-    OSMEntity entity = testData.nodes().get(4L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(nodes(4L, 0));
     assertTrue(result instanceof Point);
     assertEquals(1.42, ((Point) result).getX(), DELTA);
     assertEquals(1.21, ((Point) result).getY(), DELTA);
-    OSMEntity entity2 = testData.nodes().get(4L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof Point);
-    assertEquals(1.425, ((Point) result2).getX(), DELTA);
-    assertEquals(1.20, ((Point) result2).getY(), DELTA);
-    OSMEntity entity3 = testData.nodes().get(4L).get(2);
-    OSHDBTimestamp timestamp3 = new OSHDBTimestamp(entity3);
-    Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
-    assertTrue(result3 instanceof Point);
-    assertTrue(result3.isEmpty());
-    OSMEntity entity4 = testData.nodes().get(4L).get(3);
-    OSHDBTimestamp timestamp4 = new OSHDBTimestamp(entity4);
-    Geometry result4 = OSHDBGeometryBuilder.getGeometry(entity4, timestamp4, areaDecider);
-    assertTrue(result4 instanceof Point);
-    assertEquals(1.42, ((Point) result4).getX(), DELTA);
-    assertEquals(1.21, ((Point) result4).getY(), DELTA);
-    OSMEntity entity5 = testData.nodes().get(4L).get(4);
-    OSHDBTimestamp timestamp5 = new OSHDBTimestamp(entity5);
-    Geometry result5 = OSHDBGeometryBuilder.getGeometry(entity5, timestamp5, areaDecider);
-    assertTrue(result5 instanceof Point);
-    assertEquals(1.42, ((Point) result5).getX(), DELTA);
-    assertEquals(1.215, ((Point) result5).getY(), DELTA);
-    OSMEntity entity6 = testData.nodes().get(4L).get(5);
-    OSHDBTimestamp timestamp6 = new OSHDBTimestamp(entity6);
-    Geometry result6 = OSHDBGeometryBuilder.getGeometry(entity6, timestamp6, areaDecider);
-    assertTrue(result6 instanceof Point);
-    assertEquals(1.42, ((Point) result6).getX(), DELTA);
-    assertEquals(1.215, ((Point) result6).getY(), DELTA);
+
+    result = buildGeometry(nodes(4L, 1));
+    assertTrue(result instanceof Point);
+    assertEquals(1.425, ((Point) result).getX(), DELTA);
+    assertEquals(1.20, ((Point) result).getY(), DELTA);
+
+    result = buildGeometry(nodes(4L, 2));
+    assertTrue(result instanceof Point);
+    assertTrue(result.isEmpty());
+
+    result = buildGeometry(nodes(4L, 3));
+    assertTrue(result instanceof Point);
+    assertEquals(1.42, ((Point) result).getX(), DELTA);
+    assertEquals(1.21, ((Point) result).getY(), DELTA);
+
+    result = buildGeometry(nodes(4L, 4));
+    assertTrue(result instanceof Point);
+    assertEquals(1.42, ((Point) result).getX(), DELTA);
+    assertEquals(1.215, ((Point) result).getY(), DELTA);
+
+    result = buildGeometry(nodes(4L, 5));
+    assertTrue(result instanceof Point);
+    assertEquals(1.42, ((Point) result).getX(), DELTA);
+    assertEquals(1.215, ((Point) result).getY(), DELTA);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
@@ -19,7 +19,7 @@ import org.locationtech.jts.geom.Point;
 class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest extends OSHDBGeometryTest {
   private static final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest() {
+  OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest() {
     super("./src/test/resources/different-timestamps/node.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest.java
@@ -1,7 +1,8 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmhistorytestdata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -10,7 +11,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 
@@ -60,13 +61,15 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataNodesTest {
     assertEquals(1.23, ((Point) resultAfter).getY(), DELTA);
   }
 
-  @Test(expected = AssertionError.class)
+  @Test()
   public void testInvalidAccess() {
     // A single node, lat lon changed over time
     OSMEntity entity = testData.nodes().get(1L).get(0);
     // timestamp before oldest timestamp
     OSHDBTimestamp timestampBefore =  TimestampParser.toOSHDBTimestamp("2007-01-01T00:00:00Z");
-    OSHDBGeometryBuilder.getGeometry(entity, timestampBefore, areaDecider);
+    assertThrows(AssertionError.class, () -> {
+      OSHDBGeometryBuilder.getGeometry(entity, timestampBefore, areaDecider);
+    });
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmhistorytestdata;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -12,7 +12,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.LineString;
@@ -37,36 +37,31 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation getting more ways, one disappears, last version not valid
     OSMEntity entity = testData.relations().get(500L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
+
     // second version
     OSMEntity entity1 = testData.relations().get(500L).get(1);
     OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
+
     // third version
     OSMEntity entity2 = testData.relations().get(500L).get(2);
     OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    try {
+
+
+    assertDoesNotThrow(() -> {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection || result2 instanceof Polygonal);
       assertEquals(3, result2.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -74,58 +69,46 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation  visible tag changed
     OSMEntity entity = testData.relations().get(501L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // second version
     OSMEntity entity1 = testData.relations().get(501L).get(1);
     OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1.isEmpty());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // third version
     OSMEntity entity2 = testData.relations().get(501L).get(2);
     OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection);
       assertTrue(result2.isValid());
       assertEquals(2, result2.getNumGeometries());
       assertTrue(result2.getGeometryN(0) instanceof LineString);
       assertTrue(result2.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void testWaysNotExistent() {
     // relation with three ways, all not existing
     OSMEntity entity = testData.relations().get(502L).get(0);
-    Geometry result;
-    try {
+
+    assertDoesNotThrow(() -> {
       OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-      result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertTrue(result.isEmpty());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -133,42 +116,33 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation tags changing
     OSMEntity entity = testData.relations().get(503L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // second version
     OSMEntity entity1 = testData.relations().get(503L).get(1);
     OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
       assertEquals(1, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // third version
     OSMEntity entity2 = testData.relations().get(503L).get(2);
     OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection);
       assertTrue(result2.isValid());
       assertEquals(1, result2.getNumGeometries());
       assertTrue(result2.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -176,35 +150,29 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, way 109 -inner- and 110 -outer- ways changed node refs
     OSMEntity entity = testData.relations().get(504L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // second version
     OSMEntity entity1 = testData.relations().get(504L).get(1);
     OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
       assertEquals(2, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
       assertTrue(result1.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // version in between
     OSMEntity entityBetween = testData.relations().get(504L).get(0);
     OSHDBTimestamp timestampBetween =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry resultBetween = OSHDBGeometryBuilder
           .getGeometry(entityBetween, timestampBetween, areaDecider);
       assertTrue(resultBetween instanceof GeometryCollection);
@@ -212,10 +180,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       assertEquals(2, resultBetween.getNumGeometries());
       assertTrue(resultBetween.getGeometryN(0) instanceof LineString);
       assertTrue(resultBetween.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -223,30 +188,24 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, way 112  changed node coordinates
     OSMEntity entity = testData.relations().get(505L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // version after
     OSMEntity entityAfter = testData.relations().get(505L).get(0);
     OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry resultAfter = OSHDBGeometryBuilder
           .getGeometry(entityAfter, timestampAfter, areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertTrue(resultAfter.isValid());
       assertEquals(1, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -254,7 +213,7 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, with node members, nodes changed coordinates
     OSMEntity entity = testData.relations().get(506L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
@@ -262,14 +221,11 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       assertTrue(result.getGeometryN(0) instanceof Point);
       assertTrue(result.getGeometryN(1) instanceof Point);
       assertTrue(result.getGeometryN(2) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // version after
     OSMEntity entityAfter = testData.relations().get(506L).get(0);
     OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
           areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
@@ -278,42 +234,33 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
       assertTrue(resultAfter.getGeometryN(0) instanceof Point);
       assertTrue(resultAfter.getGeometryN(1) instanceof Point);
       assertTrue(resultAfter.getGeometryN(2) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void testGeometryCollection() {
     // relation, not valid, should be a not empty geometryCollection
     OSMEntity entity = testData.relations().get(507L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertEquals(6, result.getNumGeometries());
       assertFalse(result instanceof MultiPolygon);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation with two ways, all nodes not existing
     OSMEntity entity = testData.relations().get(508L).get(0);
-    Geometry result;
-    try {
+
+    assertDoesNotThrow(() -> {
       OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-      result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -322,31 +269,25 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     OSMEntity entity = testData.relations().get(509L).get(0);
     // timestamp where node 52 visible is false
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // version after
     OSMEntity entityAfter = testData.relations().get(509L).get(0);
     // timestamp where node 52 visible is true
     OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2014-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
           areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertTrue(resultAfter.isValid());
       assertEquals(1, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -354,30 +295,24 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, way member: node 53 changes tags, 51 changes coordinates
     OSMEntity entity = testData.relations().get(510L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // version after
     OSMEntity entityAfter = testData.relations().get(510L).get(0);
     OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2014-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry resultAfter = OSHDBGeometryBuilder
           .getGeometry(entityAfter, timestampAfter, areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertTrue(resultAfter.isValid());
       assertEquals(1, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -385,28 +320,22 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, way member: way 119 changes visible tag
     OSMEntity entity = testData.relations().get(511L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // version after, visible false
     OSMEntity entityAfter = testData.relations().get(511L).get(0);
     OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2017-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
           areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertTrue(resultAfter.isEmpty());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -414,31 +343,25 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, 2 way members making outer ring: way 120 changes visible tag later, 121 not
     OSMEntity entity = testData.relations().get(512L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // version after: way 120 does not exit any more
     OSMEntity entityAfter = testData.relations().get(512L).get(0);
     OSHDBTimestamp timestampAfter = TimestampParser.toOSHDBTimestamp("2018-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
           areaDecider);
       assertTrue(resultAfter instanceof GeometryCollection);
       assertEquals(2, resultAfter.getNumGeometries());
       assertTrue(resultAfter.getGeometryN(0) instanceof LineString
           || resultAfter.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -446,42 +369,33 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, way member: way 122 changes tags
     OSMEntity entity = testData.relations().get(513L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // way first version
     OSMEntity entity1 = testData.relations().get(513L).get(0);
     OSHDBTimestamp timestamp1 =  TimestampParser.toOSHDBTimestamp("2009-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
       assertEquals(1, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // way second version
     OSMEntity entity2 = testData.relations().get(513L).get(0);
     OSHDBTimestamp timestamp2 =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection);
       assertTrue(result2.isValid());
       assertEquals(1, result2.getNumGeometries());
       assertTrue(result2.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -489,30 +403,24 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, at the beginning two polygons, one disappears later
     OSMEntity entity = testData.relations().get(514L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // second version
     OSMEntity entity1 = testData.relations().get(514L).get(1);
     OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
       assertEquals(1, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -520,30 +428,24 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, at the beginning one way, split up later into 2 ways
     OSMEntity entity = testData.relations().get(515L).get(0);
     OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertTrue(result.isValid());
       assertEquals(1, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // second version
     OSMEntity entity1 = testData.relations().get(515L).get(1);
     OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result1 instanceof GeometryCollection);
       assertTrue(result1.isValid());
       assertEquals(2, result1.getNumGeometries());
       assertTrue(result1.getGeometryN(0) instanceof LineString);
       assertTrue(result1.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -551,17 +453,14 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation, restriction, role changes
     OSMEntity entity1 = testData.relations().get(518L).get(0);
     OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertEquals(3, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof Point);
       assertTrue(result.getGeometryN(2) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -569,30 +468,24 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTe
     // relation as building with role=part and outline
     OSMEntity entity1 = testData.relations().get(519L).get(0);
     OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertEquals(2, result.getNumGeometries());
       assertTrue(result.getGeometryN(0) instanceof LineString);
       assertTrue(result.getGeometryN(1) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
     // second version
     OSMEntity entity2 = testData.relations().get(519L).get(1);
     OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection);
       assertEquals(3, result2.getNumGeometries());
       assertTrue(result2.getGeometryN(0) instanceof LineString);
       assertTrue(result2.getGeometryN(1) instanceof LineString);
       assertTrue(result2.getGeometryN(2) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java
@@ -20,7 +20,7 @@ import org.locationtech.jts.geom.Polygonal;
 class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest
     extends OSHDBGeometryTest {
 
-  public OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest() {
+  OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest() {
     super("./src/test/resources/different-timestamps/type-not-multipolygon.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest.java
@@ -1,17 +1,11 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmhistorytestdata;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -23,470 +17,324 @@ import org.locationtech.jts.geom.Polygonal;
 /**
  * Tests the {@link OSHDBGeometryBuilder} class on OSM relations except multipolygon relations.
  */
-public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  TagInterpreter areaDecider;
+class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest
+    extends OSHDBGeometryTest {
 
   public OSHDBGeometryBuilderTestOsmHistoryTestDataRelationNotMultipolygonTest() {
-    testData.add("./src/test/resources/different-timestamps/type-not-multipolygon.osm");
-    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/different-timestamps/type-not-multipolygon.osm");
   }
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // relation getting more ways, one disappears, last version not valid
-    OSMEntity entity = testData.relations().get(500L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-    });
+    Geometry result = buildGeometry(relations(500L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
 
     // second version
-    OSMEntity entity1 = testData.relations().get(500L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    assertDoesNotThrow(() -> {
-      Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result1 instanceof GeometryCollection);
-      assertTrue(result1.isValid());
-    });
+    result = buildGeometry(relations(500L, 1));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
 
     // third version
-    OSMEntity entity2 = testData.relations().get(500L).get(2);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-
-
-    assertDoesNotThrow(() -> {
-      Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp2, areaDecider);
-      assertTrue(result2 instanceof GeometryCollection || result2 instanceof Polygonal);
-      assertEquals(3, result2.getNumGeometries());
-    });
+    result = buildGeometry(relations(500L, 2));
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(3, result.getNumGeometries());
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // relation  visible tag changed
-    OSMEntity entity = testData.relations().get(501L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(2, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(501L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(501L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    assertDoesNotThrow(() -> {
-      Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result1.isEmpty());
-    });
+    result = buildGeometry(relations(501L, 1));
+    assertTrue(result.isEmpty());
+
     // third version
-    OSMEntity entity2 = testData.relations().get(501L).get(2);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    assertDoesNotThrow(() -> {
-      Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-      assertTrue(result2 instanceof GeometryCollection);
-      assertTrue(result2.isValid());
-      assertEquals(2, result2.getNumGeometries());
-      assertTrue(result2.getGeometryN(0) instanceof LineString);
-      assertTrue(result2.getGeometryN(1) instanceof LineString);
-    });
+    result = buildGeometry(relations(501L, 2));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
   }
 
   @Test
-  public void testWaysNotExistent() {
+  void testWaysNotExistent() {
     // relation with three ways, all not existing
-    OSMEntity entity = testData.relations().get(502L).get(0);
-
-    assertDoesNotThrow(() -> {
-      OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertTrue(result.isEmpty());
-    });
+    Geometry result = buildGeometry(relations(502L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertTrue(result.isEmpty());
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // relation tags changing
-    OSMEntity entity = testData.relations().get(503L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(1, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(503L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(503L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    assertDoesNotThrow(() -> {
-      Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result1 instanceof GeometryCollection);
-      assertTrue(result1.isValid());
-      assertEquals(1, result1.getNumGeometries());
-      assertTrue(result1.getGeometryN(0) instanceof LineString);
-    });
+    result = buildGeometry(relations(503L, 1));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // third version
-    OSMEntity entity2 = testData.relations().get(503L).get(2);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    assertDoesNotThrow(() -> {
-      Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-      assertTrue(result2 instanceof GeometryCollection);
-      assertTrue(result2.isValid());
-      assertEquals(1, result2.getNumGeometries());
-      assertTrue(result2.getGeometryN(0) instanceof LineString);
-    });
+    result = buildGeometry(relations(503L, 2));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
   }
 
   @Test
-  public void testGeometryChangeOfNodeRefsInWays() {
+  void testGeometryChangeOfNodeRefsInWays() {
     // relation, way 109 -inner- and 110 -outer- ways changed node refs
-    OSMEntity entity = testData.relations().get(504L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(2, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(504L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(504L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    assertDoesNotThrow(() -> {
-      Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result1 instanceof GeometryCollection);
-      assertTrue(result1.isValid());
-      assertEquals(2, result1.getNumGeometries());
-      assertTrue(result1.getGeometryN(0) instanceof LineString);
-      assertTrue(result1.getGeometryN(1) instanceof LineString);
-    });
+    result = buildGeometry(relations(504L, 1));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
+
     // version in between
-    OSMEntity entityBetween = testData.relations().get(504L).get(0);
-    OSHDBTimestamp timestampBetween =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry resultBetween = OSHDBGeometryBuilder
-          .getGeometry(entityBetween, timestampBetween, areaDecider);
-      assertTrue(resultBetween instanceof GeometryCollection);
-      assertTrue(resultBetween.isValid());
-      assertEquals(2, resultBetween.getNumGeometries());
-      assertTrue(resultBetween.getGeometryN(0) instanceof LineString);
-      assertTrue(resultBetween.getGeometryN(1) instanceof LineString);
-    });
+    result = buildGeometry(relations(504L, 0), "2012-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInWay() {
+  void testGeometryChangeOfNodeCoordinatesInWay() {
     // relation, way 112  changed node coordinates
-    OSMEntity entity = testData.relations().get(505L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(1, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(505L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // version after
-    OSMEntity entityAfter = testData.relations().get(505L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry resultAfter = OSHDBGeometryBuilder
-          .getGeometry(entityAfter, timestampAfter, areaDecider);
-      assertTrue(resultAfter instanceof GeometryCollection);
-      assertTrue(resultAfter.isValid());
-      assertEquals(1, resultAfter.getNumGeometries());
-      assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
-    });
+    result = buildGeometry(relations(505L, 0), "2012-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
+  void testGeometryChangeOfNodeCoordinatesInRelationAndWay() {
     // relation, with node members, nodes changed coordinates
-    OSMEntity entity = testData.relations().get(506L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(3, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof Point);
-      assertTrue(result.getGeometryN(1) instanceof Point);
-      assertTrue(result.getGeometryN(2) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(506L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(3, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof Point);
+    assertTrue(result.getGeometryN(1) instanceof Point);
+    assertTrue(result.getGeometryN(2) instanceof LineString);
+
     // version after
-    OSMEntity entityAfter = testData.relations().get(506L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-          areaDecider);
-      assertTrue(resultAfter instanceof GeometryCollection);
-      assertTrue(resultAfter.isValid());
-      assertEquals(3, resultAfter.getNumGeometries());
-      assertTrue(resultAfter.getGeometryN(0) instanceof Point);
-      assertTrue(resultAfter.getGeometryN(1) instanceof Point);
-      assertTrue(resultAfter.getGeometryN(2) instanceof LineString);
-    });
+    result = buildGeometry(relations(506L, 0), "2012-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(3, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof Point);
+    assertTrue(result.getGeometryN(1) instanceof Point);
+    assertTrue(result.getGeometryN(2) instanceof LineString);
   }
 
   @Test
-  public void testGeometryCollection() {
+  void testGeometryCollection() {
     // relation, not valid, should be a not empty geometryCollection
-    OSMEntity entity = testData.relations().get(507L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertEquals(6, result.getNumGeometries());
-      assertFalse(result instanceof MultiPolygon);
-    });
+    Geometry result = buildGeometry(relations(507L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(6, result.getNumGeometries());
+    assertFalse(result instanceof MultiPolygon);
   }
 
   @Test
-  public void testNodesOfWaysNotExistent() {
+  void testNodesOfWaysNotExistent() {
     // relation with two ways, all nodes not existing
-    OSMEntity entity = testData.relations().get(508L).get(0);
-
-    assertDoesNotThrow(() -> {
-      OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-    });
+    Geometry result = buildGeometry(relations(508L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
   }
 
   @Test
-  public void testVisibleChangeOfNodeInWay() {
+  void testVisibleChangeOfNodeInWay() {
     // relation, way member: node 52 changes visible tag
-    OSMEntity entity = testData.relations().get(509L).get(0);
     // timestamp where node 52 visible is false
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(1, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(509L, 0));
     // version after
-    OSMEntity entityAfter = testData.relations().get(509L).get(0);
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // timestamp where node 52 visible is true
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2014-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-          areaDecider);
-      assertTrue(resultAfter instanceof GeometryCollection);
-      assertTrue(resultAfter.isValid());
-      assertEquals(1, resultAfter.getNumGeometries());
-      assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
-    });
+    result = buildGeometry(relations(509L, 0), "2014-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
   }
 
   @Test
-  public void testTagChangeOfNodeInWay() {
+  void testTagChangeOfNodeInWay() {
     // relation, way member: node 53 changes tags, 51 changes coordinates
-    OSMEntity entity = testData.relations().get(510L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(1, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(510L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // version after
-    OSMEntity entityAfter = testData.relations().get(510L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2014-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry resultAfter = OSHDBGeometryBuilder
-          .getGeometry(entityAfter, timestampAfter, areaDecider);
-      assertTrue(resultAfter instanceof GeometryCollection);
-      assertTrue(resultAfter.isValid());
-      assertEquals(1, resultAfter.getNumGeometries());
-      assertTrue(resultAfter.getGeometryN(0) instanceof LineString);
-    });
+    result = buildGeometry(relations(510L, 0), "2014-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
   }
 
   @Test
-  public void testVisibleChangeOfWay() {
+  void testVisibleChangeOfWay() {
     // relation, way member: way 119 changes visible tag
-    OSMEntity entity = testData.relations().get(511L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(1, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(511L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // version after, visible false
-    OSMEntity entityAfter = testData.relations().get(511L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2017-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-          areaDecider);
-      assertTrue(resultAfter instanceof GeometryCollection);
-      assertTrue(resultAfter.isEmpty());
-    });
+    result = buildGeometry(relations(511L, 0), "2017-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isEmpty());
   }
 
   @Test
-  public void testVisibleChangeOfOneWayOfOuterRing() {
+  void testVisibleChangeOfOneWayOfOuterRing() {
     // relation, 2 way members making outer ring: way 120 changes visible tag later, 121 not
-    OSMEntity entity = testData.relations().get(512L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(2, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(512L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
+
     // version after: way 120 does not exit any more
-    OSMEntity entityAfter = testData.relations().get(512L).get(0);
-    OSHDBTimestamp timestampAfter = TimestampParser.toOSHDBTimestamp("2018-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-          areaDecider);
-      assertTrue(resultAfter instanceof GeometryCollection);
-      assertEquals(2, resultAfter.getNumGeometries());
-      assertTrue(resultAfter.getGeometryN(0) instanceof LineString
-          || resultAfter.getGeometryN(1) instanceof LineString);
-    });
+    result = buildGeometry(relations(512L, 0), "2018-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString
+        || result.getGeometryN(1) instanceof LineString);
   }
 
   @Test
-  public void testTagChangeOfWay() {
+  void testTagChangeOfWay() {
     // relation, way member: way 122 changes tags
-    OSMEntity entity = testData.relations().get(513L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(1, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(513L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // way first version
-    OSMEntity entity1 = testData.relations().get(513L).get(0);
-    OSHDBTimestamp timestamp1 =  TimestampParser.toOSHDBTimestamp("2009-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result1 instanceof GeometryCollection);
-      assertTrue(result1.isValid());
-      assertEquals(1, result1.getNumGeometries());
-      assertTrue(result1.getGeometryN(0) instanceof LineString);
-    });
+    result = buildGeometry(relations(513L, 0), "2009-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // way second version
-    OSMEntity entity2 = testData.relations().get(513L).get(0);
-    OSHDBTimestamp timestamp2 =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    assertDoesNotThrow(() -> {
-      Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-      assertTrue(result2 instanceof GeometryCollection);
-      assertTrue(result2.isValid());
-      assertEquals(1, result2.getNumGeometries());
-      assertTrue(result2.getGeometryN(0) instanceof LineString);
-    });
+    result = buildGeometry(relations(513L, 0), "2012-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
   }
 
   @Test
-  public void testOneOfTwoPolygonDisappears() {
+  void testOneOfTwoPolygonDisappears() {
     // relation, at the beginning two polygons, one disappears later
-    OSMEntity entity = testData.relations().get(514L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(2, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(514L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(514L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    assertDoesNotThrow(() -> {
-      Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result1 instanceof GeometryCollection);
-      assertTrue(result1.isValid());
-      assertEquals(1, result1.getNumGeometries());
-      assertTrue(result1.getGeometryN(0) instanceof LineString);
-    });
+    result = buildGeometry(relations(514L, 1));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
   }
 
   @Test
-  public void testWaySplitUpInTwo() {
+  void testWaySplitUpInTwo() {
     // relation, at the beginning one way, split up later into 2 ways
-    OSMEntity entity = testData.relations().get(515L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertTrue(result.isValid());
-      assertEquals(1, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(515L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(1, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(515L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    assertDoesNotThrow(() -> {
-      Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result1 instanceof GeometryCollection);
-      assertTrue(result1.isValid());
-      assertEquals(2, result1.getNumGeometries());
-      assertTrue(result1.getGeometryN(0) instanceof LineString);
-      assertTrue(result1.getGeometryN(1) instanceof LineString);
-    });
+    result = buildGeometry(relations(515L, 1));
+    assertTrue(result instanceof GeometryCollection);
+    assertTrue(result.isValid());
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
   }
 
   @Test
-  public void testRestrictionRoles() {
+  void testRestrictionRoles() {
     // relation, restriction, role changes
-    OSMEntity entity1 = testData.relations().get(518L).get(0);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertEquals(3, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof Point);
-      assertTrue(result.getGeometryN(2) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(518L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(3, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof Point);
+    assertTrue(result.getGeometryN(2) instanceof LineString);
   }
 
   @Test
-  public void testRolesArePartAndOutline() {
+  void testRolesArePartAndOutline() {
     // relation as building with role=part and outline
-    OSMEntity entity1 = testData.relations().get(519L).get(0);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    assertDoesNotThrow(() -> {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertEquals(2, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof LineString);
-    });
+    Geometry result = buildGeometry(relations(519L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(2, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
+
     // second version
-    OSMEntity entity2 = testData.relations().get(519L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    assertDoesNotThrow(() -> {
-      Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-      assertTrue(result2 instanceof GeometryCollection);
-      assertEquals(3, result2.getNumGeometries());
-      assertTrue(result2.getGeometryN(0) instanceof LineString);
-      assertTrue(result2.getGeometryN(1) instanceof LineString);
-      assertTrue(result2.getGeometryN(2) instanceof LineString);
-    });
+    result = buildGeometry(relations(519L, 1));
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(3, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
+    assertTrue(result.getGeometryN(2) instanceof LineString);
   }
-
 }
-

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmhistorytestdata;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -13,7 +13,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.MultiPolygon;
@@ -67,14 +67,11 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     // third version
     OSMEntity entity2 = testData.relations().get(500L).get(2);
     OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    try {
+    assertDoesNotThrow(() -> {
       Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp2, areaDecider);
       assertTrue(result2 instanceof GeometryCollection || result2 instanceof Polygonal);
       assertEquals(3, result2.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -116,13 +113,10 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
   public void testWaysNotExistent() {
     // relation with two ways, both missing
     OSMEntity entity = testData.relations().get(502L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
       OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
@@ -272,29 +266,23 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     // relation, not valid, should be a not empty geometryCollection
     // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/143
     OSMEntity entity = testData.relations().get(507L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
       Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
       assertTrue(result instanceof GeometryCollection);
       assertEquals(6, result.getNumGeometries());
       assertFalse(result instanceof MultiPolygon);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void testNodesOfWaysNotExistent() {
     // relation with two ways, all nodes not existing
     OSMEntity entity = testData.relations().get(508L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
       OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
@@ -1,18 +1,13 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmhistorytestdata;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.osm.OSMRelation;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -25,22 +20,17 @@ import org.locationtech.jts.io.WKTReader;
 /**
  * Tests the {@link OSHDBGeometryBuilder} class on OSM relations.
  */
-public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  TagInterpreter areaDecider;
+class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest extends OSHDBGeometryTest {
   private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest() {
-    testData.add("./src/test/resources/different-timestamps/polygon.osm");
-    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/different-timestamps/polygon.osm");
   }
 
   @Test
-  public void testGeometryChange() throws ParseException {
+  void testGeometryChange() throws ParseException {
     // relation getting more ways, one disappears, last version not valid
-    OSMEntity entity = testData.relations().get(500L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(500L, 0));
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(9, result.getCoordinates().length);
@@ -50,36 +40,30 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(500L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-    assertTrue(result1 instanceof MultiPolygon);
-    assertTrue(result1.isValid());
-    assertEquals(14, result1.getCoordinates().length);
-    Geometry expectedPolygon1 = (new WKTReader()).read(
+    result = buildGeometry(relations(500L, 1));
+    assertTrue(result instanceof MultiPolygon);
+    assertTrue(result.isValid());
+    assertEquals(14, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.31 1.01,7.34 1.01,7.34 1.05, 7.31 1.01)),"
             + "((7.34 1.05, 7.32 1.05, 7.32 1.04, 7.33 1.04, 7.34 1.05)),"
             + "(( 7.32 1.05,7.32 1.07,7.31 1.07,7.31 1.05,7.32 1.05)))"
     );
-    Geometry intersection1 = result1.intersection(expectedPolygon1);
-    assertEquals(expectedPolygon1.getArea(), intersection1.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // third version
-    OSMEntity entity2 = testData.relations().get(500L).get(2);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    assertDoesNotThrow(() -> {
-      Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp2, areaDecider);
-      assertTrue(result2 instanceof GeometryCollection || result2 instanceof Polygonal);
-      assertEquals(3, result2.getNumGeometries());
-    });
+    result = buildGeometry(relations(500L, 2));
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(3, result.getNumGeometries());
   }
 
   @Test
-  public void testVisibleChange() throws ParseException {
+  void testVisibleChange() throws ParseException {
     // relation  visible tag changed
-    OSMEntity entity = testData.relations().get(501L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(501L, 0));
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(10, result.getCoordinates().length);
@@ -89,42 +73,35 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(501L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-    assertTrue(result1.isEmpty());
+    result = buildGeometry(relations(501L, 1));
+    assertTrue(result.isEmpty());
+
     // third version
-    OSMEntity entity2 = testData.relations().get(501L).get(2);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof MultiPolygon);
-    assertTrue(result2.isValid());
-    assertEquals(10, result2.getCoordinates().length);
-    Geometry expectedPolygon2 = (new WKTReader()).read(
+    result = buildGeometry(relations(501L, 2));
+    assertTrue(result instanceof MultiPolygon);
+    assertTrue(result.isValid());
+    assertEquals(10, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.35 1.01, 7.34 1.01,7.34 1.02,7.35 1.02, 7.35 1.01)),"
                + "((7.33 1.04,7.33 1.03, 7.31 1.02, 7.31 1.04, 7.33 1.04)))"
     );
-    Geometry intersection2 = result2.intersection(expectedPolygon2);
-    assertEquals(expectedPolygon2.getArea(), intersection2.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testWaysNotExistent() {
+  void testWaysNotExistent() {
     // relation with two ways, both missing
-    OSMEntity entity = testData.relations().get(502L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-      OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(502L, 0));
+    assertNotNull(result);
   }
 
   @Test
-  public void testTagChange() throws ParseException {
+  void testTagChange() throws ParseException {
     // relation tags changing
-    OSMEntity entity = testData.relations().get(503L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(503L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(5, result.getCoordinates().length);
@@ -133,38 +110,34 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(503L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-    assertTrue(result1 instanceof Polygon);
-    assertTrue(result1.isValid());
-    assertEquals(5, result1.getCoordinates().length);
-    Geometry expectedPolygon1 = (new WKTReader()).read(
+    result = buildGeometry(relations(503L, 1));
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(5, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON((( 7.33 1.05,7.33 1.06,7.32 1.06,7.32 1.05,7.33 1.05)))"
     );
-    Geometry intersection1 = result1.intersection(expectedPolygon1);
-    assertEquals(expectedPolygon1.getArea(), intersection1.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // third version
-    OSMEntity entity2 = testData.relations().get(503L).get(2);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof Polygon);
-    assertTrue(result2.isValid());
-    assertEquals(5, result2.getCoordinates().length);
-    Geometry expectedPolygon2 = (new WKTReader()).read(
+    result = buildGeometry(relations(503L, 2));
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(5, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON((( 7.33 1.05,7.33 1.06,7.32 1.06,7.32 1.05,7.33 1.05)))"
     );
-    Geometry intersection2 = result2.intersection(expectedPolygon2);
-    assertEquals(expectedPolygon2.getArea(), intersection2.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testGeometryChangeOfNodeRefsInWays() throws ParseException {
+  void testGeometryChangeOfNodeRefsInWays() throws ParseException {
     // relation, way 109 -inner- and 110 -outer- ways changed node refs
-    OSMEntity entity = testData.relations().get(504L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(504L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(10, result.getCoordinates().length);
@@ -174,41 +147,36 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(504L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-    assertTrue(result1 instanceof Polygon);
-    assertTrue(result1.isValid());
-    assertEquals(10, result1.getCoordinates().length);
-    Geometry expectedPolygon1 = (new WKTReader()).read(
+    result = buildGeometry(relations(504L, 1));
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(10, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON((( 7.24 1.04, 7.24 1.07, 7.30 1.07, 7.30 1.04, 7.24 1.04),"
             + "( 7.26 1.05,7.265 1.06, 7.28 1.06, 7.265 1.05,7.26 1.05)))"
     );
-    Geometry intersection1 = result1.intersection(expectedPolygon1);
-    assertEquals(expectedPolygon1.getArea(), intersection1.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // version in between
-    OSMEntity entityBetween = testData.relations().get(504L).get(0);
-    OSHDBTimestamp timestampBetween =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    Geometry resultBetween = OSHDBGeometryBuilder.getGeometry(entityBetween, timestampBetween,
-        areaDecider);
-    assertTrue(resultBetween instanceof Polygon);
-    assertTrue(resultBetween.isValid());
-    assertEquals(10, resultBetween.getCoordinates().length);
-    Geometry expectedPolygonBetween = (new WKTReader()).read(
+    result = buildGeometry(relations(504L, 0), "2012-02-01T00:00:00Z");
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(10, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.24 1.04, 7.24 1.07, 7.31 1.07, 7.31 1.04 , 7.24 1.04),"
             + "(7.26 1.055, 7.265 1.06, 7.28 1.06,7.265 1.065, 7.26 1.055)))"
     );
-    Geometry intersectionBetween = resultBetween.intersection(expectedPolygonBetween);
-    assertEquals(expectedPolygonBetween.getArea(), intersectionBetween.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInWay() throws ParseException {
+  void testGeometryChangeOfNodeCoordinatesInWay() throws ParseException {
     // relation, way 112  changed node coordinates
-    OSMEntity entity = testData.relations().get(505L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(505L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(5, result.getCoordinates().length);
@@ -217,27 +185,23 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // version after
-    OSMEntity entityAfter = testData.relations().get(505L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-        areaDecider);
-    assertTrue(resultAfter instanceof Polygon);
-    assertTrue(resultAfter.isValid());
-    assertEquals(5, resultAfter.getCoordinates().length);
-    Geometry expectedPolygonAfter = (new WKTReader()).read(
+    result = buildGeometry(relations(505L, 0), "2012-02-01T00:00:00Z");
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(5, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.24 1.042, 7.242 1.07, 7.305 1.07, 7.295 1.039 , 7.24 1.042)))"
     );
-    Geometry intersectionAfter = resultAfter.intersection(expectedPolygonAfter);
-    assertEquals(expectedPolygonAfter.getArea(), intersectionAfter.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testGeometryChangeOfNodeCoordinatesInRelationAndWay() throws ParseException {
+  void testGeometryChangeOfNodeCoordinatesInRelationAndWay() throws ParseException {
     // relation, with node members, nodes changed coordinates
-    OSMEntity entity = testData.relations().get(506L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(506L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(4, result.getCoordinates().length);
@@ -246,52 +210,40 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // version after
-    OSMEntity entityAfter = testData.relations().get(506L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-        areaDecider);
-    assertTrue(resultAfter instanceof Polygon);
-    assertTrue(resultAfter.isValid());
-    assertEquals(4, resultAfter.getCoordinates().length);
-    Geometry expectedPolygonAfter = (new WKTReader()).read(
+    result = buildGeometry(relations(506L, 0), "2012-02-01T00:00:00Z");
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(4, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.24 1.042, 7.242 1.07, 7.295 1.039 , 7.24 1.042)))"
     );
-    Geometry intersectionAfter = resultAfter.intersection(expectedPolygonAfter);
-    assertEquals(expectedPolygonAfter.getArea(), intersectionAfter.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testGeometryCollection() {
+  void testGeometryCollection() {
     // relation, not valid, should be a not empty geometryCollection
     // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/143
-    OSMEntity entity = testData.relations().get(507L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-      assertTrue(result instanceof GeometryCollection);
-      assertEquals(6, result.getNumGeometries());
-      assertFalse(result instanceof MultiPolygon);
-    });
+    Geometry result = buildGeometry(relations(507L, 0));
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(6, result.getNumGeometries());
+    assertFalse(result instanceof MultiPolygon);
   }
 
   @Test
-  public void testNodesOfWaysNotExistent() {
+  void testNodesOfWaysNotExistent() {
     // relation with two ways, all nodes not existing
-    OSMEntity entity = testData.relations().get(508L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-      OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(508L, 0));
+    assertNotNull(result);
   }
 
   @Test
-  public void testVisibleChangeOfNodeInWay() throws ParseException {
+  void testVisibleChangeOfNodeInWay() throws ParseException {
     // relation, way member: node 52 changes visible tag
-    OSMEntity entity = testData.relations().get(509L).get(0);
-    // timestamp where node 52 visible is false
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(509L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(4, result.getCoordinates().length);
@@ -300,28 +252,23 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // version after
-    OSMEntity entityAfter = testData.relations().get(509L).get(0);
-    // timestamp where node 52 visible is true
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2014-02-01T00:00:00Z");
-    Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-        areaDecider);
-    assertTrue(resultAfter instanceof Polygon);
-    assertTrue(resultAfter.isValid());
-    assertEquals(5, resultAfter.getCoordinates().length);
-    Geometry expectedPolygonAfter = (new WKTReader()).read(
+    result = buildGeometry(relations(509L, 0), "2014-02-01T00:00:00Z");
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(5, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.303 1.042, 7.31 1.06, 7.32 1.07, 7.32 1.04, 7.303 1.042)))"
     );
-    Geometry intersectionAfter = resultAfter.intersection(expectedPolygonAfter);
-    assertEquals(expectedPolygonAfter.getArea(), intersectionAfter.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testTagChangeOfNodeInWay() throws ParseException {
+  void testTagChangeOfNodeInWay() throws ParseException {
     // relation, way member: node 53 changes tags, 51 changes coordinates
-    OSMEntity entity = testData.relations().get(510L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(510L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(4, result.getCoordinates().length);
@@ -330,27 +277,23 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // version after
-    OSMEntity entityAfter = testData.relations().get(510L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2014-02-01T00:00:00Z");
-    Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-        areaDecider);
-    assertTrue(resultAfter instanceof Polygon);
-    assertTrue(resultAfter.isValid());
-    assertEquals(4, resultAfter.getCoordinates().length);
-    Geometry expectedPolygonAfter = (new WKTReader()).read(
+    result = buildGeometry(relations(510L, 0), "2014-02-01T00:00:00Z");
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(4, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.295 1.039, 1.43 1.24, 7.32 1.04, 7.295 1.039)))"
     );
-    Geometry intersectionAfter = resultAfter.intersection(expectedPolygonAfter);
-    assertEquals(expectedPolygonAfter.getArea(), intersectionAfter.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testVisibleChangeOfWay() throws ParseException {
+  void testVisibleChangeOfWay() throws ParseException {
     // relation, way member: way 119 changes visible tag
-    OSMEntity entity = testData.relations().get(511L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(511L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(4, result.getCoordinates().length);
@@ -359,20 +302,16 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // version after, visible false
-    OSMEntity entityAfter = testData.relations().get(511L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2017-02-01T00:00:00Z");
-    Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-        areaDecider);
-    assertTrue(resultAfter.isEmpty());
+    result = buildGeometry(relations(511L, 0), "2017-02-01T00:00:00Z");
+    assertTrue(result.isEmpty());
   }
 
   @Test
-  public void testVisibleChangeOfOneWayOfOuterRing() throws ParseException {
+  void testVisibleChangeOfOneWayOfOuterRing() throws ParseException {
     // relation, 2 way members making outer ring: way 120 changes visible tag later, 121 not
-    OSMEntity entity = testData.relations().get(512L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(512L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(5, result.getCoordinates().length);
@@ -381,21 +320,17 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // version after: way 120 does not exit any more
-    OSMEntity entityAfter = testData.relations().get(512L).get(0);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2018-02-01T00:00:00Z");
-    Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-        areaDecider);
-    assertTrue(resultAfter instanceof GeometryCollection);
-    assertEquals(2, resultAfter.getNumGeometries());
+    result = buildGeometry(relations(512L, 0), "2018-02-01T00:00:00Z");
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(2, result.getNumGeometries());
   }
 
   @Test
-  public void testTagChangeOfWay() throws ParseException {
+  void testTagChangeOfWay() throws ParseException {
     // relation, way member: way 122 changes tags
-    OSMEntity entity = testData.relations().get(513L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(513L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(5, result.getCoordinates().length);
@@ -404,38 +339,34 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // way first version
-    OSMEntity entity1 = testData.relations().get(513L).get(0);
-    OSHDBTimestamp timestamp1 =  TimestampParser.toOSHDBTimestamp("2009-02-01T00:00:00Z");
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-    assertTrue(result1 instanceof Polygon);
-    assertTrue(result1.isValid());
-    assertEquals(5, result1.getCoordinates().length);
-    Geometry expectedPolygon1 = (new WKTReader()).read(
+    result = buildGeometry(relations(513L, 0), "2009-02-01T00:00:00Z");
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(5, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.34 1.01, 7.34 1.05, 7.32 1.05, 7.32 1.04,7.34 1.01)))"
     );
-    Geometry intersection1 = result1.intersection(expectedPolygon1);
-    assertEquals(expectedPolygon1.getArea(), intersection1.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // way second version
-    OSMEntity entity2 = testData.relations().get(513L).get(0);
-    OSHDBTimestamp timestamp2 =  TimestampParser.toOSHDBTimestamp("2012-02-01T00:00:00Z");
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof Polygon);
-    assertTrue(result2.isValid());
-    assertEquals(5, result2.getCoordinates().length);
-    Geometry expectedPolygon2 = (new WKTReader()).read(
+    result = buildGeometry(relations(513L, 0), "2012-02-01T00:00:00Z");
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(5, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.34 1.01, 7.34 1.05, 7.32 1.05, 7.32 1.04,7.34 1.01)))"
     );
-    Geometry intersection2 = result2.intersection(expectedPolygon2);
-    assertEquals(expectedPolygon2.getArea(), intersection2.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testOneOfTwoPolygonDisappears() throws ParseException {
+  void testOneOfTwoPolygonDisappears() throws ParseException {
     // relation getting more ways, one disappears, last version not valid
-    OSMEntity entity = testData.relations().get(514L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(514L, 0));
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(9, result.getCoordinates().length);
@@ -445,26 +376,23 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(514L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-    assertTrue(result1 instanceof Polygon);
-    assertTrue(result1.isValid());
-    assertEquals(5, result1.getCoordinates().length);
-    Geometry expectedPolygon1 = (new WKTReader()).read(
+    result = buildGeometry(relations(514L, 1));
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(5, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON(((7.34 1.05, 7.32 1.05, 7.32 1.04, 7.33 1.04, 7.34 1.05)))"
     );
-    Geometry intersection1 = result1.intersection(expectedPolygon1);
-    assertEquals(expectedPolygon1.getArea(), intersection1.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testWaySplitUpInTwo() throws ParseException {
+  void testWaySplitUpInTwo() throws ParseException {
     // relation, at the beginning one way, split up later into 2 ways
-    OSMEntity entity = testData.relations().get(515L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(515L, 0));
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(5, result.getCoordinates().length);
@@ -473,26 +401,24 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest {
     );
     Geometry intersection = result.intersection(expectedPolygon);
     assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
+
     // second version
-    OSMEntity entity1 = testData.relations().get(515L).get(1);
-    OSHDBTimestamp timestamp1 = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp1, areaDecider);
-    assertTrue(result1 instanceof Polygon);
-    assertTrue(result1.isValid());
-    assertEquals(5, result1.getCoordinates().length);
-    Geometry expectedPolygon1 = (new WKTReader()).read(
+    result = buildGeometry(relations(515L, 1));
+    assertTrue(result instanceof Polygon);
+    assertTrue(result.isValid());
+    assertEquals(5, result.getCoordinates().length);
+    expectedPolygon = (new WKTReader()).read(
         "MULTIPOLYGON((( 7.0 1.04, 7.0 1.6, 7.2 1.6, 7.2 1.04,7.0 1.04)))"
     );
-    Geometry intersection1 = result1.intersection(expectedPolygon1);
-    assertEquals(expectedPolygon1.getArea(), intersection1.getArea(), DELTA);
+    intersection = result.intersection(expectedPolygon);
+    assertEquals(expectedPolygon.getArea(), intersection.getArea(), DELTA);
   }
 
   @Test
-  public void testNullRefEntities() {
+  void testNullRefEntities() {
     // broken rel references (=invalid OSM data) can occur after "partial" data redactions
-    OSMRelation rel = testData.relations().get(524L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(rel);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(rel, timestamp, areaDecider);
+    OSMRelation rel = relations(524L, 0);
+    Geometry result = buildGeometry(rel);
     // no exception should have been thrown at this point
     assertTrue(result.getNumGeometries() < rel.getMembers().length);
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest.java
@@ -23,7 +23,7 @@ import org.locationtech.jts.io.WKTReader;
 class OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest extends OSHDBGeometryTest {
   private static final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest() {
+  OSHDBGeometryBuilderTestOsmHistoryTestDataRelationTest() {
     super("./src/test/resources/different-timestamps/polygon.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmhistorytestdata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -11,7 +11,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Polygon;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
@@ -18,7 +18,7 @@ class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest extends OSHDBGeometryTe
 
   private static final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest() {
+  OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest() {
     super("./src/test/resources/different-timestamps/way.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmhistorytestdata/OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest.java
@@ -3,14 +3,9 @@ package org.heigit.ohsome.oshdb.util.geometry.osmhistorytestdata;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.osm.OSMWay;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.LineString;
@@ -19,14 +14,12 @@ import org.locationtech.jts.geom.Polygon;
 /**
  * Tests the {@link OSHDBGeometryBuilder} class on OSM ways.
  */
-public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  TagInterpreter areaDecider;
+class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest extends OSHDBGeometryTest {
+
   private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest() {
-    testData.add("./src/test/resources/different-timestamps/way.osm");
-    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/different-timestamps/way.osm");
   }
 
   private static void checkLineString(double[][] expectedCoordinates, Geometry result,
@@ -40,194 +33,154 @@ public class OSHDBGeometryBuilderTestOsmHistoryTestDataWaysTest {
   }
 
   @Test
-  public void testGeometryChange() {
+  void testGeometryChange() {
     // Way getting more nodes, one disappears
     // first appearance
-    OSMEntity entity1 = testData.ways().get(100L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    double[][] expectedCoordinates1 = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25}};
-    checkLineString(expectedCoordinates1, result1, 4);
+    Geometry result = buildGeometry(ways(100L, 0));
+    double[][] expectedCoordinates = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25}};
+    checkLineString(expectedCoordinates, result, 4);
+
     // second appearance
-    OSMEntity entity2 = testData.ways().get(100L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    double[][] expectedCoordinates2 = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
+    result = buildGeometry(ways(100L, 1));
+    expectedCoordinates = new double[][]{{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
         {1.42, 1.26}, {1.42, 1.27}, {1.42, 1.28}, {1.43, 1.29}};
-    checkLineString(expectedCoordinates2, result2, 8);
+    checkLineString(expectedCoordinates, result, 8);
+
     // last appearance
-    OSMEntity entity3 = testData.ways().get(100L).get(2);
-    OSHDBTimestamp timestamp3 = new OSHDBTimestamp(entity3);
-    Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
-    double[][] expectedCoordinates3 = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
+    result = buildGeometry(ways(100L, 2));
+    expectedCoordinates = new double[][]{{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
         {1.42, 1.26}, {1.42, 1.28}, {1.43, 1.29}, {1.43, 1.30}, {1.43, 1.31}};
-    checkLineString(expectedCoordinates3, result3, 9);
+    checkLineString(expectedCoordinates, result, 9);
+
     // timestamp after last one
-    OSMEntity entityAfter = testData.ways().get(100L).get(2);
-    OSHDBTimestamp timestampAfter =  TimestampParser.toOSHDBTimestamp("2012-01-01T00:00:00Z");
-    Geometry resultAfter = OSHDBGeometryBuilder.getGeometry(entityAfter, timestampAfter,
-        areaDecider);
-    double[][] expectedCoordinatesAfter = {{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
+    result = buildGeometry(ways(100L, 2), "2012-01-01T00:00:00Z");
+    expectedCoordinates = new double[][]{{1.42, 1.22}, {1.42, 1.23}, {1.42, 1.24}, {1.42, 1.25},
         {1.42, 1.26}, {1.42, 1.28}, {1.43, 1.29}, {1.43, 1.30}, {1.43, 1.31}};
-    checkLineString(expectedCoordinatesAfter, resultAfter, 9);
+    checkLineString(expectedCoordinates, result, 9);
   }
 
   @Test
-  public void testGeometryChangeOfNodeInWay() {
+  void testGeometryChangeOfNodeInWay() {
     // Way with two then three nodes, changing lat lon
     // first appearance
-    OSMEntity entity1 = testData.ways().get(101L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    double[][] expectedCoordinates1 = {{1.42, 1.22}, {1.44, 1.22}};
-    checkLineString(expectedCoordinates1, result1, 2);
+    Geometry result = buildGeometry(ways(101L, 0));
+    double[][] expectedCoordinates = {{1.42, 1.22}, {1.44, 1.22}};
+    checkLineString(expectedCoordinates, result, 2);
+
     // last appearance
-    OSMEntity entity2 = testData.ways().get(101L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    double[][] expectedCoordinates2 = {{1.425, 1.23}, {1.44, 1.23}, {1.43, 1.30}};
-    checkLineString(expectedCoordinates2, result2, 3);
+    result = buildGeometry(ways(101L, 1));
+    expectedCoordinates = new double[][]{{1.425, 1.23}, {1.44, 1.23}, {1.43, 1.30}};
+    checkLineString(expectedCoordinates, result, 3);
+
     // timestamp in between
-    OSHDBTimestamp timestampBetween =  TimestampParser.toOSHDBTimestamp("2009-02-01T00:00:00Z");
-    OSMEntity entityBetween = testData.ways().get(101L).get(0);
-    Geometry resultBetween = OSHDBGeometryBuilder.getGeometry(entityBetween, timestampBetween,
-        areaDecider);
-    double[][] expectedCoordinatesBetween = {{1.42, 1.225}, {1.445, 1.225}};
-    checkLineString(expectedCoordinatesBetween, resultBetween, 2);
+    result = buildGeometry(ways(101L, 0), "2009-02-01T00:00:00Z");
+    expectedCoordinates = new double[][]{{1.42, 1.225}, {1.445, 1.225}};
+    checkLineString(expectedCoordinates, result, 2);
   }
 
   @Test
-  public void testVisibleChange() {
+  void testVisibleChange() {
     // Way visible changed
     // first appearance
-    OSMEntity entity1 = testData.ways().get(102L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertEquals(3, result1.getNumPoints());
+    Geometry result = buildGeometry(ways(102L, 0));
+    assertTrue(result instanceof LineString);
+    assertEquals(3, result.getNumPoints());
 
     // last appearance
-    OSMEntity entity2 = testData.ways().get(102L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2.isEmpty());
+    result = buildGeometry(ways(102L, 1));
+    assertTrue(result.isEmpty());
   }
 
   @Test
-  public void testTagChange() {
+  void testTagChange() {
     // Way tags changed
     // first appearance
-    OSMEntity entity1 = testData.ways().get(103L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertEquals(3, result1.getNumPoints());
-    // second appearance
-    OSMEntity entity2 = testData.ways().get(103L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof LineString);
-    assertEquals(5, result2.getNumPoints());
-    // last appearance
-    OSMEntity entity3 = testData.ways().get(103L).get(1);
-    OSHDBTimestamp timestamp3 = new OSHDBTimestamp(entity3);
-    Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
-    assertTrue(result3 instanceof LineString);
-    assertEquals(5, result3.getNumPoints());
+    Geometry result = buildGeometry(ways(103L, 0));
+    assertTrue(result instanceof LineString);
+    assertEquals(3, result.getNumPoints());
 
+    // second appearance
+    result = buildGeometry(ways(103L, 1));
+    assertTrue(result instanceof LineString);
+    assertEquals(5, result.getNumPoints());
+
+    // last appearance
+    result = buildGeometry(ways(103L, 2));
+    assertTrue(result instanceof LineString);
+    assertEquals(5, result.getNumPoints());
   }
 
   @Test
-  public void testMultipleChangesOnNodesOfWay() {
+  void testMultipleChangesOnNodesOfWay() {
     // Way various things changed
     // first appearance
-    OSMEntity entity1 = testData.ways().get(104L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertEquals(2, result1.getNumPoints());
+    Geometry result = buildGeometry(ways(104L, 0));
+    assertTrue(result instanceof LineString);
+    assertEquals(2, result.getNumPoints());
 
     // last appearance
-    OSMEntity entity2 = testData.ways().get(104L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof LineString);
-    assertEquals(3, result2.getNumPoints());
+    result = buildGeometry(ways(104L, 1));
+    assertTrue(result instanceof LineString);
+    assertEquals(3, result.getNumPoints());
   }
 
   @Test
-  public void testMultipleChangesOnNodesAndWays() {
+  void testMultipleChangesOnNodesAndWays() {
     // way and nodes have different changes
     // first appearance
-    OSMEntity entity1 = testData.ways().get(105L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertEquals(2, result1.getNumPoints());
-    // second appearance
-    OSMEntity entity2 = testData.ways().get(105L).get(1);
-    OSHDBTimestamp timestamp2 = new OSHDBTimestamp(entity2);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp2, areaDecider);
-    assertTrue(result2 instanceof LineString);
-    assertEquals(2, result2.getNumPoints());
-    // third appearance
-    OSMEntity entity3 = testData.ways().get(105L).get(2);
-    OSHDBTimestamp timestamp3 = new OSHDBTimestamp(entity3);
-    Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp3, areaDecider);
-    assertTrue(result3.isEmpty());
-    // last appearance
-    OSMEntity entity4 = testData.ways().get(105L).get(3);
-    OSHDBTimestamp timestamp4 = new OSHDBTimestamp(entity4);
-    Geometry result4 = OSHDBGeometryBuilder.getGeometry(entity4, timestamp4, areaDecider);
-    assertTrue(result4 instanceof LineString);
-    assertEquals(4, result4.getNumPoints());
+    Geometry result = buildGeometry(ways(105L, 0));
+    assertTrue(result instanceof LineString);
+    assertEquals(2, result.getNumPoints());
 
+    // second appearance
+    result = buildGeometry(ways(105L, 1));
+    assertTrue(result instanceof LineString);
+    assertEquals(2, result.getNumPoints());
+
+    // third appearance
+    result = buildGeometry(ways(105L, 2));
+    assertTrue(result.isEmpty());
+
+    // last appearance
+    result = buildGeometry(ways(105L, 3));
+    assertTrue(result instanceof LineString);
+    assertEquals(4, result.getNumPoints());
   }
 
   // MULTIPOLYGON(((1.45 1.45, 1.46 1.45, 1.46 1.44, 1.45 1.44)))
   @Test
-  public void testPolygonAreaYesTagDisappears() {
+  void testPolygonAreaYesTagDisappears() {
     // way seems to be polygon with area=yes, later linestring because area=yes deleted
     // first appearance
-    OSMEntity entity1 = testData.ways().get(106L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof Polygon);
-    assertEquals(5, result1.getNumPoints());
+    Geometry result = buildGeometry(ways(106L, 0));
+    assertTrue(result instanceof Polygon);
+    assertEquals(5, result.getNumPoints());
 
     // last appearance
-    OSMEntity entity4 = testData.ways().get(106L).get(1);
-    OSHDBTimestamp timestamp4 = new OSHDBTimestamp(entity4);
-    Geometry result4 = OSHDBGeometryBuilder.getGeometry(entity4, timestamp4, areaDecider);
-    assertTrue(result4 instanceof LineString);
-    assertEquals(5, result4.getNumPoints());
-  }
-
-
-  @Test
-  public void testPolygonAreaYesNodeDisappears() {
-    // way seems to be polygon with area=yes, later linestring because area=yes deleted
-    // first appearance
-    OSMEntity entity1 = testData.ways().get(107L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(entity1);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof Polygon);
-    assertEquals(5, result1.getNumPoints());
-
-    // last appearance
-    OSMEntity entity4 = testData.ways().get(107L).get(1);
-    OSHDBTimestamp timestamp4 = new OSHDBTimestamp(entity4);
-    Geometry result4 = OSHDBGeometryBuilder.getGeometry(entity4, timestamp4, areaDecider);
-    assertTrue(result4 instanceof LineString);
-    assertEquals(4, result4.getNumPoints());
+    result = buildGeometry(ways(106L, 1));
+    assertTrue(result instanceof LineString);
+    assertEquals(5, result.getNumPoints());
   }
 
   @Test
-  public void testNullRefEntities() {
+  void testPolygonAreaYesNodeDisappears() {
+    // way seems to be polygon with area=yes, later linestring because area=yes deleted
+    // first appearance
+    Geometry result = buildGeometry(ways(107L, 0));
+    assertTrue(result instanceof Polygon);
+    assertEquals(5, result.getNumPoints());
+
+    // last appearance
+    result = buildGeometry(ways(107L, 1));
+    assertTrue(result instanceof LineString);
+    assertEquals(4, result.getNumPoints());
+  }
+
+  @Test
+  void testNullRefEntities() {
     // broken way references (=invalid OSM data) can occur after "partial" data redactions
-    OSMWay way = testData.ways().get(177974941L).get(0);
-    OSHDBTimestamp timestamp = new OSHDBTimestamp(way);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(way, timestamp, areaDecider);
+    OSMWay way = ways(177974941L, 0);
+    Geometry result = buildGeometry(way);
     // no exception should have been thrown at this point
     assertTrue(result.getCoordinates().length < way.getMembers().length);
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
@@ -1,22 +1,20 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmtestdata;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.FakeTagInterpreterAreaMultipolygonAllOuters;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -29,24 +27,19 @@ import org.locationtech.jts.geom.Point;
  *
  * @see <a href="https://github.com/osmcode/osm-testdata/tree/master/grid">osm-testdata</a>
  */
-public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  TagInterpreter areaDecider;
+class OSHDBGeometryBuilderTestOsmTestData1xxTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private static final double DELTA = 1E-6;
 
   public OSHDBGeometryBuilderTestOsmTestData1xxTest() {
-    testData.add("./src/test/resources/osm-testdata/all.osm");
-    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/osm-testdata/all.osm");
   }
 
-
   @Test
-  public void test100() {
+  void test100() {
     // A single node
-    OSMEntity entity = testData.nodes().get(100000L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(nodes(100000L, 0), timestamp);
     assertTrue(result instanceof Point);
     assertEquals(1.02, ((Point) result).getX(), DELTA);
     assertEquals(1.02, ((Point) result).getY(), DELTA);
@@ -59,12 +52,10 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   } */
 
   @Test
-  public void test102() {
+  void test102() {
     // Two nodes at same location
-    OSMEntity entity1 = testData.nodes().get(102000L).get(0);
-    OSMEntity entity2 = testData.nodes().get(102001L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp, areaDecider);
+    Geometry result1 = buildGeometry(nodes(102000L, 0), timestamp);
+    Geometry result2 = buildGeometry(nodes(102001L, 0), timestamp);
     assertTrue(result1 instanceof Point);
     assertTrue(result2 instanceof Point);
     assertEquals(((Point) result2).getX(), ((Point) result1).getX(), DELTA);
@@ -72,12 +63,11 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   }
 
   @Test
-  public void test110() {
+  void test110() {
     // Way with two nodes
-    OSMEntity entity1 = testData.ways().get(110800L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertEquals(2, result1.getCoordinates().length);
+    Geometry result = buildGeometry(ways(110800L, 0), timestamp);
+    assertTrue(result instanceof LineString);
+    assertEquals(2, result.getCoordinates().length);
   }
 
   /* @Test
@@ -87,38 +77,33 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   } */
 
   @Test
-  public void test112() {
+  void test112() {
     // Closed way with four nodes
-    OSMEntity entity1 = testData.ways().get(112800L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertEquals(5, result1.getCoordinates().length);
+    Geometry result = buildGeometry(ways(112800L, 0), timestamp);
+    assertTrue(result instanceof LineString);
+    assertEquals(5, result.getCoordinates().length);
     assertEquals(
-        ((LineString) result1).getCoordinateN(result1.getNumPoints() - 1),
-        ((LineString) result1).getCoordinateN(0)
+        ((LineString) result).getCoordinateN(result.getNumPoints() - 1),
+        ((LineString) result).getCoordinateN(0)
     );
   }
 
   @Test
-  public void test113() {
+  void test113() {
     // Two separate ways
-    OSMEntity entity1 = testData.ways().get(113800L).get(0);
-    OSMEntity entity2 = testData.ways().get(113801L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp, areaDecider);
+    Geometry result1 = buildGeometry(ways(113800L, 0), timestamp);
+    Geometry result2 = buildGeometry(ways(113801L, 0), timestamp);
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertFalse(result1.crosses(result2));
   }
 
   @Test
-  public void test114() {
+  void test114() {
     // Two ways connected end-to-beginning
-    OSMEntity entity1 = testData.ways().get(114800L).get(0);
-    OSMEntity entity2 = testData.ways().get(114801L).get(0);
     TagInterpreter areaDecider = new FakeTagInterpreterAreaMultipolygonAllOuters();
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp, areaDecider);
+    Geometry result1 = OSHDBGeometryBuilder.getGeometry(ways(114800L, 0), timestamp, areaDecider);
+    Geometry result2 = OSHDBGeometryBuilder.getGeometry(ways(114801L, 0), timestamp, areaDecider);
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertEquals(
@@ -128,12 +113,10 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   }
 
   @Test
-  public void test115() {
+  void test115() {
     // Two ways connected end-to-end
-    OSMEntity entity1 = testData.ways().get(115800L).get(0);
-    OSMEntity entity2 = testData.ways().get(115801L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp, areaDecider);
+    Geometry result1 = buildGeometry(ways(115800L, 0), timestamp);
+    Geometry result2 = buildGeometry(ways(115801L, 0), timestamp);
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertEquals(
@@ -143,14 +126,11 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   }
 
   @Test
-  public void test116() {
+  void test116() {
     // Three ways connected in a closed loop
-    OSMEntity entity1 = testData.ways().get(116800L).get(0);
-    OSMEntity entity2 = testData.ways().get(116801L).get(0);
-    OSMEntity entity3 = testData.ways().get(116802L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp, areaDecider);
-    Geometry result3 = OSHDBGeometryBuilder.getGeometry(entity3, timestamp, areaDecider);
+    Geometry result1 = buildGeometry(ways(116800L, 0), timestamp);
+    Geometry result2 = buildGeometry(ways(116801L, 0), timestamp);
+    Geometry result3 = buildGeometry(ways(116802L, 0), timestamp);
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertTrue(result3 instanceof LineString);
@@ -172,57 +152,45 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   }
 
   @Test
-  public void test120() {
+  void test120() {
     // Way without any nodes
-    OSMEntity entity1 = testData.ways().get(120800L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(ways(120800L, 0), timestamp);
+    assertNotNull(result);
   }
 
   @Test
-  public void test121() {
+  void test121() {
     // Way with a single node
-    OSMEntity entity1 = testData.ways().get(121800L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(ways(121800L, 0), timestamp);
+    assertNotNull(result);
   }
 
   @Test
-  public void test122() {
+  void test122() {
     // Same node twice in way
-    OSMEntity entity1 = testData.ways().get(122800L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(ways(122800L, 0), timestamp);
+    assertNotNull(result);
   }
 
   @Test
-  public void test123() {
+  void test123() {
     // Way with two nodes at same position
-    OSMEntity entity1 = testData.ways().get(123800L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(ways(123800L, 0), timestamp);
+    assertNotNull(result);
   }
 
   @Test
-  public void test124() {
+  void test124() {
     // Way with three nodes, first two nodes have the same position
-    OSMEntity entity1 = testData.ways().get(124800L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(ways(124800L, 0), timestamp);
+    assertNotNull(result);
   }
 
   @Test
-  public void test130() {
+  void test130() {
     // Crossing ways without common node
-    OSMEntity entity1 = testData.ways().get(130800L).get(0);
-    OSMEntity entity2 = testData.ways().get(130801L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp, areaDecider);
+    Geometry result1 = buildGeometry(ways(130800L, 0), timestamp);
+    Geometry result2 = buildGeometry(ways(130801L, 0), timestamp);
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertTrue(result1.crosses(result2));
@@ -235,12 +203,10 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   }
 
   @Test
-  public void test131() {
+  void test131() {
     // Crossing ways with common node
-    OSMEntity entity1 = testData.ways().get(131800L).get(0);
-    OSMEntity entity2 = testData.ways().get(131801L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp, areaDecider);
+    Geometry result1 = buildGeometry(ways(131800L, 0), timestamp);
+    Geometry result2 = buildGeometry(ways(131801L, 0), timestamp);
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertTrue(result1.intersects(result2));
@@ -253,12 +219,10 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   }
 
   @Test
-  public void test132() {
+  void test132() {
     // Crossing ways without common node, but crossing node at same position
-    OSMEntity entity1 = testData.ways().get(132800L).get(0);
-    OSMEntity entity2 = testData.ways().get(132801L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    Geometry result2 = OSHDBGeometryBuilder.getGeometry(entity2, timestamp, areaDecider);
+    Geometry result1 = buildGeometry(ways(132800L, 0), timestamp);
+    Geometry result2 = buildGeometry(ways(132801L, 0), timestamp);
     assertTrue(result1 instanceof LineString);
     assertTrue(result2 instanceof LineString);
     assertTrue(result1.crosses(result2));
@@ -272,44 +236,40 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   }
 
   @Test
-  public void test133() {
+  void test133() {
     // Self-crossing way without common node
-    OSMEntity entity1 = testData.ways().get(133800L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
+    Geometry result = buildGeometry(ways(133800L, 0), timestamp);
+    assertTrue(result instanceof LineString);
     // If a LineString intersects like that, isSimple() will return false as self-intersection is
     // not allowed for Simple Geometries.
-    assertFalse(result1.isSimple());
+    assertFalse(result.isSimple());
     // punkt mit punkt, linie bilden, crosses
     GeometryFactory geometryFactory = new GeometryFactory();
-    Coordinate[] xy1 = new Coordinate[]{(((LineString) result1).getCoordinateN(0)),
-        (((LineString) result1).getCoordinateN(1))};
+    Coordinate[] xy1 = new Coordinate[]{(((LineString) result).getCoordinateN(0)),
+        (((LineString) result).getCoordinateN(1))};
     LineString lineString1 = geometryFactory.createLineString(xy1);
-    Coordinate[] xy2 = new Coordinate[]{(((LineString) result1).getCoordinateN(2)),
-        (((LineString) result1).getCoordinateN(3))};
+    Coordinate[] xy2 = new Coordinate[]{(((LineString) result).getCoordinateN(2)),
+        (((LineString) result).getCoordinateN(3))};
     LineString lineString2 = geometryFactory.createLineString(xy2);
     assertTrue(lineString1.crosses(lineString2));
-    assertEquals(4, result1.getCoordinates().length);
+    assertEquals(4, result.getCoordinates().length);
   }
 
   @Test
-  public void test134() {
+  void test134() {
     // Self-crossing way with common node
-    OSMEntity entity1 = testData.ways().get(134800L).get(0);
-    Geometry result1 = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    assertTrue(result1 instanceof LineString);
-    assertFalse(result1.isSimple());
+    Geometry result = buildGeometry(ways(134800L, 0), timestamp);
+    assertTrue(result instanceof LineString);
+    assertFalse(result.isSimple());
     // punkt mit punkt, linie bilden, crosses
     GeometryFactory geometryFactory = new GeometryFactory();
-    Coordinate[] xy1 = new Coordinate[]{(((LineString) result1).getCoordinateN(0)),
-        (((LineString) result1).getCoordinateN(2))};
+    Coordinate[] xy1 = new Coordinate[]{(((LineString) result).getCoordinateN(0)),
+        (((LineString) result).getCoordinateN(2))};
     LineString lineString1 = geometryFactory.createLineString(xy1);
-    Coordinate[] xy2 = new Coordinate[]{(((LineString) result1).getCoordinateN(3)),
-        (((LineString) result1).getCoordinateN(5))};
+    Coordinate[] xy2 = new Coordinate[]{(((LineString) result).getCoordinateN(3)),
+        (((LineString) result).getCoordinateN(5))};
     LineString lineString2 = geometryFactory.createLineString(xy2);
     assertTrue(lineString1.intersects(lineString2));
-    assertEquals(6, result1.getCoordinates().length);
+    assertEquals(6, result.getCoordinates().length);
   }
-
-
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
@@ -32,7 +32,7 @@ class OSHDBGeometryBuilderTestOsmTestData1xxTest extends OSHDBGeometryTest {
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private static final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderTestOsmTestData1xxTest() {
+  OSHDBGeometryBuilderTestOsmTestData1xxTest() {
     super("./src/test/resources/osm-testdata/all.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData1xxTest.java
@@ -1,10 +1,10 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmtestdata;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -17,7 +17,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryFactory;
@@ -175,60 +175,45 @@ public class OSHDBGeometryBuilderTestOsmTestData1xxTest {
   public void test120() {
     // Way without any nodes
     OSMEntity entity1 = testData.ways().get(120800L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void test121() {
     // Way with a single node
     OSMEntity entity1 = testData.ways().get(121800L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void test122() {
     // Same node twice in way
     OSMEntity entity1 = testData.ways().get(122800L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void test123() {
     // Way with two nodes at same position
     OSMEntity entity1 = testData.ways().get(123800L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void test124() {
     // Way with three nodes, first two nodes have the same position
     OSMEntity entity1 = testData.ways().get(124800L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -22,7 +22,7 @@ class OSHDBGeometryBuilderTestOsmTestData3xxTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
-  public OSHDBGeometryBuilderTestOsmTestData3xxTest() {
+  OSHDBGeometryBuilderTestOsmTestData3xxTest() {
     super("./src/test/resources/osm-testdata/all.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -27,8 +27,7 @@ class OSHDBGeometryBuilderTestOsmTestData3xxTest extends OSHDBGeometryTest {
   }
 
   private Geometry buildEntityGeometry(long id) {
-    OSMEntity entity = nodes(id, 0);
-    return OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    return buildGeometry(nodes(id, 0), timestamp);
   }
 
   @Test

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -36,7 +36,7 @@ class OSHDBGeometryBuilderTestOsmTestData3xxTest extends OSHDBGeometryTest {
     // Normal node with uid (and user name)
     Geometry result = buildEntityGeometry(200000L);
     assertTrue(result instanceof Point);
-    int entityUid = testData.nodes().get(200000L).get(0).getUserId();
+    int entityUid = nodes(200000L, 0).getUserId();
     assertEquals(1, entityUid);
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -7,10 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
@@ -20,24 +18,21 @@ import org.locationtech.jts.geom.Point;
  *
  * @see <a href="https://github.com/osmcode/osm-testdata/tree/master/grid">osm-testdata</a>
  */
-public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  TagInterpreter areaDecider;
+class OSHDBGeometryBuilderTestOsmTestData3xxTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
   public OSHDBGeometryBuilderTestOsmTestData3xxTest() {
-    testData.add("./src/test/resources/osm-testdata/all.osm");
-    areaDecider = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/osm-testdata/all.osm");
   }
 
   private Geometry buildEntityGeometry(long id) {
-    OSMEntity entity = testData.nodes().get(id).get(0);
+    OSMEntity entity = nodes(id, 0);
     return OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
   }
 
   @Test
-  public void test300() {
+  void test300() {
     // Normal node with uid (and user name)
     Geometry result = buildEntityGeometry(200000L);
     assertTrue(result instanceof Point);
@@ -46,7 +41,7 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
   }
 
   @Test()
-  public void test301() {
+  void test301() {
     assertDoesNotThrow(() -> {
       // Empty username on node should not happen
       buildEntityGeometry(201000L);
@@ -54,7 +49,7 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
   }
 
   @Test
-  public void test302() {
+  void test302() {
     // No uid and no user name means user is anonymous
     // user name is not priority
     int entityUid = testData.nodes().get(202000L).get(0).getUserId();
@@ -62,14 +57,14 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
   }
 
   @Test
-  public void test303() {
+  void test303() {
     // uid 0 is the anonymous user
     int entityUid = testData.nodes().get(203000L).get(0).getUserId();
     assertEquals(0, entityUid);
   }
 
   @Test()
-  public void test304() {
+  void test304() {
     assertDoesNotThrow(() -> {
       // negative user ids are not allowed (but -1 could have been meant as anonymous user)
       buildEntityGeometry(204000L);
@@ -77,16 +72,15 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
   }
 
   @Test()
-  public void test305() {
+  void test305() {
     assertDoesNotThrow(() -> {
       // uid < 0 and username is inconsistent and definitely wrong
       buildEntityGeometry(205000L);
     });
-
   }
 
   @Test()
-  public void test306() {
+  void test306() {
     assertDoesNotThrow(() -> {
       // 250 characters in username is okay
       // user name is not priority
@@ -95,7 +89,7 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
   }
 
   @Test()
-  public void test307() {
+  void test307() {
     assertDoesNotThrow(() -> {
       // 260 characters in username is too long
       buildEntityGeometry(207000L);

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -52,7 +52,7 @@ class OSHDBGeometryBuilderTestOsmTestData3xxTest extends OSHDBGeometryTest {
   void test302() {
     // No uid and no user name means user is anonymous
     // user name is not priority
-    int entityUid = testData.nodes().get(202000L).get(0).getUserId();
+    int entityUid = nodes(202000L, 0).getUserId();
     assertTrue(entityUid < 1);
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -1,7 +1,8 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmtestdata;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -10,7 +11,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 
@@ -44,10 +45,12 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
     assertEquals(1, entityUid);
   }
 
-  @Test(expected = Test.None.class /* no exception expected */)
+  @Test()
   public void test301() {
-    // Empty username on node should not happen
-    buildEntityGeometry(201000L);
+    assertDoesNotThrow(() -> {
+      // Empty username on node should not happen
+      buildEntityGeometry(201000L);
+    });
   }
 
   @Test
@@ -65,28 +68,37 @@ public class OSHDBGeometryBuilderTestOsmTestData3xxTest {
     assertEquals(0, entityUid);
   }
 
-  @Test(expected = Test.None.class /* no exception expected */)
+  @Test()
   public void test304() {
-    // negative user ids are not allowed (but -1 could have been meant as anonymous user)
-    buildEntityGeometry(204000L);
+    assertDoesNotThrow(() -> {
+      // negative user ids are not allowed (but -1 could have been meant as anonymous user)
+      buildEntityGeometry(204000L);
+    });
   }
 
-  @Test(expected = Test.None.class /* no exception expected */)
+  @Test()
   public void test305() {
-    // uid < 0 and username is inconsistent and definitely wrong
-    buildEntityGeometry(205000L);
+    assertDoesNotThrow(() -> {
+      // uid < 0 and username is inconsistent and definitely wrong
+      buildEntityGeometry(205000L);
+    });
+
   }
 
-  @Test(expected = Test.None.class /* no exception expected */)
+  @Test()
   public void test306() {
-    // 250 characters in username is okay
-    // user name is not priority
-    buildEntityGeometry(206000L);
+    assertDoesNotThrow(() -> {
+      // 250 characters in username is okay
+      // user name is not priority
+      buildEntityGeometry(206000L);
+    });
   }
 
-  @Test(expected = Test.None.class /* no exception expected */)
+  @Test()
   public void test307() {
-    // 260 characters in username is too long
-    buildEntityGeometry(207000L);
+    assertDoesNotThrow(() -> {
+      // 260 characters in username is too long
+      buildEntityGeometry(207000L);
+    });
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData3xxTest.java
@@ -59,7 +59,7 @@ class OSHDBGeometryBuilderTestOsmTestData3xxTest extends OSHDBGeometryTest {
   @Test
   void test303() {
     // uid 0 is the anonymous user
-    int entityUid = testData.nodes().get(203000L).get(0).getUserId();
+    int entityUid = nodes(203000L, 0).getUserId();
     assertEquals(0, entityUid);
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -1,12 +1,11 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmtestdata;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
@@ -37,8 +36,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test700() {
     // Polygon with one closed way.
-    OSMEntity entity = testData.ways().get(700800L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(ways(700800L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -61,8 +59,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test701() throws ParseException {
     // Valid multipolygon relation with two ways (4 points) making up an outer ring.
-    OSMEntity entity = testData.relations().get(701900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(701900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -79,8 +76,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test702() throws ParseException {
     // Valid multipolygon relation with two ways (8 points) making up an outer ring."
-    OSMEntity entity = testData.relations().get(702900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(702900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -98,8 +94,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test703() throws ParseException {
     // Valid multipolygon relation with two ways (8 points) making up an outer ring."
-    OSMEntity entity = testData.relations().get(703900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(703900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -117,8 +112,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test704() throws ParseException {
     // Valid multipolygon relation with three ways making up an outer ring in the form of a cross.
-    OSMEntity entity = testData.relations().get(704900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(704900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -137,8 +131,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test705() throws ParseException {
     // Valid multipolygon relation with three ways making up an outer ring. Contains concave and
     // convex parts.
-    OSMEntity entity = testData.relations().get(705900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(705900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -157,8 +150,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test706() throws ParseException {
     // Valid multipolygon relation with three ways making up two outer rings that touch in one
     // point.
-    OSMEntity entity = testData.relations().get(706900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(706900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -176,8 +168,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test707() throws ParseException {
     // Valid multipolygon relation with three ways making up two separate outer rings.
-    OSMEntity entity = testData.relations().get(707900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(707900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -195,8 +186,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test708() throws ParseException {
     // Valid multipolygon relation with three ways making up two separate outer rings.
-    OSMEntity entity = testData.relations().get(708900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(708900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -216,8 +206,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test709() throws ParseException {
     // Valid multipolygon relation with four ways making up three outer rings touching in three
     // points.
-    OSMEntity entity = testData.relations().get(709900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(709900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(3, result.getNumGeometries());
@@ -237,10 +226,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test710() {
     // Invalid multipolygon relation: Three ways make up two outer rings, but the outer rings
     // overlap.
-    OSMEntity entity1 = testData.relations().get(710900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(710900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
@@ -248,10 +234,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test711() {
     // Invalid multipolygon relation: Two ways, both containing one of the segments."
-    OSMEntity entity1 = testData.relations().get(711900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(711900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
@@ -259,10 +242,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test714() {
     // Invalid multipolygon relation: Open ring.
-    OSMEntity entity1 = testData.relations().get(714900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(714900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(1, result.getNumGeometries());
   }
@@ -270,10 +250,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test715() {
     // Invalid multipolygon relation: Two open rings
-    OSMEntity entity1 = testData.relations().get(715900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(715900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
@@ -284,8 +261,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test720() throws ParseException {
     // "Multipolygon with one outer and one inner ring. They are both oriented clockwise and have
     // the correct role.
-    OSMEntity entity = testData.relations().get(720900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(720900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -326,8 +302,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test724() throws ParseException {
     // Multipolygon with one outer and one inner ring and a bit more complex geometry and nodes not
     // in order
-    OSMEntity entity = testData.relations().get(724900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(724900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -345,8 +320,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test725() throws ParseException {
     // Valid multipolygon with one concave outer ring and no inner ring.
-    OSMEntity entity = testData.relations().get(725900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(725900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -375,8 +349,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test728() throws ParseException {
     // Multipolygon with one simple outer ring and a node member
-    OSMEntity entity = testData.relations().get(728900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(728900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -394,8 +367,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test729() throws ParseException {
     // Valid multipolygon with second outer ring in inner ring.
-    OSMEntity entity = testData.relations().get(729900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(729900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertFalse((result.getGeometryN(1)).intersects((result.getGeometryN(0))));
@@ -416,8 +388,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test730() throws ParseException {
     // Valid multipolygon with one outer and three inner rings with correct roles
-    OSMEntity entity = testData.relations().get(730900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(730900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(3, ((Polygon) result).getNumInteriorRing());
@@ -438,8 +409,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test731() throws ParseException {
     // "Valid complex multipolygon with one outer and two inner rings made up of several ways. Roles
     // are tagged correctly
-    OSMEntity entity = testData.relations().get(731900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(731900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(2, ((Polygon) result).getNumInteriorRing());
@@ -460,8 +430,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test732() throws ParseException {
     // Valid multipolygon with two outer rings, one containing an inner. One ring contains a node
     // twice in succession in data.osm
-    OSMEntity entity = testData.relations().get(732900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(732900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -494,30 +463,21 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test740() {
     // Invalid multipolygon because the outer ring crosses itself.
-    OSMEntity entity1 = testData.relations().get(740900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(740900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test741() {
     // Invalid multipolygon with a line only as 'outer ring'
-    OSMEntity entity1 = testData.relations().get(741900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(741900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test742() {
     // Invalid multipolygon because of a 'spike'
-    OSMEntity entity1 = testData.relations().get(742900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(742900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
@@ -530,10 +490,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test744() {
     // Invalid multipolygon with single outer ring not closed.
-    OSMEntity entity1 = testData.relations().get(744900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(744900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
@@ -541,10 +498,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test745() {
     // Impossible multipolygon out of one way.
-    OSMEntity entity1 = testData.relations().get(745900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(745900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(1, result.getNumGeometries());
   }
@@ -552,48 +506,35 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test746() {
     // Impossible multipolygon out of two ways.
-    OSMEntity entity1 = testData.relations().get(746900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(746900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test747() {
     // Invalid multipolygon because there are two nodes with same location. Created from relation
-    OSMEntity entity1 = testData.relations().get(747900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(747900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test748() {
     // Invalid multipolygon because there are two nodes with same location. Created from way
-    OSMEntity entity1 = testData.ways().get(748800L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(ways(748800L, 0), timestamp);
     assertTrue(result instanceof LineString);
   }
 
   @Test
   void test749() {
     // Valid multipolygon with two outer rings
-    OSMEntity entity1 = testData.ways().get(749800L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(ways(749800L, 0), timestamp);
     assertTrue(result instanceof LineString);
   }
 
   @Test
   void test750() throws ParseException {
     // "Valid OSM multipolygon with touching inner rings."
-    OSMEntity entity = testData.relations().get(750900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(750900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -611,8 +552,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test751() throws ParseException {
     // "Valid OSM multipolygon with touching inner rings."
-    OSMEntity entity = testData.relations().get(751900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(751900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -631,38 +571,28 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test752() {
     // Touching inner without common nodes
-    OSMEntity entity1 = testData.relations().get(752900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(752900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test753() {
     // Touching inner with one common node missing.
-    OSMEntity entity1 = testData.relations().get(753900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(753900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test754() {
     // Inner ring touching outer, but not in node
-    OSMEntity entity1 = testData.relations().get(754900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(754900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test755() throws ParseException {
     // Inner ring touching outer in node.
-    OSMEntity entity = testData.relations().get(755900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(755900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -680,20 +610,14 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test756() {
     // Inner ring touches outer ring in line, no common nodes
-    OSMEntity entity1 = testData.relations().get(756900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(756900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test757() {
     // Inner ring touches outer ring in line using common nodes.
-    OSMEntity entity1 = testData.relations().get(757900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(757900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
@@ -734,8 +658,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test763() throws ParseException {
     // Valid multipolygon with four outer rings touching in a single point
-    OSMEntity entity = testData.relations().get(763900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(763900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result.getGeometryN(0)).getNumInteriorRing());
@@ -759,8 +682,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test764() throws ParseException {
     // Valid multipolygon with one outer ring and four inner rings touching in a single point.
-    OSMEntity entity = testData.relations().get(764900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(764900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(4, ((Polygon) result).getNumInteriorRing());
@@ -803,10 +725,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test768() {
     // Multipolygon with two overlapping ways
-    OSMEntity entity1 = testData.relations().get(768900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(768900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
@@ -819,10 +738,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test771() {
     // Multipolygon with two outer rings touching in single point, but no common node there
-    OSMEntity entity1 = testData.relations().get(771900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(771900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
@@ -830,8 +746,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test772() throws ParseException {
     // Multipolygon with two inner rings touching in single node
-    OSMEntity entity = testData.relations().get(772900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(772900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(2, ((Polygon) result).getNumInteriorRing());
@@ -850,10 +765,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test773() {
     // Multipolygon with two inner rings touching in single point, but no common node there.
-    OSMEntity entity1 = testData.relations().get(773900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(773900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
@@ -861,8 +773,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test774() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/124
     // Multipolygon with two outer rings touching in two nodes.
-    OSMEntity entity = testData.relations().get(774900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(774900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -906,8 +817,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
     */
     // https://github.com/GIScience/oshdb/issues/123
     // Multipolygon with two outer rings and two inner rings touching in two nodes
-    OSMEntity entity = testData.relations().get(777900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(777900L, 0), timestamp);
     assertTrue(result instanceof Polygonal);
 
     // compare if coordinates of created points equals the coordinates of polygon
@@ -935,8 +845,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
     */
     // https://github.com/GIScience/oshdb/issues/123
     // Multipolygon with two outer rings and two inner rings touching in two nodes
-    OSMEntity entity = testData.relations().get(778900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(778900L, 0), timestamp);
     assertTrue(result instanceof Polygonal);
   }
 
@@ -944,8 +853,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test779() throws ParseException {
     // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/137
     // Multipolygon with two outer rings and two inner rings touching in two nodes
-    OSMEntity entity = testData.relations().get(779900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(779900L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -965,10 +873,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test780() {
     // Way with different nodes as start and endpoint, but same location of those nodes
-    OSMEntity entity1 = testData.ways().get(780800L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(ways(780800L, 0), timestamp);
     assertTrue(result instanceof LineString);
   }
 
@@ -976,10 +881,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test781() {
     // Multipolygon with one outer ring from single way that has different end-nodes, but they have
     // same location
-    OSMEntity entity1 = testData.relations().get(781900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(781900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
@@ -987,10 +889,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test782() {
     // Multipolygon with correct outer ring, but inner ring made up out of two ways where locations
     // match but not node ids
-    OSMEntity entity1 = testData.relations().get(782900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(782900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
@@ -998,8 +897,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test783() throws ParseException {
     // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/131
     // Valid OSM multipolygon with multiple touching inner rings
-    OSMEntity entity = testData.relations().get(783900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(783900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -1018,8 +916,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   void test784() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/129
     // Valid OSM multipolygon with multiple touching inner rings
-    OSMEntity entity = testData.relations().get(784900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(784900L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -1047,8 +944,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
     */
     // https://github.com/GIScience/oshdb/issues/129
     // Valid OSM multipolygon with two touching inner rings leaving an empty area.
-    OSMEntity entity = testData.relations().get(785900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
+    Geometry result = buildGeometry(relations(785900L, 0), timestamp);
     assertTrue(result instanceof Polygonal);
     // compare if coordinates of created points equals the coordinates of polygon
     Geometry expectedPolygon = (new WKTReader()).read(
@@ -1063,39 +959,29 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test790() {
     // Multipolygon relation containing the same way twice.
-    OSMEntity entity1 = testData.relations().get(790900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(790900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test791() {
     // Multipolygon relation containing the two ways using the same nodes in the same order
-    OSMEntity entity1 = testData.relations().get(791900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(791900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   void test792() {
     // Multipolygon relation containing two ways using the same nodes in different order
-    OSMEntity entity1 = testData.relations().get(792900L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(792900L, 0), timestamp);
+    assertNotNull(result);
   }
 
   @Test
   void test793() {
     // Multipolygon relation containing the two ways using nearly the same nodes
-    OSMEntity entity1 = testData.relations().get(793900L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(793900L, 0), timestamp);
+    assertNotNull(result);
   }
 
   /* @Test
@@ -1107,9 +993,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   @Test
   void test795() {
     // Multipolygon with one outer and one duplicated inner ring
-    OSMEntity entity1 = testData.relations().get(795900L).get(0);
-    assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
-    });
+    Geometry result = buildGeometry(relations(795900L, 0), timestamp);
+    assertNotNull(result);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.util.geometry.osmtestdata;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -12,7 +12,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.LineString;
@@ -244,56 +244,44 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     // Invalid multipolygon relation: Three ways make up two outer rings, but the outer rings
     // overlap.
     OSMEntity entity1 = testData.relations().get(710900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertEquals(2, result.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(2, result.getNumGeometries());
   }
 
   @Test
   public void test711() {
     // Invalid multipolygon relation: Two ways, both containing one of the segments."
     OSMEntity entity1 = testData.relations().get(711900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertEquals(2, result.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(2, result.getNumGeometries());
   }
 
   @Test
   public void test714() {
     // Invalid multipolygon relation: Open ring.
     OSMEntity entity1 = testData.relations().get(714900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertEquals(1, result.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(1, result.getNumGeometries());
   }
 
   @Test
   public void test715() {
     // Invalid multipolygon relation: Two open rings
     OSMEntity entity1 = testData.relations().get(715900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertEquals(2, result.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(2, result.getNumGeometries());
   }
 
 
@@ -513,39 +501,30 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test740() {
     // Invalid multipolygon because the outer ring crosses itself.
     OSMEntity entity1 = testData.relations().get(740900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test741() {
     // Invalid multipolygon with a line only as 'outer ring'
     OSMEntity entity1 = testData.relations().get(741900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test742() {
     // Invalid multipolygon because of a 'spike'
     OSMEntity entity1 = testData.relations().get(742900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   /* @Test
@@ -558,80 +537,62 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test744() {
     // Invalid multipolygon with single outer ring not closed.
     OSMEntity entity1 = testData.relations().get(744900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertEquals(2, result.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(2, result.getNumGeometries());
   }
 
   @Test
   public void test745() {
     // Impossible multipolygon out of one way.
     OSMEntity entity1 = testData.relations().get(745900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertEquals(1, result.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(1, result.getNumGeometries());
   }
 
   @Test
   public void test746() {
     // Impossible multipolygon out of two ways.
     OSMEntity entity1 = testData.relations().get(746900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test747() {
     // Invalid multipolygon because there are two nodes with same location. Created from relation
     OSMEntity entity1 = testData.relations().get(747900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test748() {
     // Invalid multipolygon because there are two nodes with same location. Created from way
     OSMEntity entity1 = testData.ways().get(748800L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof LineString);
   }
 
   @Test
   public void test749() {
     // Valid multipolygon with two outer rings
     OSMEntity entity1 = testData.ways().get(749800L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof LineString);
   }
 
   @Test
@@ -677,39 +638,30 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test752() {
     // Touching inner without common nodes
     OSMEntity entity1 = testData.relations().get(752900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test753() {
     // Touching inner with one common node missing.
     OSMEntity entity1 = testData.relations().get(753900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test754() {
     // Inner ring touching outer, but not in node
     OSMEntity entity1 = testData.relations().get(754900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
@@ -735,26 +687,20 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test756() {
     // Inner ring touches outer ring in line, no common nodes
     OSMEntity entity1 = testData.relations().get(756900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test757() {
     // Inner ring touches outer ring in line using common nodes.
     OSMEntity entity1 = testData.relations().get(757900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   /* @Test
@@ -864,13 +810,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test768() {
     // Multipolygon with two overlapping ways
     OSMEntity entity1 = testData.relations().get(768900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   /* @Test
@@ -883,14 +826,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test771() {
     // Multipolygon with two outer rings touching in single point, but no common node there
     OSMEntity entity1 = testData.relations().get(771900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-      assertEquals(2, result.getNumGeometries());
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
+    assertEquals(2, result.getNumGeometries());
   }
 
   @Test
@@ -917,13 +857,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test773() {
     // Multipolygon with two inner rings touching in single point, but no common node there.
     OSMEntity entity1 = testData.relations().get(773900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
@@ -1035,13 +972,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test780() {
     // Way with different nodes as start and endpoint, but same location of those nodes
     OSMEntity entity1 = testData.ways().get(780800L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof LineString);
   }
 
   @Test
@@ -1049,13 +983,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     // Multipolygon with one outer ring from single way that has different end-nodes, but they have
     // same location
     OSMEntity entity1 = testData.relations().get(781900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
@@ -1063,13 +994,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     // Multipolygon with correct outer ring, but inner ring made up out of two ways where locations
     // match but not node ids
     OSMEntity entity1 = testData.relations().get(782900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
@@ -1142,50 +1070,38 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test790() {
     // Multipolygon relation containing the same way twice.
     OSMEntity entity1 = testData.relations().get(790900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test791() {
     // Multipolygon relation containing the two ways using the same nodes in the same order
     OSMEntity entity1 = testData.relations().get(791900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
   public void test792() {
     // Multipolygon relation containing two ways using the same nodes in different order
     OSMEntity entity1 = testData.relations().get(792900L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   @Test
   public void test793() {
     // Multipolygon relation containing the two ways using nearly the same nodes
     OSMEntity entity1 = testData.relations().get(793900L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 
   /* @Test
@@ -1198,11 +1114,8 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   public void test795() {
     // Multipolygon with one outer and one duplicated inner ring
     OSMEntity entity1 = testData.relations().get(795900L).get(0);
-    try {
+    assertDoesNotThrow(() -> {
       OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    });
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -8,10 +8,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -27,23 +25,20 @@ import org.locationtech.jts.io.WKTReader;
  *
  * @see <a href="https://github.com/osmcode/osm-testdata/tree/master/grid">osm-testdata</a>
  */
-public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  private final TagInterpreter tagInterpreter;
+class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private static final double DELTA = 1E-8;
 
   public OSHDBGeometryBuilderTestOsmTestData7xxTest() {
-    testData.add("./src/test/resources/osm-testdata/all.osm");
-    tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/osm-testdata/all.osm");
   }
 
   @Test
-  public void test700() {
+  void test700() {
     // Polygon with one closed way.
     OSMEntity entity = testData.ways().get(700800L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -61,14 +56,13 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
 
     // check if result has 5 points
     assertEquals(5, result.getCoordinates().length);
-
   }
 
   @Test
-  public void test701() throws ParseException {
+  void test701() throws ParseException {
     // Valid multipolygon relation with two ways (4 points) making up an outer ring.
     OSMEntity entity = testData.relations().get(701900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -83,10 +77,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test702() throws ParseException {
+  void test702() throws ParseException {
     // Valid multipolygon relation with two ways (8 points) making up an outer ring."
     OSMEntity entity = testData.relations().get(702900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -102,10 +96,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test703() throws ParseException {
+  void test703() throws ParseException {
     // Valid multipolygon relation with two ways (8 points) making up an outer ring."
     OSMEntity entity = testData.relations().get(703900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -121,10 +115,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test704() throws ParseException {
+  void test704() throws ParseException {
     // Valid multipolygon relation with three ways making up an outer ring in the form of a cross.
     OSMEntity entity = testData.relations().get(704900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -140,11 +134,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test705() throws ParseException {
+  void test705() throws ParseException {
     // Valid multipolygon relation with three ways making up an outer ring. Contains concave and
     // convex parts.
     OSMEntity entity = testData.relations().get(705900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -160,11 +154,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test706() throws ParseException {
+  void test706() throws ParseException {
     // Valid multipolygon relation with three ways making up two outer rings that touch in one
     // point.
     OSMEntity entity = testData.relations().get(706900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -180,10 +174,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test707() throws ParseException {
+  void test707() throws ParseException {
     // Valid multipolygon relation with three ways making up two separate outer rings.
     OSMEntity entity = testData.relations().get(707900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -199,10 +193,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test708() throws ParseException {
+  void test708() throws ParseException {
     // Valid multipolygon relation with three ways making up two separate outer rings.
     OSMEntity entity = testData.relations().get(708900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -219,11 +213,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test709() throws ParseException {
+  void test709() throws ParseException {
     // Valid multipolygon relation with four ways making up three outer rings touching in three
     // points.
     OSMEntity entity = testData.relations().get(709900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(3, result.getNumGeometries());
@@ -240,45 +234,45 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test710() {
+  void test710() {
     // Invalid multipolygon relation: Three ways make up two outer rings, but the outer rings
     // overlap.
     OSMEntity entity1 = testData.relations().get(710900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
 
   @Test
-  public void test711() {
+  void test711() {
     // Invalid multipolygon relation: Two ways, both containing one of the segments."
     OSMEntity entity1 = testData.relations().get(711900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
 
   @Test
-  public void test714() {
+  void test714() {
     // Invalid multipolygon relation: Open ring.
     OSMEntity entity1 = testData.relations().get(714900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(1, result.getNumGeometries());
   }
 
   @Test
-  public void test715() {
+  void test715() {
     // Invalid multipolygon relation: Two open rings
     OSMEntity entity1 = testData.relations().get(715900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
@@ -287,11 +281,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
 
 
   @Test
-  public void test720() throws ParseException {
+  void test720() throws ParseException {
     // "Multipolygon with one outer and one inner ring. They are both oriented clockwise and have
     // the correct role.
     OSMEntity entity = testData.relations().get(720900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -329,11 +323,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test724() throws ParseException {
+  void test724() throws ParseException {
     // Multipolygon with one outer and one inner ring and a bit more complex geometry and nodes not
     // in order
     OSMEntity entity = testData.relations().get(724900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -349,10 +343,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test725() throws ParseException {
+  void test725() throws ParseException {
     // Valid multipolygon with one concave outer ring and no inner ring.
     OSMEntity entity = testData.relations().get(725900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -379,10 +373,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test728() throws ParseException {
+  void test728() throws ParseException {
     // Multipolygon with one simple outer ring and a node member
     OSMEntity entity = testData.relations().get(728900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -398,10 +392,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test729() throws ParseException {
+  void test729() throws ParseException {
     // Valid multipolygon with second outer ring in inner ring.
     OSMEntity entity = testData.relations().get(729900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertFalse((result.getGeometryN(1)).intersects((result.getGeometryN(0))));
@@ -420,10 +414,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test730() throws ParseException {
+  void test730() throws ParseException {
     // Valid multipolygon with one outer and three inner rings with correct roles
     OSMEntity entity = testData.relations().get(730900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(3, ((Polygon) result).getNumInteriorRing());
@@ -441,11 +435,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test731() throws ParseException {
+  void test731() throws ParseException {
     // "Valid complex multipolygon with one outer and two inner rings made up of several ways. Roles
     // are tagged correctly
     OSMEntity entity = testData.relations().get(731900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(2, ((Polygon) result).getNumInteriorRing());
@@ -463,11 +457,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test732() throws ParseException {
+  void test732() throws ParseException {
     // Valid multipolygon with two outer rings, one containing an inner. One ring contains a node
     // twice in succession in data.osm
     OSMEntity entity = testData.relations().get(732900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -498,31 +492,31 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test740() {
+  void test740() {
     // Invalid multipolygon because the outer ring crosses itself.
     OSMEntity entity1 = testData.relations().get(740900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test741() {
+  void test741() {
     // Invalid multipolygon with a line only as 'outer ring'
     OSMEntity entity1 = testData.relations().get(741900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test742() {
+  void test742() {
     // Invalid multipolygon because of a 'spike'
     OSMEntity entity1 = testData.relations().get(742900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
@@ -534,72 +528,72 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test744() {
+  void test744() {
     // Invalid multipolygon with single outer ring not closed.
     OSMEntity entity1 = testData.relations().get(744900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
 
   @Test
-  public void test745() {
+  void test745() {
     // Impossible multipolygon out of one way.
     OSMEntity entity1 = testData.relations().get(745900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(1, result.getNumGeometries());
   }
 
   @Test
-  public void test746() {
+  void test746() {
     // Impossible multipolygon out of two ways.
     OSMEntity entity1 = testData.relations().get(746900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test747() {
+  void test747() {
     // Invalid multipolygon because there are two nodes with same location. Created from relation
     OSMEntity entity1 = testData.relations().get(747900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test748() {
+  void test748() {
     // Invalid multipolygon because there are two nodes with same location. Created from way
     OSMEntity entity1 = testData.ways().get(748800L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof LineString);
   }
 
   @Test
-  public void test749() {
+  void test749() {
     // Valid multipolygon with two outer rings
     OSMEntity entity1 = testData.ways().get(749800L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof LineString);
   }
 
   @Test
-  public void test750() throws ParseException {
+  void test750() throws ParseException {
     // "Valid OSM multipolygon with touching inner rings."
     OSMEntity entity = testData.relations().get(750900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -615,10 +609,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test751() throws ParseException {
+  void test751() throws ParseException {
     // "Valid OSM multipolygon with touching inner rings."
     OSMEntity entity = testData.relations().get(751900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -635,40 +629,40 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test752() {
+  void test752() {
     // Touching inner without common nodes
     OSMEntity entity1 = testData.relations().get(752900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test753() {
+  void test753() {
     // Touching inner with one common node missing.
     OSMEntity entity1 = testData.relations().get(753900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test754() {
+  void test754() {
     // Inner ring touching outer, but not in node
     OSMEntity entity1 = testData.relations().get(754900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test755() throws ParseException {
+  void test755() throws ParseException {
     // Inner ring touching outer in node.
     OSMEntity entity = testData.relations().get(755900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -684,21 +678,21 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test756() {
+  void test756() {
     // Inner ring touches outer ring in line, no common nodes
     OSMEntity entity1 = testData.relations().get(756900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test757() {
+  void test757() {
     // Inner ring touches outer ring in line using common nodes.
     OSMEntity entity1 = testData.relations().get(757900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
@@ -738,10 +732,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test763() throws ParseException {
+  void test763() throws ParseException {
     // Valid multipolygon with four outer rings touching in a single point
     OSMEntity entity = testData.relations().get(763900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result.getGeometryN(0)).getNumInteriorRing());
@@ -763,10 +757,10 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test764() throws ParseException {
+  void test764() throws ParseException {
     // Valid multipolygon with one outer ring and four inner rings touching in a single point.
     OSMEntity entity = testData.relations().get(764900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(4, ((Polygon) result).getNumInteriorRing());
@@ -807,11 +801,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test768() {
+  void test768() {
     // Multipolygon with two overlapping ways
     OSMEntity entity1 = testData.relations().get(768900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
@@ -823,21 +817,21 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test771() {
+  void test771() {
     // Multipolygon with two outer rings touching in single point, but no common node there
     OSMEntity entity1 = testData.relations().get(771900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
     assertEquals(2, result.getNumGeometries());
   }
 
   @Test
-  public void test772() throws ParseException {
+  void test772() throws ParseException {
     // Multipolygon with two inner rings touching in single node
     OSMEntity entity = testData.relations().get(772900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(2, ((Polygon) result).getNumInteriorRing());
@@ -854,21 +848,21 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test773() {
+  void test773() {
     // Multipolygon with two inner rings touching in single point, but no common node there.
     OSMEntity entity1 = testData.relations().get(773900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test774() throws ParseException {
+  void test774() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/124
     // Multipolygon with two outer rings touching in two nodes.
     OSMEntity entity = testData.relations().get(774900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -899,7 +893,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test777() throws ParseException {
+  void test777() throws ParseException {
     /*
     777 is not a valid test case.
 
@@ -913,7 +907,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     // https://github.com/GIScience/oshdb/issues/123
     // Multipolygon with two outer rings and two inner rings touching in two nodes
     OSMEntity entity = testData.relations().get(777900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygonal);
 
     // compare if coordinates of created points equals the coordinates of polygon
@@ -927,7 +921,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test778() {
+  void test778() {
     /*
     778 is not a valid test case.
 
@@ -942,16 +936,16 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     // https://github.com/GIScience/oshdb/issues/123
     // Multipolygon with two outer rings and two inner rings touching in two nodes
     OSMEntity entity = testData.relations().get(778900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygonal);
   }
 
   @Test
-  public void test779() throws ParseException {
+  void test779() throws ParseException {
     // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/137
     // Multipolygon with two outer rings and two inner rings touching in two nodes
     OSMEntity entity = testData.relations().get(779900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof MultiPolygon);
     assertTrue(result.isValid());
     assertEquals(2, result.getNumGeometries());
@@ -969,43 +963,43 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test780() {
+  void test780() {
     // Way with different nodes as start and endpoint, but same location of those nodes
     OSMEntity entity1 = testData.ways().get(780800L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof LineString);
   }
 
   @Test
-  public void test781() {
+  void test781() {
     // Multipolygon with one outer ring from single way that has different end-nodes, but they have
     // same location
     OSMEntity entity1 = testData.relations().get(781900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test782() {
+  void test782() {
     // Multipolygon with correct outer ring, but inner ring made up out of two ways where locations
     // match but not node ids
     OSMEntity entity1 = testData.relations().get(782900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test783() throws ParseException {
+  void test783() throws ParseException {
     // https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb/issues/131
     // Valid OSM multipolygon with multiple touching inner rings
     OSMEntity entity = testData.relations().get(783900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -1021,11 +1015,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test784() throws ParseException {
+  void test784() throws ParseException {
     // https://github.com/GIScience/oshdb/issues/129
     // Valid OSM multipolygon with multiple touching inner rings
     OSMEntity entity = testData.relations().get(784900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(1, ((Polygon) result).getNumInteriorRing());
@@ -1041,7 +1035,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test785() throws ParseException {
+  void test785() throws ParseException {
     /*
     785 is not a valid test case.
 
@@ -1054,7 +1048,7 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
     // https://github.com/GIScience/oshdb/issues/129
     // Valid OSM multipolygon with two touching inner rings leaving an empty area.
     OSMEntity entity = testData.relations().get(785900L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, areaDecider);
     assertTrue(result instanceof Polygonal);
     // compare if coordinates of created points equals the coordinates of polygon
     Geometry expectedPolygon = (new WKTReader()).read(
@@ -1067,40 +1061,40 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   }
 
   @Test
-  public void test790() {
+  void test790() {
     // Multipolygon relation containing the same way twice.
     OSMEntity entity1 = testData.relations().get(790900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test791() {
+  void test791() {
     // Multipolygon relation containing the two ways using the same nodes in the same order
     OSMEntity entity1 = testData.relations().get(791900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
     assertTrue(result instanceof GeometryCollection || result instanceof Polygonal);
   }
 
   @Test
-  public void test792() {
+  void test792() {
     // Multipolygon relation containing two ways using the same nodes in different order
     OSMEntity entity1 = testData.relations().get(792900L).get(0);
     assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
   }
 
   @Test
-  public void test793() {
+  void test793() {
     // Multipolygon relation containing the two ways using nearly the same nodes
     OSMEntity entity1 = testData.relations().get(793900L).get(0);
     assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
   }
 
@@ -1111,11 +1105,11 @@ public class OSHDBGeometryBuilderTestOsmTestData7xxTest {
   } */
 
   @Test
-  public void test795() {
+  void test795() {
     // Multipolygon with one outer and one duplicated inner ring
     OSMEntity entity1 = testData.relations().get(795900L).get(0);
     assertDoesNotThrow(() -> {
-      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+      OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
     });
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/osmtestdata/OSHDBGeometryBuilderTestOsmTestData7xxTest.java
@@ -30,7 +30,7 @@ class OSHDBGeometryBuilderTestOsmTestData7xxTest extends OSHDBGeometryTest {
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private static final double DELTA = 1E-8;
 
-  public OSHDBGeometryBuilderTestOsmTestData7xxTest() {
+  OSHDBGeometryBuilderTestOsmTestData7xxTest() {
     super("./src/test/resources/osm-testdata/all.osm");
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
@@ -17,7 +17,7 @@ import org.locationtech.jts.geom.Polygon;
  * Tests the {@link OSHDBGeometryBuilder} class for the special case of multipolygons with
  * invalid inner rings.
  */
-public class OSHDBGeometryBuilderMultipolygonInvalidInnersTest {
+class OSHDBGeometryBuilderMultipolygonInvalidInnersTest {
   private final OSMXmlReader testData = new OSMXmlReader();
   private final TagInterpreter tagInterpreter;
   private final OSHDBTimestamp timestamp =
@@ -29,7 +29,7 @@ public class OSHDBGeometryBuilderMultipolygonInvalidInnersTest {
   }
 
   @Test
-  public void testDuplicateInnerRings() {
+  void testDuplicateInnerRings() {
     // data has invalid (duplicate) inner rings
     OSMEntity entity = testData.relations().get(1L).get(0);
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
@@ -37,7 +37,7 @@ public class OSHDBGeometryBuilderMultipolygonInvalidInnersTest {
   }
 
   @Test
-  public void testTouchingIncompleteInnerRings() {
+  void testTouchingIncompleteInnerRings() {
     // data has invalid (duplicate) inner rings
     OSMEntity entity = testData.relations().get(2L).get(0);
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.util.geometry.relations;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -9,7 +9,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
@@ -3,12 +3,9 @@ package org.heigit.ohsome.oshdb.util.geometry.relations;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
@@ -17,30 +14,25 @@ import org.locationtech.jts.geom.Polygon;
  * Tests the {@link OSHDBGeometryBuilder} class for the special case of multipolygons with
  * invalid inner rings.
  */
-class OSHDBGeometryBuilderMultipolygonInvalidInnersTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  private final TagInterpreter tagInterpreter;
+class OSHDBGeometryBuilderMultipolygonInvalidInnersTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
   OSHDBGeometryBuilderMultipolygonInvalidInnersTest() {
-    testData.add("./src/test/resources/relations/invalid-inner-rings.osm");
-    tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/relations/invalid-inner-rings.osm");
   }
 
   @Test
   void testDuplicateInnerRings() {
     // data has invalid (duplicate) inner rings
-    OSMEntity entity = testData.relations().get(1L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = buildGeometry(relations(1L, 0), timestamp);
     assertTrue(result instanceof Polygon);
   }
 
   @Test
   void testTouchingIncompleteInnerRings() {
     // data has invalid (duplicate) inner rings
-    OSMEntity entity = testData.relations().get(2L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = buildGeometry(relations(2L, 0), timestamp);
     assertTrue(result instanceof Polygon);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidInnersTest.java
@@ -23,7 +23,7 @@ class OSHDBGeometryBuilderMultipolygonInvalidInnersTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
-  public OSHDBGeometryBuilderMultipolygonInvalidInnersTest() {
+  OSHDBGeometryBuilderMultipolygonInvalidInnersTest() {
     testData.add("./src/test/resources/relations/invalid-inner-rings.osm");
     tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
@@ -17,7 +17,7 @@ import org.locationtech.jts.geom.MultiPolygon;
  * Tests the {@link OSHDBGeometryBuilder} class for the special case of multipolygons with
  * invalid outer rings.
  */
-public class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
+class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
   private final OSMXmlReader testData = new OSMXmlReader();
   private final TagInterpreter tagInterpreter;
   private final OSHDBTimestamp timestamp =
@@ -29,7 +29,7 @@ public class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
   }
 
   @Test
-  public void test() {
+  void test() {
     // data has invalid (self-intersecting) outer ring
     OSMEntity entity = testData.relations().get(1L).get(0);
     Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.util.geometry.relations;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -9,7 +9,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
@@ -23,7 +23,7 @@ class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
-  public OSHDBGeometryBuilderMultipolygonInvalidOutersTest() {
+  OSHDBGeometryBuilderMultipolygonInvalidOutersTest() {
     testData.add("./src/test/resources/relations/invalid-outer-ring.osm");
     tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderMultipolygonInvalidOutersTest.java
@@ -3,12 +3,9 @@ package org.heigit.ohsome.oshdb.util.geometry.relations;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.MultiPolygon;
@@ -17,22 +14,18 @@ import org.locationtech.jts.geom.MultiPolygon;
  * Tests the {@link OSHDBGeometryBuilder} class for the special case of multipolygons with
  * invalid outer rings.
  */
-class OSHDBGeometryBuilderMultipolygonInvalidOutersTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  private final TagInterpreter tagInterpreter;
+class OSHDBGeometryBuilderMultipolygonInvalidOutersTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
   OSHDBGeometryBuilderMultipolygonInvalidOutersTest() {
-    testData.add("./src/test/resources/relations/invalid-outer-ring.osm");
-    tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/relations/invalid-outer-ring.osm");
   }
 
   @Test
   void test() {
     // data has invalid (self-intersecting) outer ring
-    OSMEntity entity = testData.relations().get(1L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = buildGeometry(relations(1L, 0), timestamp);
     assertTrue(result instanceof MultiPolygon);
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
@@ -4,12 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
@@ -20,16 +17,13 @@ import org.locationtech.jts.io.WKTReader;
  * Tests the {@link OSHDBGeometryBuilder} class for the special case of multipolygons with
  * split rings.
  */
-class OSHDBGeometryBuilderRelationOuterDirectionsTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  private final TagInterpreter tagInterpreter;
+class OSHDBGeometryBuilderRelationOuterDirectionsTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private static final double DELTA = 1E-6;
 
   OSHDBGeometryBuilderRelationOuterDirectionsTest() {
-    testData.add("./src/test/resources/relations/outer-directions.osm");
-    tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/relations/outer-directions.osm");
   }
 
 
@@ -37,8 +31,7 @@ class OSHDBGeometryBuilderRelationOuterDirectionsTest {
   void testFromPointTwoWaysGoingToDiffDirections() throws ParseException {
     // start of partial ring matches start of current line
     // from one point in outer ring two ways are going to different directions
-    OSMEntity entity = testData.relations().get(1L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = buildGeometry(relations(1L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -56,8 +49,7 @@ class OSHDBGeometryBuilderRelationOuterDirectionsTest {
   void testToPointTwoWaysPointingFromDiffDirections() throws ParseException {
     // end of partial ring matches end of current line
     // to one point in outer ring two ways are pointing from different directions
-    OSMEntity entity = testData.relations().get(2L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = buildGeometry(relations(2L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -75,8 +67,7 @@ class OSHDBGeometryBuilderRelationOuterDirectionsTest {
   void testStartMatchesEnd() throws ParseException {
     // start of partial ring matches end of current line
     //
-    OSMEntity entity = testData.relations().get(3L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = buildGeometry(relations(3L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());
@@ -94,8 +85,7 @@ class OSHDBGeometryBuilderRelationOuterDirectionsTest {
   void testEndMatchesStart() throws ParseException {
     // end of partial ring matches to start of current line
     //
-    OSMEntity entity = testData.relations().get(4L).get(0);
-    Geometry result = OSHDBGeometryBuilder.getGeometry(entity, timestamp, tagInterpreter);
+    Geometry result = buildGeometry(relations(4L, 0), timestamp);
     assertTrue(result instanceof Polygon);
     assertTrue(result.isValid());
     assertEquals(0, ((Polygon) result).getNumInteriorRing());

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.util.geometry.relations;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -10,7 +10,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Polygon;
 import org.locationtech.jts.io.ParseException;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
@@ -27,7 +27,7 @@ class OSHDBGeometryBuilderRelationOuterDirectionsTest {
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
   private static final double DELTA = 1E-6;
 
-  public OSHDBGeometryBuilderRelationOuterDirectionsTest() {
+  OSHDBGeometryBuilderRelationOuterDirectionsTest() {
     testData.add("./src/test/resources/relations/outer-directions.osm");
     tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationOuterDirectionsTest.java
@@ -20,7 +20,7 @@ import org.locationtech.jts.io.WKTReader;
  * Tests the {@link OSHDBGeometryBuilder} class for the special case of multipolygons with
  * split rings.
  */
-public class OSHDBGeometryBuilderRelationOuterDirectionsTest {
+class OSHDBGeometryBuilderRelationOuterDirectionsTest {
   private final OSMXmlReader testData = new OSMXmlReader();
   private final TagInterpreter tagInterpreter;
   private final OSHDBTimestamp timestamp =
@@ -34,7 +34,7 @@ public class OSHDBGeometryBuilderRelationOuterDirectionsTest {
 
 
   @Test
-  public void testFromPointTwoWaysGoingToDiffDirections() throws ParseException {
+  void testFromPointTwoWaysGoingToDiffDirections() throws ParseException {
     // start of partial ring matches start of current line
     // from one point in outer ring two ways are going to different directions
     OSMEntity entity = testData.relations().get(1L).get(0);
@@ -53,7 +53,7 @@ public class OSHDBGeometryBuilderRelationOuterDirectionsTest {
   }
 
   @Test
-  public void testToPointTwoWaysPointingFromDiffDirections() throws ParseException {
+  void testToPointTwoWaysPointingFromDiffDirections() throws ParseException {
     // end of partial ring matches end of current line
     // to one point in outer ring two ways are pointing from different directions
     OSMEntity entity = testData.relations().get(2L).get(0);
@@ -72,7 +72,7 @@ public class OSHDBGeometryBuilderRelationOuterDirectionsTest {
   }
 
   @Test
-  public void testStartMatchesEnd() throws ParseException {
+  void testStartMatchesEnd() throws ParseException {
     // start of partial ring matches end of current line
     //
     OSMEntity entity = testData.relations().get(3L).get(0);
@@ -91,7 +91,7 @@ public class OSHDBGeometryBuilderRelationOuterDirectionsTest {
   }
 
   @Test
-  public void testEndMatchesStart() throws ParseException {
+  void testEndMatchesStart() throws ParseException {
     // end of partial ring matches to start of current line
     //
     OSMEntity entity = testData.relations().get(4L).get(0);

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.util.geometry.relations;
 
-import static junit.framework.TestCase.fail;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -11,7 +11,7 @@ import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
 import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
 import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
 import org.locationtech.jts.geom.LineString;
@@ -36,69 +36,57 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   public void testTypeRestriction() {
     // relation type restriction
     OSMEntity entity1 = testData.relations().get(710900L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection);
-      assertEquals(3, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof Point);
-      assertTrue(result.getGeometryN(2) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(3, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof Point);
+    assertTrue(result.getGeometryN(2) instanceof LineString);
   }
 
   @Test
   public void testTypeAssociatedStreet() {
     // relation type associatedStreet
     OSMEntity entity1 = testData.relations().get(710901L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection);
-      assertEquals(3, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof Point);
-      assertTrue(result.getGeometryN(1) instanceof Point);
-      assertTrue(result.getGeometryN(2) instanceof Point);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(3, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof Point);
+    assertTrue(result.getGeometryN(1) instanceof Point);
+    assertTrue(result.getGeometryN(2) instanceof Point);
   }
 
   @Test
   public void testTypePublicTransport() {
     // relation type public_transport
     OSMEntity entity1 = testData.relations().get(710902L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection);
-      assertEquals(4, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof Point);
-      assertTrue(result.getGeometryN(2) instanceof LineString);
-      assertTrue(result.getGeometryN(3) instanceof Point);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(4, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof Point);
+    assertTrue(result.getGeometryN(2) instanceof LineString);
+    assertTrue(result.getGeometryN(3) instanceof Point);
   }
 
   @Test
   public void testTypeBuilding() {
     // relation type building
     OSMEntity entity1 = testData.relations().get(710903L).get(0);
-    try {
-      Geometry result = OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-      assertTrue(result instanceof GeometryCollection);
-      assertEquals(3, result.getNumGeometries());
-      assertTrue(result.getGeometryN(0) instanceof LineString);
-      assertTrue(result.getGeometryN(1) instanceof LineString);
-      assertTrue(result.getGeometryN(2) instanceof LineString);
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("Should not have thrown any exception");
-    }
+    Geometry result = assertDoesNotThrow(() -> {
+      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
+    });
+    assertTrue(result instanceof GeometryCollection);
+    assertEquals(3, result.getNumGeometries());
+    assertTrue(result.getGeometryN(0) instanceof LineString);
+    assertTrue(result.getGeometryN(1) instanceof LineString);
+    assertTrue(result.getGeometryN(2) instanceof LineString);
   }
 
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
@@ -1,16 +1,12 @@
 package org.heigit.ohsome.oshdb.util.geometry.relations;
 
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.osm.OSMEntity;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
-import org.heigit.ohsome.oshdb.util.geometry.helpers.OSMXmlReaderTagInterpreter;
+import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
-import org.heigit.ohsome.oshdb.util.taginterpreter.TagInterpreter;
-import org.heigit.ohsome.oshdb.util.xmlreader.OSMXmlReader;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.GeometryCollection;
@@ -21,24 +17,18 @@ import org.locationtech.jts.geom.Point;
  * Tests the {@link OSHDBGeometryBuilder} class for the special case of relations which are not
  * multipolygons (e.g. geometry collections).
  */
-class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
-  private final OSMXmlReader testData = new OSMXmlReader();
-  private final TagInterpreter tagInterpreter;
+class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest extends OSHDBGeometryTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
   OSHDBGeometryBuilderRelationTypeNotMultipolygonTest() {
-    testData.add("./src/test/resources/relations/relationTypeNotMultipolygon.osm");
-    tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
+    super("./src/test/resources/relations/relationTypeNotMultipolygon.osm");
   }
 
   @Test
   void testTypeRestriction() {
     // relation type restriction
-    OSMEntity entity1 = testData.relations().get(710900L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-    });
+    Geometry result = buildGeometry(relations(710900L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection);
     assertEquals(3, result.getNumGeometries());
     assertTrue(result.getGeometryN(0) instanceof LineString);
@@ -49,10 +39,7 @@ class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   @Test
   void testTypeAssociatedStreet() {
     // relation type associatedStreet
-    OSMEntity entity1 = testData.relations().get(710901L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-    });
+    Geometry result = buildGeometry(relations(710901L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection);
     assertEquals(3, result.getNumGeometries());
     assertTrue(result.getGeometryN(0) instanceof Point);
@@ -63,10 +50,7 @@ class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   @Test
   void testTypePublicTransport() {
     // relation type public_transport
-    OSMEntity entity1 = testData.relations().get(710902L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-    });
+    Geometry result = buildGeometry(relations(710902L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection);
     assertEquals(4, result.getNumGeometries());
     assertTrue(result.getGeometryN(0) instanceof LineString);
@@ -78,16 +62,12 @@ class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   @Test
   void testTypeBuilding() {
     // relation type building
-    OSMEntity entity1 = testData.relations().get(710903L).get(0);
-    Geometry result = assertDoesNotThrow(() -> {
-      return OSHDBGeometryBuilder.getGeometry(entity1, timestamp, tagInterpreter);
-    });
+    Geometry result = buildGeometry(relations(710903L, 0), timestamp);
     assertTrue(result instanceof GeometryCollection);
     assertEquals(3, result.getNumGeometries());
     assertTrue(result.getGeometryN(0) instanceof LineString);
     assertTrue(result.getGeometryN(1) instanceof LineString);
     assertTrue(result.getGeometryN(2) instanceof LineString);
   }
-
 }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
@@ -27,7 +27,7 @@ class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   private final OSHDBTimestamp timestamp =
       TimestampParser.toOSHDBTimestamp("2014-01-01T00:00:00Z");
 
-  public OSHDBGeometryBuilderRelationTypeNotMultipolygonTest() {
+  OSHDBGeometryBuilderRelationTypeNotMultipolygonTest() {
     testData.add("./src/test/resources/relations/relationTypeNotMultipolygon.osm");
     tagInterpreter = new OSMXmlReaderTagInterpreter(testData);
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/relations/OSHDBGeometryBuilderRelationTypeNotMultipolygonTest.java
@@ -21,7 +21,7 @@ import org.locationtech.jts.geom.Point;
  * Tests the {@link OSHDBGeometryBuilder} class for the special case of relations which are not
  * multipolygons (e.g. geometry collections).
  */
-public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
+class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   private final OSMXmlReader testData = new OSMXmlReader();
   private final TagInterpreter tagInterpreter;
   private final OSHDBTimestamp timestamp =
@@ -33,7 +33,7 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTypeRestriction() {
+  void testTypeRestriction() {
     // relation type restriction
     OSMEntity entity1 = testData.relations().get(710900L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
@@ -47,7 +47,7 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTypeAssociatedStreet() {
+  void testTypeAssociatedStreet() {
     // relation type associatedStreet
     OSMEntity entity1 = testData.relations().get(710901L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
@@ -61,7 +61,7 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTypePublicTransport() {
+  void testTypePublicTransport() {
     // relation type public_transport
     OSMEntity entity1 = testData.relations().get(710902L).get(0);
     Geometry result = assertDoesNotThrow(() -> {
@@ -76,7 +76,7 @@ public class OSHDBGeometryBuilderRelationTypeNotMultipolygonTest {
   }
 
   @Test
-  public void testTypeBuilding() {
+  void testTypeBuilding() {
     // relation type building
     OSMEntity entity1 = testData.relations().get(710903L).get(0);
     Geometry result = assertDoesNotThrow(() -> {

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/osh/TestOSHEntityTimeUtils.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/osh/TestOSHEntityTimeUtils.java
@@ -24,9 +24,9 @@ import org.junit.jupiter.api.Test;
  * Tests the {@link OSHEntityTimeUtils} class.
  */
 @SuppressWarnings("javadoc")
-public class TestOSHEntityTimeUtils {
+class TestOSHEntityTimeUtils {
   @Test
-  public void testGetModificationTimestampsNode() throws IOException {
+  void testGetModificationTimestampsNode() throws IOException {
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(123L, 2, 2L, 0L, 1, new int[] {1, 1},
             86756350, 494186210),
@@ -47,7 +47,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetModificationTimestampsNodeWithFilter() throws IOException {
+  void testGetModificationTimestampsNodeWithFilter() throws IOException {
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(123L, 3, 3L, 3L, 1, new int[] {1, 2},
             86756350, 494186210),
@@ -72,7 +72,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetModificationTimestampsWay() throws IOException {
+  void testGetModificationTimestampsWay() throws IOException {
     OSHNode hnode1 = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(123L, -3, 14L, 13L, 0, new int[]{}, 0, 0),
         OSM.node(123L, 2, 2L, 12L, 0, new int[]{}, 0, 0),
@@ -123,7 +123,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetModificationTimestampsWayWithFilter() throws IOException {
+  void testGetModificationTimestampsWayWithFilter() throws IOException {
     OSHNode hnode1 = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(123L, 2, 2L, 12L, 0, new int[]{}, 0, 0),
         OSM.node(123L, 1, 1L, 11L, 0, new int[]{}, 0, 0)
@@ -188,7 +188,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetModificationTimestampsRelation() throws IOException {
+  void testGetModificationTimestampsRelation() throws IOException {
     OSHNode hnode1 = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(123L, 2, 2L, 12L, 0, new int[]{}, 0, 0),
         OSM.node(123L, 1, 1L, 11L, 0, new int[]{}, 0, 0)
@@ -259,7 +259,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetModificationTimestampsRelationWithFilter() throws IOException {
+  void testGetModificationTimestampsRelationWithFilter() throws IOException {
     OSHNode hnode1 = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(123L, 7, 17L, 17L, 0, new int[]{}, 0, 0),
         OSM.node(123L, 6, 6L, 16L, 0, new int[]{}, 0, 0),
@@ -295,7 +295,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testIssue325() throws IOException {
+  void testIssue325() throws IOException {
     // tests that the bug reported in https://github.com/GIScience/oshdb/issues/325 is fixed:
     // relations referencing redacted ways caused a crash in the OSHEntities utility class
     // when calculating the relation's modification timestamps
@@ -330,7 +330,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetChangesetTimestampsNode() throws IOException {
+  void testGetChangesetTimestampsNode() throws IOException {
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(123L, 2, 2L, 8L, 1, new int[] {1, 1},
             86756350, 494186210),
@@ -346,7 +346,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetChangesetTimestampsWay() throws IOException {
+  void testGetChangesetTimestampsWay() throws IOException {
     OSHNode hnode1 = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(1L, 3, 5L, 5L, 1, new int[] {},
             86756340, 494186210),
@@ -397,7 +397,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetChangesetTimestampsRelation() throws IOException {
+  void testGetChangesetTimestampsRelation() throws IOException {
     OSHNode hnode1 = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(1L, 2, 3L, 3L, 1, new int[] {},
             86756340, 494186210),
@@ -474,7 +474,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetModificationTimestampsBrokenData() throws IOException {
+  void testGetModificationTimestampsBrokenData() throws IOException {
     // missing way node reference
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(1L, 1, 1L, 1L, 1, new int[] {},
@@ -514,7 +514,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetChangesetTimestampsBrokenData() throws IOException {
+  void testGetChangesetTimestampsBrokenData() throws IOException {
     // missing way node reference
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(1L, 1, 1L, 1L, 1, new int[] {},
@@ -548,7 +548,7 @@ public class TestOSHEntityTimeUtils {
   }
 
   @Test
-  public void testGetModificationTimestampsNestedRelations() throws IOException {
+  void testGetModificationTimestampsNestedRelations() throws IOException {
     OSHNode hnode = OSHNodeImpl.build(Lists.newArrayList(
         OSM.node(1L, 1, 1L, 1L, 1, new int[] {},
             86756380, 494186210)

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/osh/TestOSHEntityTimeUtils.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/osh/TestOSHEntityTimeUtils.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.util.osh;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.osh.OSHWay;
 import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMMember;
 import org.heigit.ohsome.oshdb.osm.OSMType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@link OSHEntityTimeUtils} class.

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/tagtranslator/TagTranslatorTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/tagtranslator/TagTranslatorTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the {@link TagTranslator} class.
  */
-public class TagTranslatorTest {
+class TagTranslatorTest {
   private static Connection conn;
 
   /**
@@ -26,7 +26,7 @@ public class TagTranslatorTest {
    * @throws SQLException is thrown if the connection fails
    */
   @BeforeAll
-  public static void setUpClass() throws ClassNotFoundException, SQLException {
+  static void setUpClass() throws ClassNotFoundException, SQLException {
     // load H2-support
     Class.forName("org.h2.Driver");
 
@@ -37,15 +37,14 @@ public class TagTranslatorTest {
   }
 
   @AfterAll
-  public static void breakDownClass() throws SQLException {
+  static void breakDownClass() throws SQLException {
     TagTranslatorTest.conn.close();
   }
 
-  public TagTranslatorTest() {
-  }
+  TagTranslatorTest() {}
 
   @Test
-  public void testTag2Int() throws OSHDBKeytablesNotFoundException {
+  void testTag2Int() throws OSHDBKeytablesNotFoundException {
     OSMTag tag = new OSMTag("building", "yes");
     TagTranslator instance = new TagTranslator(TagTranslatorTest.conn);
     OSHDBTag expResult = new OSHDBTag(1, 0);
@@ -54,7 +53,7 @@ public class TagTranslatorTest {
   }
 
   @Test
-  public void testTag2String() throws OSHDBKeytablesNotFoundException {
+  void testTag2String() throws OSHDBKeytablesNotFoundException {
     OSHDBTag tag = new OSHDBTag(1, 2);
     TagTranslator instance = new TagTranslator(TagTranslatorTest.conn);
     OSMTag expResult = new OSMTag("building", "residential");
@@ -63,7 +62,7 @@ public class TagTranslatorTest {
   }
 
   @Test
-  public void testKey2Int() throws OSHDBKeytablesNotFoundException {
+  void testKey2Int() throws OSHDBKeytablesNotFoundException {
     OSMTagKey key = new OSMTagKey("highway");
     TagTranslator instance = new TagTranslator(TagTranslatorTest.conn);
     OSHDBTagKey expResult = new OSHDBTagKey(2);
@@ -72,7 +71,7 @@ public class TagTranslatorTest {
   }
 
   @Test
-  public void testKey2String() throws OSHDBKeytablesNotFoundException {
+  void testKey2String() throws OSHDBKeytablesNotFoundException {
     OSHDBTagKey key = new OSHDBTagKey(1);
     TagTranslator instance = new TagTranslator(TagTranslatorTest.conn);
     OSMTagKey expResult = new OSMTagKey("building");
@@ -81,7 +80,7 @@ public class TagTranslatorTest {
   }
 
   @Test
-  public void testRole2Int() throws OSHDBKeytablesNotFoundException {
+  void testRole2Int() throws OSHDBKeytablesNotFoundException {
     OSMRole role = new OSMRole("from");
     TagTranslator instance = new TagTranslator(TagTranslatorTest.conn);
     OSHDBRole expResult = new OSHDBRole(4);
@@ -90,7 +89,7 @@ public class TagTranslatorTest {
   }
 
   @Test
-  public void testRole2String() throws OSHDBKeytablesNotFoundException {
+  void testRole2String() throws OSHDBKeytablesNotFoundException {
     OSHDBRole role = new OSHDBRole(1);
     TagTranslator instance = new TagTranslator(TagTranslatorTest.conn);
     OSMRole expResult = new OSMRole("inner");

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/tagtranslator/TagTranslatorTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/tagtranslator/TagTranslatorTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.util.tagtranslator;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -9,9 +9,9 @@ import org.heigit.ohsome.oshdb.OSHDBTag;
 import org.heigit.ohsome.oshdb.util.OSHDBRole;
 import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
 import org.heigit.ohsome.oshdb.util.exceptions.OSHDBKeytablesNotFoundException;
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@link TagTranslator} class.
@@ -25,7 +25,7 @@ public class TagTranslatorTest {
    * @throws ClassNotFoundException gets thrown if H2 driver class cannot be found
    * @throws SQLException is thrown if the connection fails
    */
-  @BeforeClass
+  @BeforeAll
   public static void setUpClass() throws ClassNotFoundException, SQLException {
     // load H2-support
     Class.forName("org.h2.Driver");
@@ -36,7 +36,7 @@ public class TagTranslatorTest {
             "sa", "");
   }
 
-  @AfterClass
+  @AfterAll
   public static void breakDownClass() throws SQLException {
     TagTranslatorTest.conn.close();
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/IsoDateTimeParserTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/IsoDateTimeParserTest.java
@@ -1,11 +1,14 @@
 package org.heigit.ohsome.oshdb.util.time;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.time.DateTimeException;
 import java.time.Duration;
 import java.time.Period;
 import java.util.Map;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@link IsoDateTimeParser} class.
@@ -21,16 +24,16 @@ public class IsoDateTimeParserTest {
     String[] yyyymm = {"2020-02-01T00:00Z", "202002"};
     String[] yyyymmdd = {"2020-02-17T00:00Z", "20200217"};
 
-    Assert.assertEquals(yyyy[0], IsoDateTimeParser.parseIsoDateTime(yyyy[1]).toString());
-    Assert.assertEquals(yyyymm[0], IsoDateTimeParser.parseIsoDateTime(yyyymm[1]).toString());
-    Assert.assertEquals(yyyymmdd[0], IsoDateTimeParser.parseIsoDateTime(yyyymmdd[1]).toString());
+    assertEquals(yyyy[0], IsoDateTimeParser.parseIsoDateTime(yyyy[1]).toString());
+    assertEquals(yyyymm[0], IsoDateTimeParser.parseIsoDateTime(yyyymm[1]).toString());
+    assertEquals(yyyymmdd[0], IsoDateTimeParser.parseIsoDateTime(yyyymmdd[1]).toString());
 
     //Extended Dates
     String[] yyyyMm = {"2020-02-01T00:00Z", "2020-02"};
     String[] yyyyMmDd = {"2020-02-17T00:00Z", "2020-02-17"};
 
-    Assert.assertEquals(yyyyMm[0], IsoDateTimeParser.parseIsoDateTime(yyyyMm[1]).toString());
-    Assert.assertEquals(yyyyMmDd[0], IsoDateTimeParser.parseIsoDateTime(yyyyMmDd[1]).toString());
+    assertEquals(yyyyMm[0], IsoDateTimeParser.parseIsoDateTime(yyyyMm[1]).toString());
+    assertEquals(yyyyMmDd[0], IsoDateTimeParser.parseIsoDateTime(yyyyMmDd[1]).toString());
 
     //Extended Date-Time
     String[] yyyyMmDdHh = {"2020-02-17T23:00Z", "2020-02-17T23"};
@@ -45,83 +48,101 @@ public class IsoDateTimeParserTest {
     String[] yyyyMmDdHhMmSsSss = {"2020-02-17T23:55:12.999Z", "2020-02-17T23:55:12.999"};
     String[] yyyyMmDdHhMmSsSssz = {"2020-02-17T23:55:12.999Z", "2020-02-17T23:55:12.999Z"};
 
-    Assert.assertEquals(yyyyMmDdHh[0],
+    assertEquals(yyyyMmDdHh[0],
         IsoDateTimeParser.parseIsoDateTime(yyyyMmDdHh[1]).toString());
-    Assert.assertEquals(yyyyMmDdHhz[0],
+    assertEquals(yyyyMmDdHhz[0],
         IsoDateTimeParser.parseIsoDateTime(yyyyMmDdHhz[1]).toString());
 
-    Assert.assertEquals(yyyyMmDdHhMm[0],
+    assertEquals(yyyyMmDdHhMm[0],
         IsoDateTimeParser.parseIsoDateTime(yyyyMmDdHhMm[1]).toString());
-    Assert.assertEquals(yyyyMmDdHhMmz[0],
+    assertEquals(yyyyMmDdHhMmz[0],
         IsoDateTimeParser.parseIsoDateTime(yyyyMmDdHhMmz[1]).toString());
 
-    Assert.assertEquals(yyyyMmDdHhMmSs[0],
+    assertEquals(yyyyMmDdHhMmSs[0],
         IsoDateTimeParser.parseIsoDateTime(yyyyMmDdHhMmSs[1]).toString());
-    Assert.assertEquals(yyyyMmDdHhMmSsz[0],
+    assertEquals(yyyyMmDdHhMmSsz[0],
         IsoDateTimeParser.parseIsoDateTime(yyyyMmDdHhMmSsz[1]).toString());
 
-    Assert.assertEquals(yyyyMmDdHhMmSsSss[0],
+    assertEquals(yyyyMmDdHhMmSsSss[0],
         IsoDateTimeParser.parseIsoDateTime(yyyyMmDdHhMmSsSss[1]).toString());
-    Assert.assertEquals(yyyyMmDdHhMmSsSssz[0],
+    assertEquals(yyyyMmDdHhMmSsSssz[0],
         IsoDateTimeParser.parseIsoDateTime(yyyyMmDdHhMmSsSssz[1]).toString());
 
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsNegativeDateParseIsoDateTime() {
     //Negative Dates
     String nyyyy = "-0333";
-    IsoDateTimeParser.parseIsoDateTime(nyyyy);
+    assertThrows(OSHDBTimestampException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(nyyyy);
+    });
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsShortYearParseIsoDateTime() {
     //Short Year
     String yy = "12";
-    IsoDateTimeParser.parseIsoDateTime(yy);
+    assertThrows(OSHDBTimestampException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(yy);
+    });
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsPosTimezoneHhParseIsoDateTime() {
     String posTimezoneHh = "2020-02-17T23:55+02";
-    IsoDateTimeParser.parseIsoDateTime(posTimezoneHh);
+    assertThrows(OSHDBTimestampException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(posTimezoneHh);
+    });
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsPosTimezoneHhMmParseIsoDateTime() {
     String posTimezoneHhmm = "2020-02-17T23:55+0230";
-    IsoDateTimeParser.parseIsoDateTime(posTimezoneHhmm);
+    assertThrows(OSHDBTimestampException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(posTimezoneHhmm);
+    });
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsPosTimezoneHh_MmParseIsoDateTime() {
     String posTimezoneHhMm = "2020-02-17T23:55+02:30";
-    IsoDateTimeParser.parseIsoDateTime(posTimezoneHhMm);
+    assertThrows(OSHDBTimestampException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(posTimezoneHhMm);
+    });
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsNegTimezoneHhParseIsoDateTime() {
     String negTimezoneHh = "2020-02-17T23:55-02";
-    IsoDateTimeParser.parseIsoDateTime(negTimezoneHh);
+    assertThrows(OSHDBTimestampException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(negTimezoneHh);
+    });
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsNegTimezoneHhMmParseIsoDateTime() {
     String negTimezoneHhMm = "2020-02-17T23:55-0230";
-    IsoDateTimeParser.parseIsoDateTime(negTimezoneHhMm);
+    assertThrows(OSHDBTimestampException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(negTimezoneHhMm);
+    });
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsNegTimezoneHh_MmParseIsoDateTime() {
     String negTimezoneHhMm = "2020-02-17T23:55-02:30";
-    IsoDateTimeParser.parseIsoDateTime(negTimezoneHhMm);
+    assertThrows(OSHDBTimestampException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(negTimezoneHhMm);
+    });
   }
 
-  @Test(expected = DateTimeException.class)
+  @Test()
   public void throwsWrongDateParseIsoDateTime() {
     //Wrong Date
     String wrongDateTime = "2020-13-01T00:00";
-    IsoDateTimeParser.parseIsoDateTime(wrongDateTime);
+    assertThrows(DateTimeException.class, () -> {
+      IsoDateTimeParser.parseIsoDateTime(wrongDateTime);
+    });
   }
 
 
@@ -148,45 +169,49 @@ public class IsoDateTimeParserTest {
         IsoDateTimeParser.parseIsoPeriod(fullDateTimePeriod[0]);
     Period fullYearMonthDayTimePeriod = (Period) fullYearMonthDayTime.get("period");
     Duration fullYearMonthDayTimeDuration = (Duration) fullYearMonthDayTime.get("duration");
-    Assert.assertEquals(fullDateTimePeriod[1], fullYearMonthDayTimePeriod.toString());
-    Assert.assertEquals(fullDateTimePeriod[2], fullYearMonthDayTimeDuration.toString());
+    assertEquals(fullDateTimePeriod[1], fullYearMonthDayTimePeriod.toString());
+    assertEquals(fullDateTimePeriod[2], fullYearMonthDayTimeDuration.toString());
 
     // Period output should be same as input, Duration should be ZERO
     String fullDatePeriod = "P1Y3M10D";
     Map<String, Object> fullYearMonthDay = IsoDateTimeParser.parseIsoPeriod(fullDatePeriod);
     Period fullYearMonthDayPeriod = (Period) fullYearMonthDay.get("period");
     Duration fullYearMonthDayDuration = (Duration) fullYearMonthDay.get("duration");
-    Assert.assertEquals(fullDatePeriod, fullYearMonthDayPeriod.toString());
-    Assert.assertTrue(fullYearMonthDayDuration.isZero());
+    assertEquals(fullDatePeriod, fullYearMonthDayPeriod.toString());
+    assertTrue(fullYearMonthDayDuration.isZero());
 
     // Period output should be same as input, Duration should be ZERO
     String shortDatePeriod = "P3M10D";
     Map<String, Object> shortMonthDay = IsoDateTimeParser.parseIsoPeriod(shortDatePeriod);
     Period shortMonthDayPeriod = (Period) shortMonthDay.get("period");
     Duration shortMonthDayDuration = (Duration) shortMonthDay.get("duration");
-    Assert.assertEquals(shortDatePeriod, shortMonthDayPeriod.toString());
-    Assert.assertTrue(shortMonthDayDuration.isZero());
+    assertEquals(shortDatePeriod, shortMonthDayPeriod.toString());
+    assertTrue(shortMonthDayDuration.isZero());
 
     // Period should equal 14 days, Duration should be ZERO
     String weekPeriod = "P2W";
     Map<String, Object> twoWeeks = IsoDateTimeParser.parseIsoPeriod(weekPeriod);
     Period twoWeeksPeriod = (Period) twoWeeks.get("period");
     Duration twoWeeksDuration = (Duration) twoWeeks.get("duration");
-    Assert.assertEquals(14, twoWeeksPeriod.getDays());
-    Assert.assertTrue(twoWeeksDuration.isZero());
+    assertEquals(14, twoWeeksPeriod.getDays());
+    assertTrue(twoWeeksDuration.isZero());
 
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsFormatParseIsoPeriod() {
-    // test throw exeption for unsupported formats
-    IsoDateTimeParser.parseIsoPeriod("PT1Y2M");
+    assertThrows(OSHDBTimestampException.class, () -> {
+      // test throw exeption for unsupported formats
+      IsoDateTimeParser.parseIsoPeriod("PT1Y2M");
+    });
   }
 
-  @Test(expected = OSHDBTimestampException.class)
+  @Test()
   public void throwsZeroLengthParseIsoPeriod() {
-    //test for zero length ISOPeriod
-    IsoDateTimeParser.parseIsoPeriod("PT0S");
+    assertThrows(OSHDBTimestampException.class, () -> {
+      //test for zero length ISOPeriod
+      IsoDateTimeParser.parseIsoPeriod("PT0S");
+    });
   }
 
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/IsoDateTimeParserTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/IsoDateTimeParserTest.java
@@ -13,10 +13,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the {@link IsoDateTimeParser} class.
  */
-public class IsoDateTimeParserTest {
+class IsoDateTimeParserTest {
 
   @Test
-  public void testParseIsoDateTime() {
+  void testParseIsoDateTime() {
     // test allowed variants
 
     //Basic Dates
@@ -71,7 +71,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsNegativeDateParseIsoDateTime() {
+  void throwsNegativeDateParseIsoDateTime() {
     //Negative Dates
     String nyyyy = "-0333";
     assertThrows(OSHDBTimestampException.class, () -> {
@@ -80,7 +80,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsShortYearParseIsoDateTime() {
+  void throwsShortYearParseIsoDateTime() {
     //Short Year
     String yy = "12";
     assertThrows(OSHDBTimestampException.class, () -> {
@@ -89,7 +89,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsPosTimezoneHhParseIsoDateTime() {
+  void throwsPosTimezoneHhParseIsoDateTime() {
     String posTimezoneHh = "2020-02-17T23:55+02";
     assertThrows(OSHDBTimestampException.class, () -> {
       IsoDateTimeParser.parseIsoDateTime(posTimezoneHh);
@@ -97,7 +97,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsPosTimezoneHhMmParseIsoDateTime() {
+  void throwsPosTimezoneHhMmParseIsoDateTime() {
     String posTimezoneHhmm = "2020-02-17T23:55+0230";
     assertThrows(OSHDBTimestampException.class, () -> {
       IsoDateTimeParser.parseIsoDateTime(posTimezoneHhmm);
@@ -105,7 +105,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsPosTimezoneHh_MmParseIsoDateTime() {
+  void throwsPosTimezoneHh_MmParseIsoDateTime() {
     String posTimezoneHhMm = "2020-02-17T23:55+02:30";
     assertThrows(OSHDBTimestampException.class, () -> {
       IsoDateTimeParser.parseIsoDateTime(posTimezoneHhMm);
@@ -113,7 +113,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsNegTimezoneHhParseIsoDateTime() {
+  void throwsNegTimezoneHhParseIsoDateTime() {
     String negTimezoneHh = "2020-02-17T23:55-02";
     assertThrows(OSHDBTimestampException.class, () -> {
       IsoDateTimeParser.parseIsoDateTime(negTimezoneHh);
@@ -121,7 +121,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsNegTimezoneHhMmParseIsoDateTime() {
+  void throwsNegTimezoneHhMmParseIsoDateTime() {
     String negTimezoneHhMm = "2020-02-17T23:55-0230";
     assertThrows(OSHDBTimestampException.class, () -> {
       IsoDateTimeParser.parseIsoDateTime(negTimezoneHhMm);
@@ -129,7 +129,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsNegTimezoneHh_MmParseIsoDateTime() {
+  void throwsNegTimezoneHh_MmParseIsoDateTime() {
     String negTimezoneHhMm = "2020-02-17T23:55-02:30";
     assertThrows(OSHDBTimestampException.class, () -> {
       IsoDateTimeParser.parseIsoDateTime(negTimezoneHhMm);
@@ -137,7 +137,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsWrongDateParseIsoDateTime() {
+  void throwsWrongDateParseIsoDateTime() {
     //Wrong Date
     String wrongDateTime = "2020-13-01T00:00";
     assertThrows(DateTimeException.class, () -> {
@@ -147,7 +147,7 @@ public class IsoDateTimeParserTest {
 
 
   @Test
-  public void testParseIsoPeriod() {
+  void testParseIsoPeriod() {
     // test allowed variants
 
     //    Full DateTime Period: PnYnMnDTnHnMnS,
@@ -199,7 +199,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsFormatParseIsoPeriod() {
+  void throwsFormatParseIsoPeriod() {
     assertThrows(OSHDBTimestampException.class, () -> {
       // test throw exeption for unsupported formats
       IsoDateTimeParser.parseIsoPeriod("PT1Y2M");
@@ -207,7 +207,7 @@ public class IsoDateTimeParserTest {
   }
 
   @Test()
-  public void throwsZeroLengthParseIsoPeriod() {
+  void throwsZeroLengthParseIsoPeriod() {
     assertThrows(OSHDBTimestampException.class, () -> {
       //test for zero length ISOPeriod
       IsoDateTimeParser.parseIsoPeriod("PT0S");

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/OSHDBTimestampIntervalTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/OSHDBTimestampIntervalTest.java
@@ -1,10 +1,10 @@
 package org.heigit.ohsome.oshdb.util.time;
 
 import static java.lang.Integer.signum;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test Suite for {@code OSHDBTimestampInterval}.

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/OSHDBTimestampIntervalTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/OSHDBTimestampIntervalTest.java
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.Test;
 /**
  * Test Suite for {@code OSHDBTimestampInterval}.
  */
-public class OSHDBTimestampIntervalTest {
+class OSHDBTimestampIntervalTest {
 
   /**
    * Test for the contract of {@code Comparable.compareTo}.
    */
   @Test
-  public void testCompareTo() {
+  void testCompareTo() {
     var x = new OSHDBTimestampInterval(new OSHDBTimestamp(0), new OSHDBTimestamp(1));
     var y = new OSHDBTimestampInterval(new OSHDBTimestamp(0), new OSHDBTimestamp(2));
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/OSHDBTimestampsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/OSHDBTimestampsTest.java
@@ -1,8 +1,9 @@
 package org.heigit.ohsome.oshdb.util.time;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -10,7 +11,7 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.Set;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps.Interval;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests the {@link OSHDBTimestamps} class.
@@ -85,9 +86,11 @@ public class OSHDBTimestampsTest {
     assertTrue(testedIntervals.containsAll(EnumSet.allOf(Interval.class)));
   }
 
-  @Test(expected = RuntimeException.class)
+  @Test()
   public void testInvalidTimestamp() {
-    new OSHDBTimestamps("test123");
+    assertThrows(RuntimeException.class, () -> {
+      new OSHDBTimestamps("test123");
+    });
   }
 
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/OSHDBTimestampsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/time/OSHDBTimestampsTest.java
@@ -16,10 +16,10 @@ import org.junit.jupiter.api.Test;
 /**
  * Tests the {@link OSHDBTimestamps} class.
  */
-public class OSHDBTimestampsTest {
+class OSHDBTimestampsTest {
 
   @Test
-  public void testTimeIntervals() {
+  void testTimeIntervals() {
     final List<String> startList = new ArrayList<>();
     final List<String> endList = new ArrayList<>();
     final List<Interval> intervalList = new ArrayList<>();
@@ -87,7 +87,7 @@ public class OSHDBTimestampsTest {
   }
 
   @Test()
-  public void testInvalidTimestamp() {
+  void testInvalidTimestamp() {
     assertThrows(RuntimeException.class, () -> {
       new OSHDBTimestamps("test123");
     });

--- a/oshdb/pom.xml
+++ b/oshdb/pom.xml
@@ -27,14 +27,7 @@
       <artifactId>guava</artifactId>
       <version>${guava.version}</version>
     </dependency>
-    
-    <!-- TEST dependencies -->
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    
+
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-log4j12</artifactId>
@@ -47,7 +40,6 @@
       <version>${h2.version}</version>
       <scope>test</scope>
     </dependency>
-    
   </dependencies>
   
   <profiles>

--- a/oshdb/pom.xml
+++ b/oshdb/pom.xml
@@ -30,8 +30,8 @@
     
     <!-- TEST dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>
     </dependency>
     

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
@@ -15,17 +15,15 @@ import org.junit.jupiter.api.Test;
  * Test class for OSHDBTags interface.
  *
  */
-@SuppressWarnings("javadoc")
-public class OSHDBTagsTest {
-  int[] kvs = new int[] {1, 2, 2, 3, 4, 5};
+class OSHDBTagsTest {
+  private final int[] kvs = new int[] {1, 2, 2, 3, 4, 5};
 
   @Test
-  public void testArrayHasTagKey() {
+  void testArrayHasTagKey() {
     var tags = OSHDBTags.of(kvs);
 
     var tagKey2 = new OSHDBTagKey(2);
     var tagKey3 = new OSHDBTagKey(3);
-
 
     assertTrue(tags.hasTagKey(tagKey2), "tag key should exist");
     assertFalse(tags.hasTagKey(tagKey3), "tag key should not exist");
@@ -33,7 +31,7 @@ public class OSHDBTagsTest {
   }
 
   @Test
-  public void testArrayHasTagKeyExcluding() {
+  void testArrayHasTagKeyExcluding() {
     var tags = OSHDBTags.of(kvs);
 
     assertTrue(tags.hasTagKeyExcluding(2, new int[] {1, 2, 4}));
@@ -41,11 +39,10 @@ public class OSHDBTagsTest {
     assertFalse(tags.hasTagKeyExcluding(2, new int[] {3}));
     assertFalse(tags.hasTagKeyExcluding(3, new int[0]));
     assertFalse(tags.hasTagKeyExcluding(5, new int[0]));
-
   }
 
   @Test
-  public void testArrayHasTagValue() {
+  void testArrayHasTagValue() {
     var tags = OSHDBTags.of(kvs);
 
     assertTrue(tags.hasTagValue(1, 2));
@@ -56,7 +53,7 @@ public class OSHDBTagsTest {
   }
 
   @Test()
-  public void testImmutableAdd() {
+  void testImmutableAdd() {
     var tags = OSHDBTags.of(kvs);
     assertThrows(UnsupportedOperationException.class, () -> {
       tags.add(new OSHDBTag(5, 6));
@@ -64,7 +61,7 @@ public class OSHDBTagsTest {
   }
 
   @Test()
-  public void testImmutableRemove() {
+  void testImmutableRemove() {
     var tags = OSHDBTags.of(kvs);
     assertThrows(UnsupportedOperationException.class, () -> {
       tags.removeIf(tag -> tag.getKey() == 2);
@@ -72,7 +69,7 @@ public class OSHDBTagsTest {
   }
 
   @Test
-  public void testArrayEquality() {
+  void testArrayEquality() {
     var tags = OSHDBTags.of(new int[] {2, 2, 4, 4});
 
     assertEquals(tags, tags);
@@ -82,5 +79,4 @@ public class OSHDBTagsTest {
     assertNotEquals(tags, OSHDBTags.of(new int[] {1, 1, 4, 4}));
     assertNotEquals(tags, List.of(new OSHDBTag(2, 2), new OSHDBTag(4, 4)));
   }
-
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
@@ -1,14 +1,15 @@
 package org.heigit.ohsome.oshdb;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Set;
 import org.heigit.ohsome.oshdb.util.OSHDBTagKey;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test class for OSHDBTags interface.
@@ -25,9 +26,10 @@ public class OSHDBTagsTest {
     var tagKey2 = new OSHDBTagKey(2);
     var tagKey3 = new OSHDBTagKey(3);
 
-    assertTrue("tag key should exist", tags.hasTagKey(tagKey2));
-    assertFalse("tag key should not exist", tags.hasTagKey(tagKey3));
-    assertFalse("tag key should not exist", tags.hasTagKey(5));
+
+    assertTrue(tags.hasTagKey(tagKey2), "tag key should exist");
+    assertFalse(tags.hasTagKey(tagKey3), "tag key should not exist");
+    assertFalse(tags.hasTagKey(5), "tag key should not exist");
   }
 
   @Test
@@ -53,18 +55,20 @@ public class OSHDBTagsTest {
     assertFalse(tags.hasTagValue(5, 6));
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test()
   public void testImmutableAdd() {
     var tags = OSHDBTags.of(kvs);
-
-    tags.add(new OSHDBTag(5, 6));
+    assertThrows(UnsupportedOperationException.class, () -> {
+      tags.add(new OSHDBTag(5, 6));
+    });
   }
 
-  @Test(expected = UnsupportedOperationException.class)
+  @Test()
   public void testImmutableRemove() {
     var tags = OSHDBTags.of(kvs);
-
-    tags.removeIf(tag -> tag.getKey() == 2);
+    assertThrows(UnsupportedOperationException.class, () -> {
+      tags.removeIf(tag -> tag.getKey() == 2);
+    });
   }
 
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
@@ -12,11 +12,10 @@ import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMNode;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("javadoc")
-public class GridOSHNodesTest {
+class GridOSHNodesTest {
 
   @Test
-  public void testRebaseEntities() throws IOException {
+  void testRebaseEntities() throws IOException {
     List<OSHNode> hosmNodes = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       List<OSMNode> versions = new ArrayList<>();

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHNodesTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.grid;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Iterables;
 import java.io.IOException;
@@ -10,7 +10,7 @@ import org.heigit.ohsome.oshdb.impl.osh.OSHNodeImpl;
 import org.heigit.ohsome.oshdb.osh.OSHNode;
 import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
 public class GridOSHNodesTest {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
@@ -20,10 +20,6 @@ import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.osm.OSMWay;
 import org.junit.jupiter.api.Test;
 
-/**
- * General {@link GridOSHRelations} tests case.
- *
- */
 class GridOSHRelationsTest {
 
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.grid;
 
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Iterables;
 import java.io.IOException;
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.osm.OSMNode;
 import org.heigit.ohsome.oshdb.osm.OSMRelation;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.osm.OSMWay;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * General {@link GridOSHRelations} tests case.

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHRelationsTest.java
@@ -24,10 +24,10 @@ import org.junit.jupiter.api.Test;
  * General {@link GridOSHRelations} tests case.
  *
  */
-public class GridOSHRelationsTest {
+class GridOSHRelationsTest {
 
   @Test
-  public void test() throws IOException {
+  void test() throws IOException {
     var node100 = buildOSHNode(node(100L, 1, 1L, 0L, 123, tags(1, 2), 494094984, 86809727));
     var node102 = buildOSHNode(node(102L, 1, 1L, 0L, 123, tags(2, 1), 494094984, 86809727));
     var node104 = buildOSHNode(node(104L, 1, 1L, 0L, 123, tags(2, 4), 494094984, 86809727));

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHWaysTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHWaysTest.java
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.osm.OSMWay;
 import org.junit.jupiter.api.Test;
 
-public class GridOSHWaysTest {
+class GridOSHWaysTest {
 
   static OSHNode buildOSHNode(List<OSMNode> versions) {
     return OSHNodeImpl.build(versions);
@@ -32,7 +32,7 @@ public class GridOSHWaysTest {
       Arrays.asList(OSM.node(104L, 1, 1L, 0L, 123, new int[] {2, 4}, 494094984, 86809727)));
 
   @Test
-  public void testGrid() throws IOException {
+  void testGrid() throws IOException {
     List<OSHWay> hosmWays = new ArrayList<>();
     for (int i = 0; i < 3; i++) {
       List<OSMWay> versions = new ArrayList<>();

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHWaysTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/grid/GridOSHWaysTest.java
@@ -1,6 +1,6 @@
 package org.heigit.ohsome.oshdb.grid;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.common.collect.Iterables;
 import java.io.IOException;
@@ -16,7 +16,7 @@ import org.heigit.ohsome.oshdb.osm.OSMMember;
 import org.heigit.ohsome.oshdb.osm.OSMNode;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.osm.OSMWay;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class GridOSHWaysTest {
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTest.java
@@ -15,7 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("checkstyle:abbreviationAsWordInName")
-public class XYGridTest {
+class XYGridTest {
 
   private static final int MAXZOOM = OSHDB.MAXZOOM;
   private static final Logger LOG = LoggerFactory.getLogger(XYGridTest.class);
@@ -24,7 +24,7 @@ public class XYGridTest {
   private final XYGrid thirty = new XYGrid(30);
 
   @Test
-  public void testGetId_double_double() {
+  void testGetId_double_double() {
     double longitude = 0.0;
     double latitude = 0.0;
     XYGrid instance = new XYGrid(2);
@@ -34,7 +34,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testnegneg181_neg91_2() {
+  void testnegneg181_neg91_2() {
     // Testing Coordinates: -181, -91, zoom 2
     double longitude = -181.0;
     double latitude = -91.0;
@@ -45,7 +45,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testneg180_neg90_0() {
+  void testneg180_neg90_0() {
     // Testing Coordinates: -180, -90, zoom 0
     double longitude = -180.0;
     double latitude = -90.0;
@@ -56,7 +56,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void test180_90_0() {
+  void test180_90_0() {
     // Testing Coordinates: 180, 90, zoom 0
     double longitude = 180.0;
     double latitude = 90.0;
@@ -67,7 +67,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void test179_90_0() {
+  void test179_90_0() {
     // Testing Coordinates: 179, 90, zoom 0
     double longitude = 179.0;
     double latitude = 90.0;
@@ -78,7 +78,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testneg180_neg90_2() {
+  void testneg180_neg90_2() {
     // Testing Coordinates: -180, -90, zoom 2
     double longitude = -180.0;
     double latitude = -90.0;
@@ -89,7 +89,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void test180_90_2() {
+  void test180_90_2() {
     // Testing Coordinates: 180, 90, zoom 2
     double longitude = 180.0;
     double latitude = 90.0;
@@ -100,7 +100,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void test179_90_2() {
+  void test179_90_2() {
     // Testing Coordinates: 179, 90, zoom 2
     double longitude = 180.0 - GEOM_PRECISION;
     double latitude = 90.0;
@@ -111,7 +111,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testneg180_neg90_31() {
+  void testneg180_neg90_31() {
     // Testing Coordinates: -180, -90, zoom 31
     double longitude = -180.0;
     double latitude = -90.0;
@@ -125,7 +125,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void test180_90_neg1() {
+  void test180_90_neg1() {
     // Testing Coordinates: 180, 90, zoom -1
     double longitude = 180.0;
     double latitude = 90.0;
@@ -139,7 +139,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testneg180_neg90_30() {
+  void testneg180_neg90_30() {
     // Testing Coordinates: -180, -90, zoom 30
     double longitude = -180.0;
     double latitude = -90.0;
@@ -150,7 +150,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void test180_90_30() {
+  void test180_90_30() {
     // Testing Coordinates: 180, 90, zoom 30
     double longitude = 180.0;
     double latitude = 90.0;
@@ -161,7 +161,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void test179_90_30() {
+  void test179_90_30() {
     // Testing Coordinates: 179, 90, zoom 30
     double longitude = 180.0 - GEOM_PRECISION;
     double latitude = 90.0;
@@ -172,7 +172,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testGetId_BoundingBox() {
+  void testGetId_BoundingBox() {
     OSHDBBoundingBox bbx = bboxWgs84Coordinates(-10.0, -10.0, 10.0, 10.0);
     XYGrid instance = new XYGrid(2);
     long expResult = 1L;
@@ -187,7 +187,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testGetCellWidth() {
+  void testGetCellWidth() {
     double expResult = 90;
 
     double result = two.getCellWidth();
@@ -195,7 +195,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testGetCellDimensions() {
+  void testGetCellDimensions() {
     long cellId = 0L;
     OSHDBBoundingBox expResult = bboxWgs84Coordinates(-180.0, -90.0, -90.0 - GEOM_PRECISION,
         0.0 - GEOM_PRECISION);
@@ -225,7 +225,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testGetEstimatedIdCount() {
+  void testGetEstimatedIdCount() {
     OSHDBBoundingBox data = bboxWgs84Coordinates(0.0, 0.0, 89.0, 89.0);
     long expResult = 1L;
     long result = two.getEstimatedIdCount(data);
@@ -249,14 +249,14 @@ public class XYGridTest {
   }
 
   @Test
-  public void testGetLevel() {
+  void testGetLevel() {
     int expResult = 2;
     int result = two.getLevel();
     assertEquals(expResult, result);
   }
 
   @Test
-  public void testBbox2Ids() {
+  void testBbox2Ids() {
     OSHDBBoundingBox bbox = bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0);
     Set<IdRange> result = zero.bbox2CellIdRanges(bbox, false);
 
@@ -355,7 +355,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testGetNeighbours() {
+  void testGetNeighbours() {
     CellId center = new CellId(2, 6L);
     Set<IdRange> expResult = new TreeSet<>();
     expResult.add(IdRange.of(1L, 3L));
@@ -366,7 +366,7 @@ public class XYGridTest {
   }
 
   @Test
-  public void testGetBoundingBox() {
+  void testGetBoundingBox() {
     OSHDBBoundingBox result = XYGrid.getBoundingBox(new CellId(2, 2));
     OSHDBBoundingBox expResult =
         bboxWgs84Coordinates(0.0, -90.0, 90.0 - GEOM_PRECISION, 0.0 - GEOM_PRECISION);

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTest.java
@@ -2,7 +2,7 @@ package org.heigit.ohsome.oshdb.index;
 
 import static org.heigit.ohsome.oshdb.OSHDBBoundingBox.bboxWgs84Coordinates;
 import static org.heigit.ohsome.oshdb.osm.OSMCoordinates.GEOM_PRECISION;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.Set;
 import java.util.TreeSet;
@@ -10,7 +10,7 @@ import org.heigit.ohsome.oshdb.OSHDB;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.index.XYGrid.IdRange;
 import org.heigit.ohsome.oshdb.util.CellId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTreeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTreeTest.java
@@ -1,7 +1,7 @@
 package org.heigit.ohsome.oshdb.index;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Sets;
 import java.util.HashSet;
@@ -9,7 +9,7 @@ import java.util.Iterator;
 import java.util.Set;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.util.CellId;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("checkstyle:abbreviationAsWordInName")
 public class XYGridTreeTest {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTreeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/index/XYGridTreeTest.java
@@ -12,10 +12,10 @@ import org.heigit.ohsome.oshdb.util.CellId;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("checkstyle:abbreviationAsWordInName")
-public class XYGridTreeTest {
+class XYGridTreeTest {
 
   @Test
-  public void testGetIds() {
+  void testGetIds() {
     double longitude = 0.1;
     double latitude = 0.1;
     XYGridTree instance = new XYGridTree(4);
@@ -30,7 +30,7 @@ public class XYGridTreeTest {
   }
 
   @Test
-  public void testGetInsertId() {
+  void testGetInsertId() {
     OSHDBBoundingBox bbox = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, -90.0, 179.0, 90.0);
     XYGridTree instance = new XYGridTree(4);
     CellId expResult = new CellId(2, 2L);
@@ -54,7 +54,7 @@ public class XYGridTreeTest {
   }
 
   @Test
-  public void testBbox2CellIds_BoundingBox_boolean() {
+  void testBbox2CellIds_BoundingBox_boolean() {
     HashSet<CellId> expectedCellIds = new HashSet<>(4);
     expectedCellIds.add(new CellId(3, 20L));
     expectedCellIds.add(new CellId(2, 6L));
@@ -71,7 +71,7 @@ public class XYGridTreeTest {
   }
 
   @Test
-  public void testBbox2CellIds_BoundingBox2_boolean() {
+  void testBbox2CellIds_BoundingBox2_boolean() {
     HashSet<CellId> expectedCellIds = new HashSet<>(16);
     expectedCellIds.add(new CellId(3, 12L));
     expectedCellIds.add(new CellId(3, 11L));

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHEntityTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHEntityTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.osh;
 
 import static org.heigit.ohsome.oshdb.osh.OSHNodeTest.buildOSHNode;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -10,7 +10,7 @@ import java.util.Collections;
 import org.heigit.ohsome.oshdb.impl.osh.OSHRelationImpl;
 import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMMember;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
 public class OSHEntityTest {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHEntityTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHEntityTest.java
@@ -12,11 +12,10 @@ import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMMember;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("javadoc")
-public class OSHEntityTest {
+class OSHEntityTest {
 
   @Test
-  public void testHashCodeEquals() throws IOException {
+  void testHashCodeEquals() throws IOException {
     var expected = buildOSHNode(
         OSM.node(123L, 1, 1L, 0L, 1, new int[0], 0, 0)
     );
@@ -35,5 +34,4 @@ public class OSHEntityTest {
     assertEquals(expected, a);
     assertNotEquals(expected, b);
   }
-
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHNodeTest.java
@@ -17,15 +17,14 @@ import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMNode;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("javadoc")
-public class OSHNodeTest {
+class OSHNodeTest {
   private static final int USER_A = 1;
   private static final int[] TAGS_A = new int[] {1, 1};
   private static final int[] LONLAT_A = new int[] {86756350, 494186210};
   private static final int[] LONLAT_B = new int[] {87153340, 494102830};
 
   @Test
-  public void testBuildAndSerialize() throws IOException, ClassNotFoundException {
+  void testBuildAndSerialize() throws IOException, ClassNotFoundException {
     OSHNode hnode = buildOSHNode(
         OSM.node(123L, 1, 1L, 0L, USER_A, TAGS_A, LONLAT_A[0], LONLAT_A[1]),
         OSM.node(123L, -2, 2L, 0L, USER_A, TAGS_A, LONLAT_A[0], LONLAT_A[1])
@@ -52,7 +51,7 @@ public class OSHNodeTest {
   }
 
   @Test
-  public void testToString() throws IOException {
+  void testToString() throws IOException {
     OSHNode instance = buildOSHNode(
         OSM.node(123L, 2, 2L, 0L, USER_A, TAGS_A, LONLAT_A[0], LONLAT_A[1]),
         OSM.node(123L, 1, 1L, 0L, USER_A, TAGS_A, LONLAT_B[0], LONLAT_B[1])
@@ -65,7 +64,7 @@ public class OSHNodeTest {
   }
 
   @Test
-  public void testHashCodeEquals() throws IOException {
+  void testHashCodeEquals() throws IOException {
     var expected = buildOSHNode(
         OSM.node(123L, 1, 1L, 0L, USER_A, TAGS_A, 0, 0)
     );

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHNodeTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.osh;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -15,7 +15,7 @@ import java.util.List;
 import org.heigit.ohsome.oshdb.impl.osh.OSHNodeImpl;
 import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMNode;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
 public class OSHNodeTest {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
@@ -1,10 +1,10 @@
 package org.heigit.ohsome.oshdb.osh;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -22,7 +22,7 @@ import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMMember;
 import org.heigit.ohsome.oshdb.osm.OSMRelation;
 import org.heigit.ohsome.oshdb.osm.OSMType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
 public class OSHRelationTest {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
@@ -24,8 +24,7 @@ import org.heigit.ohsome.oshdb.osm.OSMRelation;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("javadoc")
-public class OSHRelationTest {
+class OSHRelationTest {
 
   OSHNode node100 = OSHNodeTest.buildOSHNode(OSM.node(
       100L, 1, 1L, 0L, 123, new int[]{1, 2}, 494094980, 86809720));
@@ -48,7 +47,7 @@ public class OSHRelationTest {
   public OSHRelationTest() throws IOException {}
 
   @Test
-  public void testGetNodes() throws IOException {
+  void testGetNodes() throws IOException {
     OSHRelation hrelation = OSHRelationImpl.build(Lists.newArrayList(
         OSM.relation(300, 1, 3333L, 4444L, 23, new int[]{}, new OSMMember[]{
             new OSMMember(100, OSMType.NODE, 0),
@@ -61,7 +60,7 @@ public class OSHRelationTest {
   }
 
   @Test
-  public void testWithMissingNode() throws IOException {
+  void testWithMissingNode() throws IOException {
     OSHRelation hrelation = OSHRelationImpl.build(Lists.newArrayList(
         OSM.relation(300, 1, 3333L, 4444L, 23, new int[]{}, new OSMMember[]{
             new OSMMember(100, OSMType.NODE, 0),
@@ -90,7 +89,7 @@ public class OSHRelationTest {
   }
 
   @Test
-  public void testGetWays() throws IOException {
+  void testGetWays() throws IOException {
     OSHRelation hrelation = OSHRelationImpl.build(Lists.newArrayList(
         OSM.relation(300, 1, 3333L, 4444L, 23, new int[]{}, new OSMMember[]{
             new OSMMember(200, OSMType.WAY, 0),
@@ -107,7 +106,7 @@ public class OSHRelationTest {
   }
 
   @Test
-  public void testCompactAndSerialize() throws IOException, ClassNotFoundException {
+  void testCompactAndSerialize() throws IOException, ClassNotFoundException {
     OSHRelation hrelation = OSHRelationImpl.build(Lists.newArrayList(
         OSM.relation(300, 1, 3333L, 4444L, 23, new int[]{}, new OSMMember[]{
             new OSMMember(100, OSMType.NODE, 0),
@@ -169,7 +168,7 @@ public class OSHRelationTest {
   }
 
   @Test
-  public void testToString() throws IOException {
+  void testToString() throws IOException {
     OSHRelation instance = OSHRelationImpl.build(Lists.newArrayList(
         OSM.relation(300, 1, 3333L, 4444L, 23, new int[]{}, new OSMMember[]{
             new OSMMember(100, OSMType.NODE, 0),
@@ -183,7 +182,7 @@ public class OSHRelationTest {
   }
 
   @Test
-  public void testHashCodeEquals() throws IOException {
+  void testHashCodeEquals() throws IOException {
     var expected = OSHRelationImpl.build(Lists.newArrayList(
         OSM.relation(123L, 1, 3333L, 4444L, 23, new int[]{},
             new OSMMember[]{})), Collections.emptyList(), Collections.emptyList());

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHRelationTest.java
@@ -44,7 +44,7 @@ class OSHRelationTest {
           new OSMMember(102, OSMType.NODE, 0)})
   ), List.of(node100, node102));
 
-  public OSHRelationTest() throws IOException {}
+  OSHRelationTest() throws IOException {}
 
   @Test
   void testGetNodes() throws IOException {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
@@ -29,7 +29,7 @@ class OSHWayTest {
   OSHNode node104 = OSHNodeTest.buildOSHNode(OSM.node(
       104L, 1, 1L, 0L, 123, new int[]{2, 4}, 494094984, 86809727));
 
-  public OSHWayTest() throws IOException {}
+  OSHWayTest() throws IOException {}
 
   @Test
   void testGetNodes() throws IOException, ClassNotFoundException {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
@@ -1,9 +1,9 @@
 package org.heigit.ohsome.oshdb.osh;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -18,7 +18,7 @@ import org.heigit.ohsome.oshdb.impl.osh.OSHWayImpl;
 import org.heigit.ohsome.oshdb.osm.OSM;
 import org.heigit.ohsome.oshdb.osm.OSMMember;
 import org.heigit.ohsome.oshdb.osm.OSMType;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("javadoc")
 public class OSHWayTest {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osh/OSHWayTest.java
@@ -20,8 +20,7 @@ import org.heigit.ohsome.oshdb.osm.OSMMember;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.junit.jupiter.api.Test;
 
-@SuppressWarnings("javadoc")
-public class OSHWayTest {
+class OSHWayTest {
 
   OSHNode node100 = OSHNodeTest.buildOSHNode(OSM.node(
       100L, 1, 1L, 0L, 123, new int[]{1, 2}, 494094984, 86809727));
@@ -33,7 +32,7 @@ public class OSHWayTest {
   public OSHWayTest() throws IOException {}
 
   @Test
-  public void testGetNodes() throws IOException, ClassNotFoundException {
+  void testGetNodes() throws IOException, ClassNotFoundException {
     OSHWay hway = OSHWayImpl.build(Lists.newArrayList(
         OSM.way(123, 1, 3333L, 4444L, 23, new int[]{1, 1, 2, 1},
             new OSMMember[]{
@@ -64,7 +63,7 @@ public class OSHWayTest {
   }
 
   @Test
-  public void testWithMissingNode() throws IOException {
+  void testWithMissingNode() throws IOException {
     OSHWay hway = OSHWayImpl.build(Lists.newArrayList(
         OSM.way(123, 3, 3333L, 4444L, 23, new int[]{1, 1, 2, 2},
             new OSMMember[]{
@@ -98,7 +97,7 @@ public class OSHWayTest {
   }
 
   @Test
-  public void testToString() throws IOException {
+  void testToString() throws IOException {
     OSHWay instance = OSHWayImpl.build(Lists.newArrayList(
         OSM.way(123, 1, 3333L, 4444L, 23, new int[]{1, 1, 2, 1},
             new OSMMember[]{
@@ -117,7 +116,7 @@ public class OSHWayTest {
   }
 
   @Test
-  public void testHashCodeEquals() throws IOException {
+  void testHashCodeEquals() throws IOException {
     var expected = OSHWayImpl.build(Lists.newArrayList(
         OSM.way(123L, 1, 3333L, 4444L, 23, new int[]{},
             new OSMMember[]{})), Arrays.asList());

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMMemberTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMMemberTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.osm;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OSMMemberTest {
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMMemberTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMMemberTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class OSMMemberTest {
+class OSMMemberTest {
 
   public OSMMemberTest() {}
 
   @Test
-  public void testGetId() {
+  void testGetId() {
     OSMMember instance = new OSMMember(1L, OSMType.WAY, 1);
     long expResult = 1L;
     long result = instance.getId();
@@ -17,7 +17,7 @@ public class OSMMemberTest {
   }
 
   @Test
-  public void testGetType() {
+  void testGetType() {
     OSMMember instance = new OSMMember(1L, OSMType.WAY, 1);
     OSMType expResult = OSMType.WAY;
     OSMType result = instance.getType();
@@ -25,7 +25,7 @@ public class OSMMemberTest {
   }
 
   @Test
-  public void testGetRoleId() {
+  void testGetRoleId() {
     OSMMember instance = new OSMMember(1L, OSMType.WAY, 1);
     int expResult = 1;
     int result = instance.getRawRoleId();
@@ -33,7 +33,7 @@ public class OSMMemberTest {
   }
 
   @Test
-  public void testGetData() {
+  void testGetData() {
     // getEntity (explicit null)
     OSMMember instance = new OSMMember(1L, OSMType.WAY, 1, null);
     Object expResult = null;
@@ -42,7 +42,7 @@ public class OSMMemberTest {
   }
 
   @Test
-  public void testGetData2() {
+  void testGetData2() {
     // getEntity (implicit null)
     OSMMember instance = new OSMMember(1L, OSMType.WAY, 1);
     Object expResult = null;
@@ -51,11 +51,10 @@ public class OSMMemberTest {
   }
 
   @Test
-  public void testToString() {
+  void testToString() {
     OSMMember instance = new OSMMember(1L, OSMType.WAY, 1);
     String expResult = "T:WAY ID:1 R:1";
     String result = instance.toString();
     assertEquals(expResult, result);
   }
-
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMMemberTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMMemberTest.java
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test;
 
 class OSMMemberTest {
 
-  public OSMMemberTest() {}
+  OSMMemberTest() {}
 
   @Test
   void testGetId() {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
@@ -5,12 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.jupiter.api.Test;
 
-public class OSMNodeTest {
+class OSMNodeTest {
 
   public OSMNodeTest() {}
 
   @Test
-  public void testGetLongitude() {
+  void testGetLongitude() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1);
     double expResult = 100.0;
     double result = instance.getLongitude();
@@ -18,7 +18,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testGetLatitude() {
+  void testGetLatitude() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     double expResult = 100.0;
     double result = instance.getLatitude();
@@ -26,7 +26,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testGetLon() {
+  void testGetLon() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1000000000L;
     long result = instance.getLon();
@@ -34,7 +34,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testGetLat() {
+  void testGetLat() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1000000000L;
     long result = instance.getLat();
@@ -42,7 +42,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testToString() {
+  void testToString() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1100000000, 100000000);
     String expResult = "NODE: ID:1 V:+1+ TS:1 CS:1 VIS:true UID:1 TAGS:[] 110.0000000:10.0000000";
     String result = instance.toString();
@@ -50,7 +50,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testEquals() {
+  void testEquals() {
     OSMNode o =
         OSM.node(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     OSMNode instance =
@@ -61,7 +61,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testEquals2() {
+  void testEquals2() {
     OSMNode o =
         OSM.node(2L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2, 3, 3}, 1000000000, 1000000000);
     OSMNode instance =
@@ -73,7 +73,7 @@ public class OSMNodeTest {
 
   // -------------------
   @Test
-  public void testGetId() {
+  void testGetId() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1L;
     long result = instance.getId();
@@ -81,7 +81,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testGetVersion() {
+  void testGetVersion() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     int expResult = 1;
     int result = instance.getVersion();
@@ -89,7 +89,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testGetTimestamp() {
+  void testGetTimestamp() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1L;
     long result = instance.getEpochSecond();
@@ -97,7 +97,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testGetChangeset() {
+  void testGetChangeset() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     long expResult = 1L;
     long result = instance.getChangesetId();
@@ -105,7 +105,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testGetUserId() {
+  void testGetUserId() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     int expResult = 1;
     int result = instance.getUserId();
@@ -113,7 +113,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testisVisible() {
+  void testisVisible() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     boolean expResult = true;
     boolean result = instance.isVisible();
@@ -121,7 +121,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testisVisible2() {
+  void testisVisible2() {
     OSMNode instance = OSM.node(1L, -1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     boolean expResult = false;
     boolean result = instance.isVisible();
@@ -129,7 +129,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testGetTags() {
+  void testGetTags() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     var expResult = OSHDBTags.empty();
     var result = instance.getTags();
@@ -137,7 +137,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testHasTagKey() {
+  void testHasTagKey() {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     boolean expResult = false;
     boolean result = instance.getTags().hasTagKey(1);
@@ -168,7 +168,7 @@ public class OSMNodeTest {
   }
 
   @Test
-  public void testHasTagValue() {
+  void testHasTagValue() {
     OSMNode instance =
         OSM.node(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 3}, 1000000000, 1000000000);
     boolean expResult = false;
@@ -183,7 +183,7 @@ public class OSMNodeTest {
 
   // --------------------
   @Test
-  public void testEqualsToOSMNode() {
+  void testEqualsToOSMNode() {
     long id = 123;
     int version = 1;
     long timestamp = 310172400000L;
@@ -197,5 +197,4 @@ public class OSMNodeTest {
     OSMNode b = OSM.node(id, version, timestamp, changeset, userId, tags, longitude, latitude);
     assertEquals(true, a.equals(b));
   }
-
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 
 class OSMNodeTest {
 
-  public OSMNodeTest() {}
+  OSMNodeTest() {}
 
   @Test
   void testGetLongitude() {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMNodeTest.java
@@ -1,10 +1,9 @@
 package org.heigit.ohsome.oshdb.osm;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.heigit.ohsome.oshdb.OSHDBTags;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OSMNodeTest {
 
@@ -134,7 +133,7 @@ public class OSMNodeTest {
     OSMNode instance = OSM.node(1L, 1, 1L, 1L, 1, new int[] {}, 1000000000, 1000000000);
     var expResult = OSHDBTags.empty();
     var result = instance.getTags();
-    Assert.assertEquals(expResult, result);
+    assertEquals(expResult, result);
   }
 
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
@@ -6,13 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.jupiter.api.Test;
 
-public class OSMRelationTest {
+class OSMRelationTest {
 
   public OSMRelationTest() {
   }
 
   @Test
-  public void testGetMembers() {
+  void testGetMembers() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
@@ -23,7 +23,7 @@ public class OSMRelationTest {
 
   // -----------------------
   @Test
-  public void testGetId() {
+  void testGetId() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
@@ -33,7 +33,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testGetVersion() {
+  void testGetVersion() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
@@ -43,7 +43,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testGetTimestamp() {
+  void testGetTimestamp() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
@@ -53,7 +53,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testGetChangeset() {
+  void testGetChangeset() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
@@ -63,7 +63,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testGetUserId() {
+  void testGetUserId() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
@@ -73,7 +73,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testisVisible() {
+  void testisVisible() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
@@ -90,7 +90,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testGetTags() {
+  void testGetTags() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
@@ -100,7 +100,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testHasTagKey() {
+  void testHasTagKey() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
@@ -138,7 +138,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testHasTagValue() {
+  void testHasTagValue() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 3}, new OSMMember[] {part, part});
@@ -148,7 +148,7 @@ public class OSMRelationTest {
   }
 
   @Test
-  public void testHasTagValue2() {
+  void testHasTagValue2() {
     OSMMember part = new OSMMember(1L, OSMType.WAY, 1);
     OSMRelation instance =
         OSM.relation(1L, 1, 1L, 1L, 1, new int[] {1, 1, 2, 3}, new OSMMember[] {part, part});

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
@@ -8,8 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class OSMRelationTest {
 
-  public OSMRelationTest() {
-  }
+  OSMRelationTest() {}
 
   @Test
   void testGetMembers() {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMRelationTest.java
@@ -1,11 +1,10 @@
 package org.heigit.ohsome.oshdb.osm;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.heigit.ohsome.oshdb.OSHDBTags;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OSMRelationTest {
 
@@ -97,7 +96,7 @@ public class OSMRelationTest {
         OSM.relation(1L, 2, 1L, 1L, 1, new int[] {1, 1, 2, 2}, new OSMMember[] {part, part});
     var expResult = OSHDBTags.of(new int[] {1, 1, 2, 2});
     var result = instance.getTags();
-    Assert.assertEquals(expResult, result);
+    assertEquals(expResult, result);
   }
 
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 class OSMWayTest {
 
-  public OSMWayTest() {}
+  OSMWayTest() {}
 
   @Test
   void testGetRefs() {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
@@ -1,11 +1,10 @@
 package org.heigit.ohsome.oshdb.osm;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.heigit.ohsome.oshdb.OSHDBTags;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OSMWayTest {
 
@@ -97,7 +96,7 @@ public class OSMWayTest {
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {1, 1}, new OSMMember[] {part, part});
     var expResult = OSHDBTags.of(new int[] {1, 1});
     var result = instance.getTags();
-    Assert.assertEquals(expResult, result);
+    assertEquals(expResult, result);
   }
 
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/osm/OSMWayTest.java
@@ -6,12 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.heigit.ohsome.oshdb.OSHDBTags;
 import org.junit.jupiter.api.Test;
 
-public class OSMWayTest {
+class OSMWayTest {
 
   public OSMWayTest() {}
 
   @Test
-  public void testGetRefs() {
+  void testGetRefs() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     OSMMember[] expResult = new OSMMember[] {part, part};
@@ -31,7 +31,7 @@ public class OSMWayTest {
 
   // ---------------
   @Test
-  public void testGetId() {
+  void testGetId() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     long expResult = 1L;
@@ -40,7 +40,7 @@ public class OSMWayTest {
   }
 
   @Test
-  public void testGetVersion() {
+  void testGetVersion() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     int expResult = 1;
@@ -49,7 +49,7 @@ public class OSMWayTest {
   }
 
   @Test
-  public void testGetTimestamp() {
+  void testGetTimestamp() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     long expResult = 1L;
@@ -58,7 +58,7 @@ public class OSMWayTest {
   }
 
   @Test
-  public void testGetChangeset() {
+  void testGetChangeset() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     long expResult = 1L;
@@ -67,7 +67,7 @@ public class OSMWayTest {
   }
 
   @Test
-  public void testGetUserId() {
+  void testGetUserId() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     int expResult = 1;
@@ -76,7 +76,7 @@ public class OSMWayTest {
   }
 
   @Test
-  public void testisVisible() {
+  void testisVisible() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     boolean expResult = true;
@@ -91,7 +91,7 @@ public class OSMWayTest {
   }
 
   @Test
-  public void testGetTags() {
+  void testGetTags() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {1, 1}, new OSMMember[] {part, part});
     var expResult = OSHDBTags.of(new int[] {1, 1});
@@ -100,7 +100,7 @@ public class OSMWayTest {
   }
 
   @Test
-  public void testHasTagKey() {
+  void testHasTagKey() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance = OSM.way(1L, 1, 1L, 1L, 1, new int[] {}, new OSMMember[] {part, part});
     boolean expResult = false;
@@ -136,7 +136,7 @@ public class OSMWayTest {
   }
 
   @Test
-  public void testHasTagValue() {
+  void testHasTagValue() {
     OSMMember part = new OSMMember(1L, OSMType.NODE, 1);
     OSMWay instance =
         OSM.way(1L, 1, 1L, 1L, 1, new int[] {1, 2, 2, 3}, new OSMMember[] {part, part});

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/CellIdTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/CellIdTest.java
@@ -1,8 +1,8 @@
 package org.heigit.ohsome.oshdb.util;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class CellIdTest {
   public CellIdTest() {

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/CellIdTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/CellIdTest.java
@@ -4,12 +4,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-public class CellIdTest {
-  public CellIdTest() {
-  }
+class CellIdTest {
 
   @Test
-  public void testGetid() {
+  void testGetid() {
     CellId instance = new CellId(1, 1L);
     long expResult = 1L;
     long result = instance.getId();
@@ -17,7 +15,7 @@ public class CellIdTest {
   }
 
   @Test
-  public void testGetzoomlevel() {
+  void testGetzoomlevel() {
     CellId instance = new CellId(1, 1L);
     int expResult = 1;
     int result = instance.getZoomLevel();

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundableTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundableTest.java
@@ -1,12 +1,12 @@
 package org.heigit.ohsome.oshdb.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBBoundable;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OSHDBBoundableTest {
   private OSHDBBoundable point = OSHDBBoundingBox.bboxOSMCoordinates(0, 0, 0, 0);

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundableTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundableTest.java
@@ -8,18 +8,18 @@ import org.heigit.ohsome.oshdb.OSHDBBoundable;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.junit.jupiter.api.Test;
 
-public class OSHDBBoundableTest {
+class OSHDBBoundableTest {
   private OSHDBBoundable point = OSHDBBoundingBox.bboxOSMCoordinates(0, 0, 0, 0);
   private OSHDBBoundable box = OSHDBBoundingBox.bboxOSMCoordinates(-1, -1, 1, 1);
 
   @Test
-  public void testPoint() {
+  void testPoint() {
     assertTrue(point.isPoint());
     assertFalse(box.isPoint());
   }
 
   @Test
-  public void testValid() {
+  void testValid() {
     assertTrue(point.isValid());
     assertTrue(box.isValid());
     OSHDBBoundable invalid = OSHDBBoundingBox.bboxOSMCoordinates(1, 1, -1, -1);
@@ -27,19 +27,19 @@ public class OSHDBBoundableTest {
   }
 
   @Test
-  public void testCovered() {
+  void testCovered() {
     assertTrue(point.coveredBy(box));
     assertFalse(point.coveredBy(null));
   }
 
   @Test
-  public void testIntersects() {
+  void testIntersects() {
     assertTrue(point.intersects(box));
     assertFalse(point.intersects(null));
   }
 
   @Test
-  public void testIntersection() {
+  void testIntersection() {
     OSHDBBoundable box2 = OSHDBBoundingBox.bboxOSMCoordinates(0, 0, 2, 2);
     OSHDBBoundable intersection = box2.intersection(box);
     assertEquals(0, intersection.getMinLongitude());

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
@@ -6,13 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.junit.jupiter.api.Test;
 
-public class OSHDBBoundingBoxTest {
-
-  public OSHDBBoundingBoxTest() {
-  }
+class OSHDBBoundingBoxTest {
 
   @Test
-  public void testToString() {
+  void testToString() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 1.0, 89.0, 90.0);
     String expResult = "(0.0000000,1.0000000,89.0000000,90.0000000)";
     String result = instance.toString();
@@ -20,7 +17,7 @@ public class OSHDBBoundingBoxTest {
   }
 
   @Test
-  public void testIntersect() {
+  void testIntersect() {
     OSHDBBoundingBox first = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     OSHDBBoundingBox second = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.9, 2.0, 90.0);
     OSHDBBoundingBox expResult = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.9, 1.0, 90.0);
@@ -29,7 +26,7 @@ public class OSHDBBoundingBoxTest {
   }
 
   @Test
-  public void testGetMinLon() {
+  void testGetMinLon() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 0;
     int result = instance.getMinLongitude();
@@ -37,7 +34,7 @@ public class OSHDBBoundingBoxTest {
   }
 
   @Test
-  public void testGetMaxLon() {
+  void testGetMaxLon() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 1_0000000;
     int result = instance.getMaxLongitude();
@@ -45,7 +42,7 @@ public class OSHDBBoundingBoxTest {
   }
 
   @Test
-  public void testGetMinLat() {
+  void testGetMinLat() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 89_0000000;
     int result = instance.getMinLatitude();
@@ -53,7 +50,7 @@ public class OSHDBBoundingBoxTest {
   }
 
   @Test
-  public void testGetMaxLat() {
+  void testGetMaxLat() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 90_0000000;
     int result = instance.getMaxLatitude();
@@ -61,7 +58,7 @@ public class OSHDBBoundingBoxTest {
   }
 
   @Test
-  public void testHashCode() {
+  void testHashCode() {
     OSHDBBoundingBox instance = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     int expResult = 1260356225;
     int result = instance.hashCode();
@@ -69,12 +66,11 @@ public class OSHDBBoundingBoxTest {
   }
 
   @Test
-  public void testEquals() {
+  void testEquals() {
     Object obj = OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0);
     assertEquals(obj, obj);
     assertNotEquals("", obj);
     assertEquals(obj, OSHDBBoundingBox.bboxWgs84Coordinates(0.0, 89.0, 1.0, 90.0));
     assertNotEquals(obj, OSHDBBoundingBox.bboxWgs84Coordinates(0.1, 89.0, 1.0, 90.0));
   }
-
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBBoundingBoxTest.java
@@ -1,10 +1,10 @@
 package org.heigit.ohsome.oshdb.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OSHDBBoundingBoxTest {
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBTemporalTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBTemporalTest.java
@@ -1,11 +1,11 @@
 package org.heigit.ohsome.oshdb.util;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTemporal;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class OSHDBTemporalTest {
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBTemporalTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/OSHDBTemporalTest.java
@@ -7,9 +7,9 @@ import org.heigit.ohsome.oshdb.OSHDBTemporal;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
 import org.junit.jupiter.api.Test;
 
-public class OSHDBTemporalTest {
+class OSHDBTemporalTest {
   @Test
-  public void testBeforeAfter() {
+  void testBeforeAfter() {
     OSHDBTemporal t1 = new OSHDBTimestamp(0);
     OSHDBTemporal t2 = new OSHDBTimestamp(1);
     assertTrue(t1.isBefore(t2));

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/bytearray/ByteArrayOutputWrapperTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/bytearray/ByteArrayOutputWrapperTest.java
@@ -10,10 +10,10 @@ import org.junit.jupiter.api.Test;
 /**
  *  General {@link ByteArrayOutputWrapper} test case.
  */
-public class ByteArrayOutputWrapperTest {
+class ByteArrayOutputWrapperTest {
 
   @Test
-  public void testWriteU32() throws IOException {
+  void testWriteU32() throws IOException {
     var bao = new ByteArrayOutputWrapper(1024);
 
     assertWriteU32(bao, bytes(0x00), 0);
@@ -26,7 +26,7 @@ public class ByteArrayOutputWrapperTest {
   }
 
   @Test
-  public void testReadU32() throws IOException {
+  void testReadU32() throws IOException {
     assertReadU32(bytes(0x00), 0);
     assertReadU32(bytes(0x01), 1);
     assertReadU32(bytes(0x7f), 127);
@@ -37,7 +37,7 @@ public class ByteArrayOutputWrapperTest {
   }
 
   @Test
-  public void testWriteS32() throws IOException {
+  void testWriteS32() throws IOException {
     var bao = new ByteArrayOutputWrapper(1024);
 
     assertWriteS32(bao, bytes(0x00), 0);
@@ -56,7 +56,7 @@ public class ByteArrayOutputWrapperTest {
   }
 
   @Test
-  public void testReadS32() throws IOException {
+  void testReadS32() throws IOException {
     assertReadS32(bytes(0x00), 0);
     assertReadS32(bytes(0x01), -1);
     assertReadS32(bytes(0x02), 1);
@@ -73,7 +73,7 @@ public class ByteArrayOutputWrapperTest {
   }
 
   @Test
-  public void testWriteU64() throws IOException {
+  void testWriteU64() throws IOException {
     var bao = new ByteArrayOutputWrapper(1024);
 
     assertWriteU64(bao, bytes(0x00), 0);
@@ -87,7 +87,7 @@ public class ByteArrayOutputWrapperTest {
   }
 
   @Test
-  public void testReadU64() throws IOException {
+  void testReadU64() throws IOException {
     assertReadU64(bytes(0x00), 0);
     assertReadU64(bytes(0x01), 1);
     assertReadU64(bytes(0x7f), 127);
@@ -98,7 +98,7 @@ public class ByteArrayOutputWrapperTest {
   }
 
   @Test
-  public void testWriteS64() throws IOException {
+  void testWriteS64() throws IOException {
     var bao = new ByteArrayOutputWrapper(1024);
 
     assertWriteS64(bao, bytes(0x00), 0);
@@ -121,7 +121,7 @@ public class ByteArrayOutputWrapperTest {
   }
 
   @Test
-  public void testReadS64() throws IOException {
+  void testReadS64() throws IOException {
     assertReadS64(bytes(0x00), 0);
     assertReadS64(bytes(0x01), -1);
     assertReadS64(bytes(0x02), 1);
@@ -142,7 +142,7 @@ public class ByteArrayOutputWrapperTest {
   }
 
   @Test
-  public void testWriteByteArray() throws IOException {
+  void testWriteByteArray() throws IOException {
     var bao = new ByteArrayOutputWrapper(1024);
     var bytes = bytes(0xc4, 0xe8, 0x01);
     bao.writeByteArray(bytes);

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/bytearray/ByteArrayOutputWrapperTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/util/bytearray/ByteArrayOutputWrapperTest.java
@@ -1,11 +1,11 @@
 package org.heigit.ohsome.oshdb.util.bytearray;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.Arrays;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  *  General {@link ByteArrayOutputWrapper} test case.

--- a/pom.xml
+++ b/pom.xml
@@ -63,9 +63,18 @@
         <version>${junit.version}</version>
         <type>pom</type>
         <scope>import</scope>
-    </dependency>
+      </dependency>
     </dependencies>
   </dependencyManagement>
+  
+  <dependencies>
+    <!-- TEST dependencies -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
   <repositories>
     <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <h2.version>1.4.197</h2.version>
     <postgresql.version>42.1.4</postgresql.version>
     <slf4j.version>1.7.32</slf4j.version>
-    <junit.version>4.13.1</junit.version>
+    <junit.version>5.8.2</junit.version>
     <rxjava2.version>2.1.9</rxjava2.version>
     <jetbrainsannotations.version>13.0</jetbrainsannotations.version>
     
@@ -58,11 +58,12 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
         <version>${junit.version}</version>
-        <scope>test</scope>
-      </dependency>
+        <type>pom</type>
+        <scope>import</scope>
+    </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Migrating from junit4 to junit5. 

The migrations was mostly straight forward, changing import from 
`org.junit` to `org.junit.jupiter.api`.

In the `oshdb-util` module there is a dependency to `json-simple` which includes `junit4` as a compile dependency. But if you check the github project the scope of the junit4 dependency is reduced to `test` as it should be. So in this PR we exculde the `junit4` dependency of `json-simple`.

There are some test which checks explicit that an exception is NOT thrown. Like
```
try {
  OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
} catch (Exception e) {
  e.printStackTrace();
  fail("Should not have thrown any exception");
}
```
which is now replaces with:
```
assertDoesNotThrow(() -> {
  OSHDBGeometryBuilder.getGeometry(entity1, timestamp, areaDecider);
});
```
We could discuss if this check is actually necessary.


### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- ~[ ] I have written javadoc (required for public classes and methods)~
- ~[ ] I have added sufficient unit tests~
- [ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~[ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~[ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
