### PR TITLE
Extend H2Support to create `JdbcConnectionPool`s from Paths

### DIFF
--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/MapReduceOSHDBIgniteTest.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/MapReduceOSHDBIgniteTest.java
@@ -1,11 +1,10 @@
 package org.heigit.ohsome.oshdb.api.tests;
 
-import static org.heigit.ohsome.oshdb.api.db.H2Support.pathToUrl;
+import static org.heigit.ohsome.oshdb.api.db.H2Support.createJdbcPoolFromPath;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -69,8 +68,7 @@ abstract class MapReduceOSHDBIgniteTest extends MapReduceTest {
 
     loadTestdataIntoIgnite(ignite, cache.getName(), KEYTABLES);
 
-    JdbcConnectionPool oshdbH2 = JdbcConnectionPool.create(pathToUrl(Path.of(keytables)), "sa",
-        "");
+    JdbcConnectionPool oshdbH2 = createJdbcPoolFromPath(keytables);
 
     ignite.cluster().state(ClusterState.ACTIVE_READ_ONLY);
 
@@ -80,8 +78,7 @@ abstract class MapReduceOSHDBIgniteTest extends MapReduceTest {
   }
 
   private static void loadTestdataIntoIgnite(Ignite ignite, String cache, String keytables) {
-    JdbcConnectionPool oshdbH2 = JdbcConnectionPool.create(pathToUrl(Path.of(keytables)), "sa",
-        "");
+    JdbcConnectionPool oshdbH2 = createJdbcPoolFromPath(keytables);
 
     // load test data into ignite cache
     try (IgniteDataStreamer<Long, GridOSHNodes> streamer = ignite.dataStreamer(cache);

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/db/H2Support.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/db/H2Support.java
@@ -1,15 +1,82 @@
 package org.heigit.ohsome.oshdb.api.db;
 
-import java.nio.file.Path;
+import static org.heigit.ohsome.oshdb.api.db.OSHDBH2.DEFAULT_PASSWORD;
+import static org.heigit.ohsome.oshdb.api.db.OSHDBH2.DEFAULT_USER;
 
+import java.nio.file.Path;
+import org.h2.jdbcx.JdbcConnectionPool;
+
+/**
+ * Support class for creating H2 JdbcConnectionPools.
+ */
 public class H2Support {
 
-  private H2Support() {
+  private H2Support() {}
+
+  /**
+   * Creates a JdbcConnectionPool for an H2 file.
+   *
+   * @param databaseFile the file name and path to the H2 database file. (the ".mv.db" file ending
+   *        of H2 should be omitted here)
+   */
+  public static JdbcConnectionPool createJdbcPoolFromPath(String databaseFile) {
+    return createJdbcPoolFromPath(databaseFile, DEFAULT_USER, DEFAULT_PASSWORD);
   }
 
-  public static String pathToUrl(Path path) {
-    var absolutePath = path.toAbsolutePath().toString();
-    absolutePath = absolutePath.replaceAll("\\.mv\\.db$", "");
-    return String.format("jdbc:h2:%s;ACCESS_MODE_DATA=r", absolutePath);
+  /**
+   * Creates a JdbcConnectionPool for an H2 file.
+   *
+   * @param databaseFile the file name and path to the H2 database file. (the ".mv.db" file ending
+   *        of H2 should be omitted here)
+   */
+  public static JdbcConnectionPool createJdbcPoolFromPath(Path databaseFile) {
+    return createJdbcPoolFromPath(databaseFile, DEFAULT_USER, DEFAULT_PASSWORD);
+  }
+
+  /**
+   * Creates a JdbcConnectionPool for an H2 file.
+   *
+   * @param path the file name and path to the H2 database file. (the ".mv.db" file ending
+   *        of H2 should be omitted here)
+   * @param user username for the H2 JDBC connection
+   * @param password password for the H2 JDBC connection
+   */
+  public static JdbcConnectionPool createJdbcPoolFromPath(String path, String user,
+      String password) {
+    return createJdbcPool(pathToUrl(path), user, password);
+  }
+
+  /**
+   * Creates a JdbcConnectionPool for an H2 file.
+   *
+   * @param path the file name and path to the H2 database file. (the ".mv.db" file ending
+   *        of H2 should be omitted here)
+   * @param user username for the H2 JDBC connection
+   * @param password password for the H2 JDBC connection
+   */
+  public static JdbcConnectionPool createJdbcPoolFromPath(Path path, String user, String password) {
+    return createJdbcPool(pathToUrl(path), user, password);
+  }
+
+  /**
+   * Creates a JdbcConnectionPool for an H2 file.
+   *
+   * @param url the JDBC URL to the H2 database file.
+   * @param user username for the H2 JDBC connection
+   * @param password password for the H2 JDBC connection
+   */
+  public static JdbcConnectionPool createJdbcPool(String url, String user, String password) {
+    return JdbcConnectionPool.create(url, user, password);
+  }
+
+  private static String pathToUrl(String path) {
+    return pathToUrl(Path.of(path));
+  }
+
+  private static String pathToUrl(Path path) {
+    var processedPath = path.toString().replaceFirst("^~", System.getProperty("user.home"));
+    processedPath = Path.of(processedPath).toAbsolutePath().toString();
+    processedPath = processedPath.replaceAll("\\.mv\\.db$", "");
+    return String.format("jdbc:h2:%s;ACCESS_MODE_DATA=r", processedPath);
   }
 }

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBH2.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/db/OSHDBH2.java
@@ -1,6 +1,7 @@
 package org.heigit.ohsome.oshdb.api.db;
 
-import static org.heigit.ohsome.oshdb.api.db.H2Support.pathToUrl;
+import static org.heigit.ohsome.oshdb.api.db.H2Support.createJdbcPool;
+import static org.heigit.ohsome.oshdb.api.db.H2Support.createJdbcPoolFromPath;
 
 import java.nio.file.Path;
 import org.h2.jdbcx.JdbcConnectionPool;
@@ -10,6 +11,8 @@ import org.h2.jdbcx.JdbcConnectionPool;
  */
 public class OSHDBH2 extends OSHDBJdbc {
 
+  public static final String DEFAULT_USER = "sa";
+  public static final String DEFAULT_PASSWORD = "";
   private final JdbcConnectionPool connectionPool;
 
   /**
@@ -19,7 +22,7 @@ public class OSHDBH2 extends OSHDBJdbc {
    *        of H2 should be omitted here)
    */
   public OSHDBH2(Path databaseFile) {
-    this(databaseFile, "sa", "");
+    this(createJdbcPoolFromPath(databaseFile));
   }
 
   /**
@@ -29,7 +32,7 @@ public class OSHDBH2 extends OSHDBJdbc {
    *        of H2 should be omitted here)
    */
   public OSHDBH2(String databaseFile) {
-    this(Path.of(databaseFile));
+    this(createJdbcPoolFromPath(databaseFile));
   }
 
   /**
@@ -40,7 +43,7 @@ public class OSHDBH2 extends OSHDBJdbc {
    * @param password password for the H2 JDBC connection
    */
   public OSHDBH2(String url, String user, String password) {
-    this(JdbcConnectionPool.create(url, user, password));
+    this(createJdbcPool(url, user, password));
   }
 
   /**
@@ -52,7 +55,7 @@ public class OSHDBH2 extends OSHDBJdbc {
    * @param password password for the H2 JDBC connection
    */
   public OSHDBH2(Path path, String user, String password) {
-    this(pathToUrl(path), user, password);
+    this(createJdbcPoolFromPath(path, user, password));
   }
 
   private OSHDBH2(JdbcConnectionPool ds) {


### PR DESCRIPTION
### Description
Extend H2Support to create `JdbcConnectionPool`s from Paths with default user/pw.

### Corresponding issue
None

### New or changed dependencies
None

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- [x] I have added sufficient unit tests
- [x] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~[ ] I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~[ ] I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~