### PR TITLE
upgrade checkstyle version to v10.8.0 to match parent

### DIFF
--- a/.idea/checkstyle-idea.xml
+++ b/.idea/checkstyle-idea.xml
@@ -4,7 +4,7 @@
     <option name="configuration">
       <map>
         <entry key="active-configuration" value="HTTP_URL:https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/parent/raw/2.13.0/ohsome-codestyle/src/main/resources/checkstyle-google-ohsome.xml:ohsome Google Checks" />
-        <entry key="checkstyle-version" value="8.44" />
+        <entry key="checkstyle-version" value="10.8.0" />
         <entry key="copy-libs" value="false" />
         <entry key="location-0" value="BUNDLED:(bundled):Sun Checks" />
         <entry key="location-1" value="BUNDLED:(bundled):Google Checks" />


### PR DESCRIPTION
Upgrades IntelliJ config to make the ohsome parent's [checkstyle version](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/parent/-/blob/2.13.1/pom.xml#L76) to run the updated [checks](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/parent/-/blob/2.13.1/ohsome-codestyle/src/main/resources/checkstyle-google-ohsome.xml).
