### PR TITLE
replace simple lambda function calls in OSHDB API tests

### DIFF
--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBIgniteMissingCache.java
@@ -23,48 +23,36 @@ class TestMapReduceOSHDBIgniteMissingCache extends TestMapReduceOSHDBIgnite {
   @Override
   @Test()
   void testOSMContributionView() throws Exception {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMContributionView();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, super::testOSMContributionView);
   }
 
   @Override
   @Test()
   void testOSMEntitySnapshotView() throws Exception {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMEntitySnapshotView();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, super::testOSMEntitySnapshotView);
   }
 
   @Override
   @Test()
   void testOSMContributionViewStream() throws Exception {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMContributionViewStream();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, super::testOSMContributionViewStream);
   }
 
   @Override
   @Test()
   void testOSMEntitySnapshotViewStream() throws Exception {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMEntitySnapshotViewStream();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, super::testOSMEntitySnapshotViewStream);
   }
 
   @Override
   @Test()
   void testTimeoutMapReduce() throws Exception {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      timeoutMapReduce();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, this::timeoutMapReduce);
   }
 
   @Override
   @Test()
   void testTimeoutStream() {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      timeoutStream();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, this::timeoutStream);
   }
 }

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduce.java
@@ -195,9 +195,7 @@ abstract class TestMapReduce {
 
   @Test
   void testTimeoutMapReduce() throws Exception {
-    assertThrows(OSHDBTimeoutException.class, () -> {
-      timeoutMapReduce();
-    });
+    assertThrows(OSHDBTimeoutException.class, this::timeoutMapReduce);
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored") // we only test for thrown exceptions here
@@ -220,9 +218,7 @@ abstract class TestMapReduce {
 
   @Test
   void testTimeoutStream() throws Exception {
-    assertThrows(OSHDBTimeoutException.class, () -> {
-      timeoutStream();
-    });
+    assertThrows(OSHDBTimeoutException.class, this::timeoutStream);
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored") // we only test for thrown exceptions here

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestMapReduceOSHDBJdbcMissingTables.java
@@ -24,48 +24,36 @@ class TestMapReduceOSHDBJdbcMissingTables extends TestMapReduce {
   @Override
   @Test()
   void testOSMContributionView() {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMContributionView();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, super::testOSMContributionView);
   }
 
   @Override
   @Test()
   void testOSMEntitySnapshotView() {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMEntitySnapshotView();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, super::testOSMEntitySnapshotView);
   }
 
   @Override
   @Test()
   void testOSMContributionViewStream() {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMContributionViewStream();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, super::testOSMContributionViewStream);
   }
 
   @Override
   @Test()
   void testOSMEntitySnapshotViewStream() {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      super.testOSMEntitySnapshotViewStream();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, super::testOSMEntitySnapshotViewStream);
   }
 
   @Override
   @Test()
   void testTimeoutMapReduce() throws Exception {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      timeoutMapReduce();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, this::timeoutMapReduce);
   }
 
   @Override
   @Test()
   void testTimeoutStream() {
-    assertThrows(OSHDBTableNotFoundException.class, () -> {
-      timeoutStream();
-    });
+    assertThrows(OSHDBTableNotFoundException.class, this::timeoutStream);
   }
 }


### PR DESCRIPTION
### Description
Use method references instead of simple function calls in lambda functions in OSHDB API tests

### Corresponding issue
follow-up to #450

### New or changed dependencies
None

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- ~[ ] I have written javadoc (required for public classes and methods)~
- ~[ ] I have added sufficient unit tests~
- ~[ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- ~[ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)~
- ~[ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~[ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~