### PR TITLE
Fix bug when calling aggregateByGeometry after a mapper is set

### DIFF
--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
@@ -1,0 +1,169 @@
+package org.heigit.ohsome.oshdb.api.tests;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.google.common.collect.Streams;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.heigit.ohsome.oshdb.api.db.OSHDBDatabase;
+import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer;
+import org.heigit.ohsome.oshdb.api.object.OSMEntitySnapshotImpl;
+import org.heigit.ohsome.oshdb.impl.osh.OSHNodeImpl;
+import org.heigit.ohsome.oshdb.osh.OSHNode;
+import org.heigit.ohsome.oshdb.osm.OSM;
+import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateByTimestampEntry;
+import org.heigit.ohsome.oshdb.util.celliterator.LazyEvaluatedObject;
+import org.heigit.ohsome.oshdb.util.function.SerializableBiFunction;
+import org.heigit.ohsome.oshdb.util.function.SerializableBinaryOperator;
+import org.heigit.ohsome.oshdb.util.function.SerializableFunction;
+import org.heigit.ohsome.oshdb.util.function.SerializableSupplier;
+import org.heigit.ohsome.oshdb.util.mappable.OSHDBMapReducible;
+import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
+import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
+import org.heigit.ohsome.oshdb.util.time.OSHDBTimestampList;
+import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Envelope;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
+
+class TestAutoAggregation {
+  private static final GeometryFactory geomFactory = new GeometryFactory();
+  private static final Point point = geomFactory.createPoint(new Coordinate(10.0, 10.0));
+  private static final Polygon area = (Polygon) geomFactory.toGeometry(new Envelope(0, 20, 0, 20));
+
+  private static final OSHNode node = OSHNodeImpl.build(
+      new ArrayList<>(List.of(OSM.node(1, 1, 1000, 1, 23, new int[0], 10_0000000, 10_0000000))));
+  private static final List<OSHNode> nodes = List.of(node);
+  private static final OSHDBTimestampList timestamps = new OSHDBTimestamps("2020-01-01");
+
+  private static final OSHDBDatabase oshdb = new OSHDBDatabaseMock();
+
+  @Test
+  void testAggregateByGeometryThenMap() throws UnsupportedOperationException, Exception {
+    var geometries = Map.of("TEST", area);
+    var mr = new MapReducerMock<>(oshdb, OSMEntitySnapshot.class);
+
+    var result = mr.timestamps("2020-01-01").aggregateByGeometry(geometries)
+        .map(s -> s.getEntity().getUserId()).sum();
+
+    assertEquals(1, result.size());
+    assertEquals(23, result.get("TEST").intValue());
+  }
+
+  @Test
+  void testMapThenAggregateByGeometry() throws UnsupportedOperationException, Exception {
+    var geometries = Map.of("TEST", area);
+    var mr = new MapReducerMock<>(oshdb, OSMEntitySnapshot.class);
+
+    var result = mr.timestamps("2020-01-01").map(s -> s.getEntity().getUserId())
+        .aggregateByGeometry(geometries).sum();
+
+    assertEquals(1, result.size());
+    assertEquals(23, result.get("TEST").intValue());
+  }
+
+  /**
+   * Mocks and helper functions.
+   *
+   */
+  private static class OSHDBDatabaseMock extends OSHDBDatabase {
+    @Override
+    public void close() throws Exception {}
+
+    @Override
+    public <X extends OSHDBMapReducible> MapReducer<X> createMapReducer(Class<X> forClass) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String metadata(String property) {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  private static class MapReducerMock<X extends OSHDBMapReducible> extends MapReducer<X> {
+
+    protected MapReducerMock(OSHDBDatabase oshdb, Class<X> viewClass) {
+      super(oshdb, viewClass);
+    }
+
+    @Override
+    protected MapReducer<X> copy() {
+      return this;
+    }
+
+    @Override
+    protected Stream<X> mapStreamCellsOSMContribution(
+        SerializableFunction<OSMContribution, X> mapper) throws Exception {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Stream<X> flatMapStreamCellsOSMContributionGroupedById(
+        SerializableFunction<List<OSMContribution>, Iterable<X>> mapper) throws Exception {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Stream<X> mapStreamCellsOSMEntitySnapshot(
+        SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected Stream<X> flatMapStreamCellsOSMEntitySnapshotGroupedById(
+        SerializableFunction<List<OSMEntitySnapshot>, Iterable<X>> mapper) throws Exception {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected <R, S> S mapReduceCellsOSMContribution(
+        SerializableFunction<OSMContribution, R> mapper, SerializableSupplier<S> identitySupplier,
+        SerializableBiFunction<S, R, S> accumulator, SerializableBinaryOperator<S> combiner)
+            throws Exception {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected <R, S> S flatMapReduceCellsOSMContributionGroupedById(
+        SerializableFunction<List<OSMContribution>, Iterable<R>> mapper,
+        SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
+        SerializableBinaryOperator<S> combiner) throws Exception {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    protected <R, S> S mapReduceCellsOSMEntitySnapshot(
+        SerializableFunction<OSMEntitySnapshot, R> mapper, SerializableSupplier<S> identitySupplier,
+        SerializableBiFunction<S, R, S> accumulator, SerializableBinaryOperator<S> combiner)
+            throws Exception {
+      return nodes.stream().map(n -> snapshot(n)).map(mapper).reduce(identitySupplier.get(),
+          accumulator, combiner);
+    }
+
+    @Override
+    protected <R, S> S flatMapReduceCellsOSMEntitySnapshotGroupedById(
+        SerializableFunction<List<OSMEntitySnapshot>, Iterable<R>> mapper,
+        SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
+        SerializableBinaryOperator<S> combiner) throws Exception {
+      return Streams.stream(mapper.apply(nodes.stream().map(n -> snapshot(n)).toList()))
+          .reduce(identitySupplier.get(), accumulator, combiner);
+    }
+
+  }
+
+  private static OSMEntitySnapshot snapshot(OSHNode node) {
+    var timestamp = timestamps.get().first();;
+    var data = new IterateByTimestampEntry(timestamp, node.getVersions().iterator().next(), node,
+        new LazyEvaluatedObject<Geometry>(point),
+        new LazyEvaluatedObject<Geometry>(point));
+    return new OSMEntitySnapshotImpl(data);
+  }
+
+}

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
@@ -1,12 +1,12 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import com.google.common.collect.Streams;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.heigit.ohsome.oshdb.api.db.OSHDBDatabase;
 import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer;
@@ -170,7 +170,9 @@ class TestAutoAggregation {
         SerializableFunction<List<OSMEntitySnapshot>, Iterable<R>> mapper,
         SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
         SerializableBinaryOperator<S> combiner) throws Exception {
-      return Streams.stream(mapper.apply(nodes.stream().map(n -> snapshot(n)).toList()))
+      return Streams.stream(mapper.apply(nodes.stream()
+          .map(n -> snapshot(n))
+          .collect(Collectors.toList())))
           .reduce(identitySupplier.get(), accumulator, combiner);
     }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
@@ -25,6 +25,7 @@ import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestampList;
 import org.heigit.ohsome.oshdb.util.time.OSHDBTimestamps;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Envelope;
@@ -111,9 +112,14 @@ class TestAutoAggregation {
       super(oshdb, viewClass);
     }
 
+    private MapReducerMock(MapReducerMock<X> other) {
+      super(other);
+    }
+
+    @NotNull
     @Override
     protected MapReducer<X> copy() {
-      return this;
+      return new MapReducerMock<>(this);
     }
 
     @Override


### PR DESCRIPTION
Fixes a crash caused by the _autoaggregation_ code which is triggered when `aggregateByGeometry` is called after specifying a `map` function in a query. It's solved by just re-applying the _mappers_ (or _flatMappers_) after the geometry splitting phase.

See also #451

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- ~~I have commented my code~~
- ~~I have written javadoc (required for public classes and methods)~~
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- ~~I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)~~
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

