### PR TITLE
add comparable to oshdbtag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Changelog
 * remove `OSMMember.getRawRoleId` ([#453])
 * refactor `OSHDBRole` and move to oshdb-core ([#453])
 * update jts dependency to version 1.18.2
+* add natural order to `OSHDBTag` ([#454])
 
 [#419]: https://github.com/GIScience/oshdb/pull/419
 [#433]: https://github.com/GIScience/oshdb/issues/433
@@ -30,6 +31,7 @@ Changelog
 [#447]: https://github.com/GIScience/oshdb/pull/447
 [#449]: https://github.com/GIScience/oshdb/pull/449
 [#453]: https://github.com/GIScience/oshdb/pull/453
+[#454]: https://github.com/GIScience/oshdb/pull/454
 
 ## 0.7.2
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTag.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTag.java
@@ -1,9 +1,13 @@
 package org.heigit.ohsome.oshdb;
 
 import java.io.Serializable;
+import java.util.Comparator;
 import java.util.Objects;
 
-public class OSHDBTag implements Serializable {
+public class OSHDBTag implements Comparable<OSHDBTag>, Serializable {
+  public static final Comparator<OSHDBTag> ORDER_BY_ID = Comparator
+      .comparingInt(OSHDBTag::getKey)
+      .thenComparingInt(OSHDBTag::getValue);
 
   private static final long serialVersionUID = 1L;
   private final int key;
@@ -24,6 +28,11 @@ public class OSHDBTag implements Serializable {
 
   public boolean isPresentInKeytables() {
     return this.value >= 0 && this.key >= 0;
+  }
+
+  @Override
+  public int compareTo(OSHDBTag o) {
+    return ORDER_BY_ID.compare(this, o);
   }
 
   @Override

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTag.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTag.java
@@ -33,7 +33,6 @@ public class OSHDBTag implements Comparable<OSHDBTag>, Serializable {
     return this.value;
   }
 
-  @Deprecated
   public boolean isPresentInKeytables() {
     return this.value >= 0 && this.key >= 0;
   }

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTag.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/OSHDBTag.java
@@ -4,7 +4,14 @@ import java.io.Serializable;
 import java.util.Comparator;
 import java.util.Objects;
 
+/**
+ * Key/Value id base OSM Tag class.
+ *
+ */
 public class OSHDBTag implements Comparable<OSHDBTag>, Serializable {
+  /**
+   * Order by keyId/valueId, default Comparator for OSHDBTag.
+   */
   public static final Comparator<OSHDBTag> ORDER_BY_ID = Comparator
       .comparingInt(OSHDBTag::getKey)
       .thenComparingInt(OSHDBTag::getValue);
@@ -26,6 +33,7 @@ public class OSHDBTag implements Comparable<OSHDBTag>, Serializable {
     return this.value;
   }
 
+  @Deprecated
   public boolean isPresentInKeytables() {
     return this.value >= 0 && this.key >= 0;
   }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagTest.java
@@ -1,0 +1,42 @@
+package org.heigit.ohsome.oshdb;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+class OSHDBTagTest {
+
+  @Test
+  void test() {
+    var tag = new OSHDBTag(10, 20);
+    assertEquals(10, tag.getKey());
+    assertEquals(20, tag.getValue());
+  }
+
+  @Test
+  void testComparable() {
+    var tag = new OSHDBTag(10, 10);
+
+    assertEquals(0, tag.compareTo(new OSHDBTag(10, 10)));
+    assertEquals(1, tag.compareTo(new OSHDBTag(5, 10)));
+    assertEquals(1, tag.compareTo(new OSHDBTag(10, 5)));
+    assertEquals(-1, tag.compareTo(new OSHDBTag(20, 10)));
+    assertEquals(-1, tag.compareTo(new OSHDBTag(10, 15)));
+  }
+
+  @Test
+  void testHashEqual() {
+    var tag = new OSHDBTag(10, 10);
+
+    assertEquals(tag, tag);
+    assertEquals(tag, new OSHDBTag(10, 10));
+    assertEquals(tag.hashCode(), new OSHDBTag(10, 10).hashCode());
+
+    assertNotEquals(tag, new OSHDBTag(10, 20));
+    assertNotEquals(tag, new OSHDBTag(20, 10));
+
+    assertNotEquals(tag, tag.toString());;
+  }
+
+}

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagTest.java
@@ -19,10 +19,10 @@ class OSHDBTagTest {
     var tag = new OSHDBTag(10, 10);
 
     assertEquals(0, tag.compareTo(new OSHDBTag(10, 10)));
-    assertEquals(1, tag.compareTo(new OSHDBTag(5, 10)));
-    assertEquals(1, tag.compareTo(new OSHDBTag(10, 5)));
-    assertEquals(-1, tag.compareTo(new OSHDBTag(20, 10)));
-    assertEquals(-1, tag.compareTo(new OSHDBTag(10, 15)));
+    assertTrue(tag.compareTo(new OSHDBTag(5, 10)) > 0);
+    assertTrue(tag.compareTo(new OSHDBTag(10, 5)) > 0);
+    assertTrue(tag.compareTo(new OSHDBTag(20, 10)) < 0);
+    assertTrue(tag.compareTo(new OSHDBTag(10, 15)) < 0);
   }
 
   @Test

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagTest.java
@@ -2,6 +2,7 @@ package org.heigit.ohsome.oshdb;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
@@ -79,6 +79,4 @@ class OSHDBTagsTest {
     assertNotEquals(tags, OSHDBTags.of(new int[] {1, 1, 4, 4}));
     assertNotEquals(tags, List.of(new OSHDBTag(2, 2), new OSHDBTag(4, 4)));
   }
-
-
 }

--- a/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
+++ b/oshdb/src/test/java/org/heigit/ohsome/oshdb/OSHDBTagsTest.java
@@ -79,4 +79,6 @@ class OSHDBTagsTest {
     assertNotEquals(tags, OSHDBTags.of(new int[] {1, 1, 4, 4}));
     assertNotEquals(tags, List.of(new OSHDBTag(2, 2), new OSHDBTag(4, 4)));
   }
+
+
 }


### PR DESCRIPTION
Make `OSHDBTag` natural orderd by id.

### Corresponding issue
Closes #440 

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- [x] I have added sufficient unit tests
- ~[] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~[ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~[ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
