### PR TITLE
CellIterator: add "lastContributionTimestamp" to OSMEntitySnapshot & decouple from Grid implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## 1.2.0-SNAPSHOT (current master)
+
+### new features
+
+* `OSMEntitySnapshot` now also returns the `lastContributionTimestamp` for each snapshot ([#495])
+
+[#495]: https://github.com/GIScience/oshdb/pull/495
+
+
 ## 1.1.1
 
 * update ignite dependency to [2.14.0-heigit1] ([#491])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 * `OSMEntitySnapshot` now also returns the `lastContributionTimestamp` for each snapshot ([#495])
 
+### other changes
+
+* `CellIterator` is now decoupled from implementation of the "Grid" ([#495])
+
 [#495]: https://github.com/GIScience/oshdb/pull/495
 
 

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
@@ -264,7 +263,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
           this.timeout
       ).stream()
           .flatMap(Collection::stream)
-          .collect(Collectors.toList());
+          .toList();
       Collections.shuffle(cellsWithData);
       Stream<X> resultForType = cellsWithData.parallelStream()
           .filter(ignored -> this.isActive())

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -106,7 +106,7 @@ public class MapReducerIgniteLocalPeek<X> extends MapReducer<X> {
 
   private List<String> cacheNames(String prefix) {
     return this.typeFilter.stream().map(TableNames::forOSMType).filter(Optional::isPresent)
-        .map(Optional::get).map(tn -> tn.toString(prefix)).collect(Collectors.toList());
+        .map(Optional::get).map(tn -> tn.toString(prefix)).toList();
   }
 
   @Override

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteLocalPeek.java
@@ -32,6 +32,7 @@ import org.heigit.ohsome.oshdb.index.XYGridTree.CellIdRange;
 import org.heigit.ohsome.oshdb.util.CellId;
 import org.heigit.ohsome.oshdb.util.TableNames;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator;
+import org.heigit.ohsome.oshdb.util.celliterator.OSHEntitySource;
 import org.heigit.ohsome.oshdb.util.exceptions.OSHDBTimeoutException;
 import org.heigit.ohsome.oshdb.util.function.OSHEntityFilter;
 import org.heigit.ohsome.oshdb.util.function.OSMEntityFilter;
@@ -281,7 +282,8 @@ public class MapReducerIgniteLocalPeek<X> extends MapReducer<X> {
           // filter out cache misses === empty oshdb cells or not "local" data
           .filter(Objects::nonNull)
           .filter(ignored -> this.isActive())
-          .map(cell -> cellProcessor.apply(cell, this.cellIterator))
+          .map(cell ->
+              cellProcessor.apply(OSHEntitySource.fromGridOSHEntity(cell), this.cellIterator))
           .reduce(identitySupplier.get(), combiner);
     }
   }

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -13,7 +13,6 @@ import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.ignite.Ignite;
 import org.apache.ignite.IgniteCache;

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/Kernels.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/Kernels.java
@@ -10,7 +10,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 import org.heigit.ohsome.oshdb.api.object.OSMContributionImpl;
 import org.heigit.ohsome.oshdb.api.object.OSMEntitySnapshotImpl;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator;
 import org.heigit.ohsome.oshdb.util.celliterator.OSHEntitySource;
 import org.heigit.ohsome.oshdb.util.function.SerializableBiFunction;
@@ -20,7 +19,7 @@ import org.heigit.ohsome.oshdb.util.mappable.OSMContribution;
 import org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot;
 
 class Kernels implements Serializable {
-  interface CellProcessor<S> extends SerializableBiFunction<GridOSHEntity, CellIterator, S> {}
+  interface CellProcessor<S> extends SerializableBiFunction<OSHEntitySource, CellIterator, S> {}
 
   interface CancelableProcessStatus {
     default <T> boolean isActive(T ignored) {
@@ -58,10 +57,10 @@ class Kernels implements Serializable {
       SerializableBiFunction<S, R, S> accumulator,
       CancelableProcessStatus process
   ) {
-    return (oshEntityCell, cellIterator) -> {
+    return (source, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      cellIterator.iterateByContribution(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
+      cellIterator.iterateByContribution(source)
           .takeWhile(process::isActive)
           .forEach(contribution -> {
             OSMContribution osmContribution = new OSMContributionImpl(contribution);
@@ -87,11 +86,11 @@ class Kernels implements Serializable {
       SerializableBiFunction<S, R, S> accumulator,
       CancelableProcessStatus process
   ) {
-    return (oshEntityCell, cellIterator) -> {
+    return (source, cellIterator) -> {
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       // iterate over the history of all OSM objects in the current cell
       List<OSMContribution> contributions = new ArrayList<>();
-      cellIterator.iterateByContribution(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
+      cellIterator.iterateByContribution(source)
           .takeWhile(process::isActive)
           .forEach(contribution -> {
             OSMContribution thisContribution = new OSMContributionImpl(contribution);
@@ -132,10 +131,10 @@ class Kernels implements Serializable {
       SerializableBiFunction<S, R, S> accumulator,
       CancelableProcessStatus process
   ) {
-    return (oshEntityCell, cellIterator) -> {
+    return (source, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      cellIterator.iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
+      cellIterator.iterateByTimestamps(source)
           .takeWhile(process::isActive)
           .forEach(data -> {
             OSMEntitySnapshot snapshot = new OSMEntitySnapshotImpl(data);
@@ -162,11 +161,11 @@ class Kernels implements Serializable {
       SerializableBiFunction<S, R, S> accumulator,
       CancelableProcessStatus process
   ) {
-    return (oshEntityCell, cellIterator) -> {
+    return (source, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
-      cellIterator.iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
+      cellIterator.iterateByTimestamps(source)
           .takeWhile(process::isActive)
           .forEach(data -> {
             OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshotImpl(data);
@@ -205,9 +204,9 @@ class Kernels implements Serializable {
       SerializableFunction<OSMContribution, S> mapper,
       CancelableProcessStatus process
   ) {
-    return (oshEntityCell, cellIterator) -> {
+    return (source, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByContribution(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
+      return cellIterator.iterateByContribution(source)
           .takeWhile(process::isActive)
           .map(OSMContributionImpl::new)
           .map(mapper);
@@ -226,11 +225,11 @@ class Kernels implements Serializable {
       SerializableFunction<List<OSMContribution>, Iterable<S>> mapper,
       CancelableProcessStatus process
   ) {
-    return (oshEntityCell, cellIterator) -> {
+    return (source, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       List<OSMContribution> contributions = new ArrayList<>();
       List<S> result = new LinkedList<>();
-      cellIterator.iterateByContribution(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
+      cellIterator.iterateByContribution(source)
           .takeWhile(process::isActive)
           .map(OSMContributionImpl::new)
           .forEach(contribution -> {
@@ -262,9 +261,9 @@ class Kernels implements Serializable {
       SerializableFunction<OSMEntitySnapshot, S> mapper,
       CancelableProcessStatus process
   ) {
-    return (oshEntityCell, cellIterator) -> {
+    return (source, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
+      return cellIterator.iterateByTimestamps(source)
           .takeWhile(process::isActive)
           .map(OSMEntitySnapshotImpl::new)
           .map(mapper);
@@ -283,11 +282,11 @@ class Kernels implements Serializable {
       SerializableFunction<List<OSMEntitySnapshot>, Iterable<S>> mapper,
       CancelableProcessStatus process
   ) {
-    return (oshEntityCell, cellIterator) -> {
+    return (source, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       List<OSMEntitySnapshot> snapshots = new ArrayList<>();
       List<S> result = new LinkedList<>();
-      cellIterator.iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
+      cellIterator.iterateByTimestamps(source)
           .takeWhile(process::isActive)
           .map(OSMEntitySnapshotImpl::new)
           .forEach(contribution -> {

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/Kernels.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/Kernels.java
@@ -12,6 +12,7 @@ import org.heigit.ohsome.oshdb.api.object.OSMContributionImpl;
 import org.heigit.ohsome.oshdb.api.object.OSMEntitySnapshotImpl;
 import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator;
+import org.heigit.ohsome.oshdb.util.celliterator.OSHEntitySource;
 import org.heigit.ohsome.oshdb.util.function.SerializableBiFunction;
 import org.heigit.ohsome.oshdb.util.function.SerializableFunction;
 import org.heigit.ohsome.oshdb.util.function.SerializableSupplier;
@@ -60,7 +61,7 @@ class Kernels implements Serializable {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      cellIterator.iterateByContribution(oshEntityCell)
+      cellIterator.iterateByContribution(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
           .takeWhile(process::isActive)
           .forEach(contribution -> {
             OSMContribution osmContribution = new OSMContributionImpl(contribution);
@@ -90,7 +91,7 @@ class Kernels implements Serializable {
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       // iterate over the history of all OSM objects in the current cell
       List<OSMContribution> contributions = new ArrayList<>();
-      cellIterator.iterateByContribution(oshEntityCell)
+      cellIterator.iterateByContribution(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
           .takeWhile(process::isActive)
           .forEach(contribution -> {
             OSMContribution thisContribution = new OSMContributionImpl(contribution);
@@ -134,7 +135,7 @@ class Kernels implements Serializable {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
-      cellIterator.iterateByTimestamps(oshEntityCell)
+      cellIterator.iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
           .takeWhile(process::isActive)
           .forEach(data -> {
             OSMEntitySnapshot snapshot = new OSMEntitySnapshotImpl(data);
@@ -165,7 +166,7 @@ class Kernels implements Serializable {
       // iterate over the history of all OSM objects in the current cell
       AtomicReference<S> accInternal = new AtomicReference<>(identitySupplier.get());
       List<OSMEntitySnapshot> osmEntitySnapshots = new ArrayList<>();
-      cellIterator.iterateByTimestamps(oshEntityCell)
+      cellIterator.iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
           .takeWhile(process::isActive)
           .forEach(data -> {
             OSMEntitySnapshot thisSnapshot = new OSMEntitySnapshotImpl(data);
@@ -206,7 +207,7 @@ class Kernels implements Serializable {
   ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByContribution(oshEntityCell)
+      return cellIterator.iterateByContribution(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
           .takeWhile(process::isActive)
           .map(OSMContributionImpl::new)
           .map(mapper);
@@ -229,7 +230,7 @@ class Kernels implements Serializable {
       // iterate over the history of all OSM objects in the current cell
       List<OSMContribution> contributions = new ArrayList<>();
       List<S> result = new LinkedList<>();
-      cellIterator.iterateByContribution(oshEntityCell)
+      cellIterator.iterateByContribution(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
           .takeWhile(process::isActive)
           .map(OSMContributionImpl::new)
           .forEach(contribution -> {
@@ -263,7 +264,7 @@ class Kernels implements Serializable {
   ) {
     return (oshEntityCell, cellIterator) -> {
       // iterate over the history of all OSM objects in the current cell
-      return cellIterator.iterateByTimestamps(oshEntityCell)
+      return cellIterator.iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
           .takeWhile(process::isActive)
           .map(OSMEntitySnapshotImpl::new)
           .map(mapper);
@@ -286,7 +287,7 @@ class Kernels implements Serializable {
       // iterate over the history of all OSM objects in the current cell
       List<OSMEntitySnapshot> snapshots = new ArrayList<>();
       List<S> result = new LinkedList<>();
-      cellIterator.iterateByTimestamps(oshEntityCell)
+      cellIterator.iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(oshEntityCell))
           .takeWhile(process::isActive)
           .map(OSMEntitySnapshotImpl::new)
           .forEach(contribution -> {

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
@@ -10,6 +10,7 @@ import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer;
 import org.heigit.ohsome.oshdb.api.mapreducer.backend.Kernels.CellProcessor;
 import org.heigit.ohsome.oshdb.index.XYGridTree.CellIdRange;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator;
+import org.heigit.ohsome.oshdb.util.celliterator.OSHEntitySource;
 import org.heigit.ohsome.oshdb.util.function.SerializableBiFunction;
 import org.heigit.ohsome.oshdb.util.function.SerializableBinaryOperator;
 import org.heigit.ohsome.oshdb.util.function.SerializableFunction;
@@ -69,7 +70,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
         .filter(ignored -> this.isActive())
         .flatMap(this::getOshCellsStream)
         .filter(ignored -> this.isActive())
-        .map(oshCell -> processor.apply(oshCell, cellIterator))
+        .map(cell -> processor.apply(OSHEntitySource.fromGridOSHEntity(cell), cellIterator))
         .reduce(identitySupplier.get(), combiner);
   }
 
@@ -91,7 +92,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
         .filter(ignored -> this.isActive())
         .flatMap(this::getOshCellsStream)
         .filter(ignored -> this.isActive())
-        .flatMap(oshCell -> processor.apply(oshCell, cellIterator));
+        .flatMap(cell -> processor.apply(OSHEntitySource.fromGridOSHEntity(cell), cellIterator));
   }
 
   // === map-reduce operations ===

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/object/OSMContributionImpl.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/object/OSMContributionImpl.java
@@ -75,52 +75,52 @@ public class OSMContributionImpl implements OSMContribution {
 
   @Override
   public OSHDBTimestamp getTimestamp() {
-    return data.timestamp;
+    return data.timestamp();
   }
 
   @Override
   public Geometry getGeometryBefore() {
-    return data.previousGeometry.get();
+    return data.previousGeometry().get();
   }
 
   @Override
   public Geometry getGeometryUnclippedBefore() {
-    return data.unclippedPreviousGeometry.get();
+    return data.unclippedPreviousGeometry().get();
   }
 
   @Override
   public Geometry getGeometryAfter() {
-    return data.geometry.get();
+    return data.geometry().get();
   }
 
   @Override
   public Geometry getGeometryUnclippedAfter() {
-    return data.unclippedGeometry.get();
+    return data.unclippedGeometry().get();
   }
 
   @Override
   public OSMEntity getEntityBefore() {
-    return data.previousOsmEntity;
+    return data.previousOsmEntity();
   }
 
   @Override
   public OSMEntity getEntityAfter() {
-    return data.osmEntity;
+    return data.osmEntity();
   }
 
   @Override
   public OSHEntity getOSHEntity() {
-    return data.oshEntity;
+    return data.oshEntity();
   }
 
   @Override
   public boolean is(ContributionType contributionType) {
-    return data.activities.contains(contributionType);
+    return data.activities().contains(contributionType);
   }
 
   @Override
   public EnumSet<ContributionType> getContributionTypes() {
-    return data.activities.get();
+    return data.activities().get();
   }
 
 
@@ -175,7 +175,7 @@ public class OSMContributionImpl implements OSMContribution {
 
   @Override
   public long getChangesetId() {
-    return data.changeset;
+    return data.changeset();
   }
 
   @Override

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/object/OSMEntitySnapshotImpl.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/object/OSMEntitySnapshotImpl.java
@@ -15,8 +15,7 @@ import org.locationtech.jts.geom.Geometry;
  *
  * <p>Alongside the entity and the timestamp, also the entity's geometry is provided.</p>
  */
-public class OSMEntitySnapshotImpl implements
-    org.heigit.ohsome.oshdb.util.mappable.OSMEntitySnapshot {
+public class OSMEntitySnapshotImpl implements OSMEntitySnapshot {
   private final IterateByTimestampEntry data;
 
   public OSMEntitySnapshotImpl(IterateByTimestampEntry data) {
@@ -48,27 +47,27 @@ public class OSMEntitySnapshotImpl implements
 
   @Override
   public OSHDBTimestamp getTimestamp() {
-    return data.timestamp;
+    return data.timestamp();
   }
 
   @Override
   public Geometry getGeometry() {
-    return data.geometry.get();
+    return data.geometry().get();
   }
 
   @Override
   public Geometry getGeometryUnclipped() {
-    return data.unclippedGeometry.get();
+    return data.unclippedGeometry().get();
   }
 
   @Override
   public OSMEntity getEntity() {
-    return data.osmEntity;
+    return data.osmEntity();
   }
 
   @Override
   public OSHEntity getOSHEntity() {
-    return data.oshEntity;
+    return data.oshEntity();
   }
 
   /**

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/object/OSMEntitySnapshotImpl.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/object/OSMEntitySnapshotImpl.java
@@ -38,6 +38,7 @@ public class OSMEntitySnapshotImpl implements OSMEntitySnapshot {
   ) {
     this.data = new IterateByTimestampEntry(
         other.getTimestamp(),
+        other.getLastContributionTimestamp(),
         other.getEntity(),
         other.getOSHEntity(),
         reclippedGeometry,
@@ -48,6 +49,11 @@ public class OSMEntitySnapshotImpl implements OSMEntitySnapshot {
   @Override
   public OSHDBTimestamp getTimestamp() {
     return data.timestamp();
+  }
+
+  @Override
+  public OSHDBTimestamp getLastContributionTimestamp() {
+    return data.lastModificationTimestamp();
   }
 
   @Override

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
@@ -194,7 +194,8 @@ class TestAutoAggregation {
 
   private static OSMEntitySnapshot snapshot(OSHNode node) {
     var timestamp = timestamps.get().first();
-    var data = new IterateByTimestampEntry(timestamp, node.getVersions().iterator().next(), node,
+    var data = new IterateByTimestampEntry(timestamp, null,
+        node.getVersions().iterator().next(), node,
         new LazyEvaluatedObject<>(point),
         new LazyEvaluatedObject<>(point));
     return new OSMEntitySnapshotImpl(data);

--- a/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
+++ b/oshdb-filter/src/test/java/org/heigit/ohsome/oshdb/filter/ApplyOSMEntitySnapshotTest.java
@@ -36,6 +36,11 @@ class ApplyOSMEntitySnapshotTest extends FilterTest {
     }
 
     @Override
+    public OSHDBTimestamp getLastContributionTimestamp() {
+      throw new UnsupportedOperationException(UNSUPPORTED_IN_TEST);
+    }
+
+    @Override
     public Geometry getGeometry() {
       return this.geometry;
     }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
@@ -21,8 +21,6 @@ import org.heigit.ohsome.oshdb.OSHDBBoundable;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.OSHDBTemporal;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
-import org.heigit.ohsome.oshdb.index.XYGrid;
 import org.heigit.ohsome.oshdb.osh.OSHEntities;
 import org.heigit.ohsome.oshdb.osh.OSHEntity;
 import org.heigit.ohsome.oshdb.osm.OSMEntity;
@@ -30,7 +28,6 @@ import org.heigit.ohsome.oshdb.osm.OSMMember;
 import org.heigit.ohsome.oshdb.osm.OSMRelation;
 import org.heigit.ohsome.oshdb.osm.OSMType;
 import org.heigit.ohsome.oshdb.osm.OSMWay;
-import org.heigit.ohsome.oshdb.util.CellId;
 import org.heigit.ohsome.oshdb.util.function.OSHEntityFilter;
 import org.heigit.ohsome.oshdb.util.function.OSMEntityFilter;
 import org.heigit.ohsome.oshdb.util.geometry.Geo;
@@ -59,8 +56,8 @@ import org.slf4j.LoggerFactory;
  * Allows to iterate through the contents of OSH grid cells.
  *
  * <p>There are two modes of iterating through a cell: 1) iterate at specific timestamps
- * (entity snapshots) {@link #iterateByTimestamps(GridOSHEntity)} or 2) iterate through
- * all (minor) versions of each entity {@link #iterateByContribution(GridOSHEntity)}.
+ * (entity snapshots) {@link #iterateByTimestamps(OSHEntitySource)} or 2) iterate through
+ * all (minor) versions of each entity {@link #iterateByContribution(OSHEntitySource)}.
  */
 public class CellIterator implements Serializable {
   private static final Logger LOG = LoggerFactory.getLogger(CellIterator.class);
@@ -208,7 +205,7 @@ public class CellIterator implements Serializable {
   }
 
   /**
-   * Holds the result of a single item returned by {@link #iterateByTimestamps(GridOSHEntity)}.
+   * Holds the result of a single item returned by {@link #iterateByTimestamps(OSHEntitySource)}.
    *
    * @param timestamp timestamp of the snapshot
    * @param lastModificationTimestamp last modification timestamp before the snapshot's timestamp
@@ -262,7 +259,7 @@ public class CellIterator implements Serializable {
    *         optimize away recalculating expensive geometry operations on unchanged feature
    *         geometries later on in the code.
    */
-  public Stream<IterateByTimestampEntry> iterateByTimestamps(Stream<? extends OSHEntity> oshData,
+  private Stream<IterateByTimestampEntry> iterateByTimestamps(Stream<? extends OSHEntity> oshData,
       boolean allFullyInside) {
     return oshData.flatMap(oshEntity -> {
       if (!oshEntityPreFilter.test(oshEntity)
@@ -462,7 +459,7 @@ public class CellIterator implements Serializable {
   }
 
   /**
-   * Holds the result of a single item returned by {@link #iterateByContribution(GridOSHEntity)}.
+   * Holds the result of a single item returned by {@link #iterateByContribution(OSHEntitySource)}.
    *
    * @param timestamp the timestamp when the OSM object was modified
    * @param osmEntity the version of the OSM object after the modification
@@ -521,7 +518,7 @@ public class CellIterator implements Serializable {
    * @return a stream of matching filtered OSMEntities with their clipped Geometries and timestamp
    *         intervals.
    */
-  public Stream<IterateAllEntry> iterateByContribution(Stream<? extends OSHEntity> oshData,
+  private Stream<IterateAllEntry> iterateByContribution(Stream<? extends OSHEntity> oshData,
       boolean allFullyInside) {
     if (includeOldStyleMultipolygons) {
       //todo: remove this by finishing the functionality below

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
@@ -317,17 +317,16 @@ public class CellIterator implements Serializable {
           // skip because this entity is deleted at this timestamp
           continue;
         }
-        if (osmEntity instanceof OSMWay && ((OSMWay) osmEntity).getMembers().length == 0
-            || osmEntity instanceof OSMRelation
-                && ((OSMRelation) osmEntity).getMembers().length == 0) {
+        if (osmEntity instanceof OSMWay osmWay && osmWay.getMembers().length == 0
+            || osmEntity instanceof OSMRelation osmRelation
+                && osmRelation.getMembers().length == 0) {
           // skip way/relation with zero nodes/members
           continue;
         }
 
         boolean isOldStyleMultipolygon = false;
-        if (includeOldStyleMultipolygons && osmEntity instanceof OSMRelation
-            && tagInterpreter.isOldStyleMultipolygon((OSMRelation) osmEntity)) {
-          final OSMRelation rel = (OSMRelation) osmEntity;
+        if (includeOldStyleMultipolygons && osmEntity instanceof OSMRelation rel
+            && tagInterpreter.isOldStyleMultipolygon(rel)) {
           for (int i = 0; i < rel.getMembers().length; i++) {
             final OSMMember relMember = rel.getMembers()[i];
             if (relMember.getType() == OSMType.WAY

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
@@ -229,10 +229,10 @@ public class CellIterator implements Serializable {
   ) {}
 
   /**
-   * Helper method to easily iterate over all entities in a cell that match a given condition/filter
+   * Helper method to easily iterate over all entities that match a given condition/filter
    * as they existed at the given timestamps.
    *
-   * @param cell the data cell
+   * @param source a provider of a stream of OSHEntity objects and a corresponding bounding box
    *
    * @return a stream of matching filtered OSMEntities with their clipped Geometries at each
    *         timestamp. If an object has not been modified between timestamps, the output may
@@ -240,17 +240,17 @@ public class CellIterator implements Serializable {
    *         optimize away recalculating expensive geometry operations on unchanged feature
    *         geometries later on in the code.
    */
-  public Stream<IterateByTimestampEntry> iterateByTimestamps(GridOSHEntity cell) {
-    var cellBoundingBox = XYGrid.getBoundingBox(new CellId(cell.getLevel(), cell.getId()), true);
+  public Stream<IterateByTimestampEntry> iterateByTimestamps(OSHEntitySource source) {
+    var cellBoundingBox = source.getBoundingBox();
     final boolean allFullyInside = fullyInside(cellBoundingBox);
     if (!allFullyInside && isBoundByPolygon && bboxOutsidePolygon.test(cellBoundingBox)) {
       return Stream.empty();
     }
-    return iterateByTimestamps(Streams.stream(cell.getEntities()), allFullyInside);
+    return iterateByTimestamps(source.getData(), allFullyInside);
   }
 
   /**
-   * Helper method to easily iterate over all entities in a cell that match a given condition/filter
+   * Helper method to easily iterate over all entities that match a given condition/filter
    * as they existed at the given timestamps.
    *
    * @param oshData the entities to iterate through
@@ -494,25 +494,25 @@ public class CellIterator implements Serializable {
   ) {}
 
   /**
-   * Helper method to easily iterate over all entity modifications in a cell that match a given
+   * Helper method to easily iterate over all entity modifications that match a given
    * condition/filter.
    *
-   * @param cell the data cell
+   * @param source a provider of a stream of OSHEntity objects and a corresponding bounding box
    *
    * @return a stream of matching filtered OSMEntities with their clipped Geometries and timestamp
    *         intervals.
    */
-  public Stream<IterateAllEntry> iterateByContribution(GridOSHEntity cell) {
-    var cellBoundingBox = XYGrid.getBoundingBox(new CellId(cell.getLevel(), cell.getId()), true);
+  public Stream<IterateAllEntry> iterateByContribution(OSHEntitySource source) {
+    var cellBoundingBox = source.getBoundingBox();
     final boolean allFullyInside = fullyInside(cellBoundingBox);
     if (!allFullyInside && isBoundByPolygon && bboxOutsidePolygon.test(cellBoundingBox)) {
       return Stream.empty();
     }
-    return iterateByContribution(Streams.stream(cell.getEntities()), allFullyInside);
+    return iterateByContribution(source.getData(), allFullyInside);
   }
 
   /**
-   * Helper method to easily iterate over all entity modifications in a cell that match a given
+   * Helper method to easily iterate over all entity modifications that match a given
    * condition/filter.
    *
    * @param oshData the entities to iterate through

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
@@ -258,14 +258,14 @@ public class CellIterator implements Serializable {
     if (!allFullyInside && isBoundByPolygon && bboxOutsidePolygon.test(cellBoundingBox)) {
       return Stream.empty();
     }
-    return iterateByTimestamps(cell.getEntities(), allFullyInside);
+    return iterateByTimestamps(Streams.stream(cell.getEntities()), allFullyInside);
   }
 
   /**
    * Helper method to easily iterate over all entities in a cell that match a given condition/filter
    * as they existed at the given timestamps.
    *
-   * @param cellData the entities to iterate through
+   * @param oshData the entities to iterate through
    * @param allFullyInside indicator that exact geometry inclusion checks can be skipped
    *
    * @return a stream of matching filtered OSMEntities with their clipped Geometries at each
@@ -274,9 +274,9 @@ public class CellIterator implements Serializable {
    *         optimize away recalculating expensive geometry operations on unchanged feature
    *         geometries later on in the code.
    */
-  public Stream<IterateByTimestampEntry> iterateByTimestamps(Iterable<? extends OSHEntity> cellData,
+  public Stream<IterateByTimestampEntry> iterateByTimestamps(Stream<? extends OSHEntity> oshData,
       boolean allFullyInside) {
-    return Streams.stream(cellData).flatMap(oshEntity -> {
+    return oshData.flatMap(oshEntity -> {
       if (!oshEntityPreFilter.test(oshEntity)
           || !allFullyInside && (
               !oshEntity.getBoundable().intersects(boundingBox)
@@ -541,26 +541,26 @@ public class CellIterator implements Serializable {
     if (!allFullyInside && isBoundByPolygon && bboxOutsidePolygon.test(cellBoundingBox)) {
       return Stream.empty();
     }
-    return iterateByContribution(cell.getEntities(), allFullyInside);
+    return iterateByContribution(Streams.stream(cell.getEntities()), allFullyInside);
   }
 
   /**
    * Helper method to easily iterate over all entity modifications in a cell that match a given
    * condition/filter.
    *
-   * @param cellData the entities to iterate through
+   * @param oshData the entities to iterate through
    * @param allFullyInside indicator that exact geometry inclusion checks can be skipped
    *
    * @return a stream of matching filtered OSMEntities with their clipped Geometries and timestamp
    *         intervals.
    */
-  public Stream<IterateAllEntry> iterateByContribution(Iterable<? extends OSHEntity> cellData,
+  public Stream<IterateAllEntry> iterateByContribution(Stream<? extends OSHEntity> oshData,
       boolean allFullyInside) {
     if (includeOldStyleMultipolygons) {
       //todo: remove this by finishing the functionality below
       throw new UnsupportedOperationException("this is not yet properly implemented (probably)");
     }
-    return Streams.stream(cellData)
+    return oshData
         .filter(oshEntity -> allFullyInside || oshEntity.getBoundable().intersects(boundingBox))
         .filter(oshEntityPreFilter)
         .filter(oshEntity -> allFullyInside || !isBoundByPolygon

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/CellIterator.java
@@ -621,8 +621,8 @@ public class CellIterator implements Serializable {
 
     private IterateAllEntry getNext() {
       while (pos < osmEntityAtTimestamps.size()) {
-        OSHDBTimestamp timestamp = modTs.get(pos);
-        OSMEntity osmEntity = osmEntityAtTimestamps.get(pos);
+        final OSHDBTimestamp timestamp = modTs.get(pos);
+        final OSMEntity osmEntity = osmEntityAtTimestamps.get(pos);
         pos++;
 
         // todo: replace with variable outside of osmEntitiyLoop (than we can also get rid of

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/OSHEntitySource.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/celliterator/OSHEntitySource.java
@@ -1,0 +1,52 @@
+package org.heigit.ohsome.oshdb.util.celliterator;
+
+import com.google.common.collect.Streams;
+import java.util.stream.Stream;
+import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
+import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
+import org.heigit.ohsome.oshdb.index.XYGrid;
+import org.heigit.ohsome.oshdb.osh.OSHEntity;
+import org.heigit.ohsome.oshdb.util.CellId;
+
+/**
+ * A source of OSH entities.
+ */
+public interface OSHEntitySource {
+
+  /**
+   * Returns a stream of OSH entities.
+   *
+   * @return a stream of OSH entities
+   */
+  Stream<? extends OSHEntity> getData();
+
+  /**
+   * Returns the bounding box of the entities returned by `getData()`.
+   *
+   * <p>By convention this bbox must contain the bboxes of all OSH entities returned by this source.
+   * It should be the minimal bbox encompassing all of the entities.</p>
+   *
+   * @return A bounding box enclosing all OSH entities of this source
+   */
+  OSHDBBoundingBox getBoundingBox();
+
+  /**
+   * A helper method which transforms a grid cell to an OSH entity source.
+   *
+   * @param cell A grid cell containing OSH entities
+   * @return A source object which will return the entities of the given grid cell and its bbox
+   */
+  static OSHEntitySource fromGridOSHEntity(GridOSHEntity cell) {
+    return new OSHEntitySource() {
+      @Override
+      public Stream<? extends OSHEntity> getData() {
+        return Streams.stream(cell.getEntities());
+      }
+
+      @Override
+      public OSHDBBoundingBox getBoundingBox() {
+        return XYGrid.getBoundingBox(new CellId(cell.getLevel(), cell.getId()), true);
+      }
+    };
+  }
+}

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilder.java
@@ -80,15 +80,13 @@ public class OSHDBGeometryBuilder {
           "cannot produce geometry of entity for timestamp before this entity's version's timestamp"
       );
     }
-    if (entity instanceof OSMNode) {
-      OSMNode node = (OSMNode) entity;
+    if (entity instanceof OSMNode node) {
       if (node.isVisible()) {
         return geometryFactory.createPoint(new Coordinate(node.getLongitude(), node.getLatitude()));
       } else {
         return geometryFactory.createPoint((Coordinate) null);
       }
-    } else if (entity instanceof OSMWay) {
-      OSMWay way = (OSMWay) entity;
+    } else if (entity instanceof OSMWay way) {
       if (!way.isVisible()) {
         LOG.info("way/{} is deleted - falling back to empty (line) geometry", way.getId());
         return geometryFactory.createLineString((CoordinateSequence) null);

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/mappable/OSMEntitySnapshot.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/mappable/OSMEntitySnapshot.java
@@ -17,6 +17,13 @@ public interface OSMEntitySnapshot extends OSHDBMapReducible, Comparable<OSMEnti
   OSHDBTimestamp getTimestamp();
 
   /**
+   * The timestamp when the entity of the snapshot was last modified before the snapshot timestamp.
+   *
+   * @return last modification timestamp as an OSHDBTimestamp object
+   */
+  OSHDBTimestamp getLastContributionTimestamp();
+
+  /**
    * The geometry of this entity at the snapshot's timestamp clipped to the requested area of
    * interest.
    *

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHNodes;
 import org.heigit.ohsome.oshdb.index.XYGrid;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateAllEntry;
@@ -26,7 +25,7 @@ import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on nodes.
+ * Tests the {@link CellIterator#iterateByContribution(OSHEntitySource)} method on nodes.
  */
 class IterateByContributionNodesTest {
   private final GridOSHNodes oshdbDataGridCell;
@@ -58,7 +57,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -98,7 +97,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -134,7 +133,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(5, result.size());
@@ -181,7 +180,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(6, result.size());
@@ -231,7 +230,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -251,7 +250,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -271,7 +270,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -291,7 +290,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.size());
   }
@@ -311,7 +310,7 @@ class IterateByContributionNodesTest {
         osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(4, result.size());
@@ -347,7 +346,7 @@ class IterateByContributionNodesTest {
         osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("disused:shop")),
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -379,7 +378,7 @@ class IterateByContributionNodesTest {
         osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(4, result.size());
@@ -413,7 +412,7 @@ class IterateByContributionNodesTest {
             osmXmlTestData.keys().getOrDefault("amenity", -1)),
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -441,7 +440,7 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(2, result.size());
   }
@@ -471,7 +470,7 @@ class IterateByContributionNodesTest {
         osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     // result size =2 because if tag filtered for disappears it's a deletion
     assertEquals(2, result.size()); // one version with tag shop
@@ -498,8 +497,10 @@ class IterateByContributionNodesTest {
         oshEntity -> oshEntity.getId() >= 10 && oshEntity.getId() < 20,
         osmEntity -> true,
         false
-    )).iterateByContribution(GridOSHFactory.getGridOSHNodes(osmXmlTestData, 6, (new XYGrid(6))
-            .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)).toList();
+    )).iterateByContribution(OSHEntitySource.fromGridOSHEntity(
+        GridOSHFactory.getGridOSHNodes(osmXmlTestData, 6, (new XYGrid(6))
+            .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)
+    )).toList();
 
     assertEquals(2, result.size());
     assertEquals(13, result.get(0).osmEntity().getId());

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNodesTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHNodes;
@@ -60,28 +59,28 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(1, result.get(0).changeset);
-    assertNull(result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertEquals(1, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Point);
-    assertEquals(result.get(0).geometry.get(), result.get(1).previousGeometry.get());
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
+    assertEquals(result.get(0).geometry().get(), result.get(1).previousGeometry().get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertEquals(result.get(1).osmEntity().getTags(), result.get(0).osmEntity().getTags());
   }
 
   @Test
@@ -100,24 +99,24 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(3, result.get(0).changeset);
-    assertNotEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertNotEquals(result.get(2).osmEntity.getTags(), result.get(1).osmEntity.getTags());
+    assertEquals(3, result.get(0).changeset());
+    assertNotEquals(result.get(1).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertNotEquals(result.get(2).osmEntity().getTags(), result.get(1).osmEntity().getTags());
   }
 
   @Test
@@ -136,30 +135,30 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(5, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(3).activities.get()
+        result.get(3).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(4).activities.get()
+        result.get(4).activities().get()
     );
-    assertEquals(6, result.get(0).changeset);
+    assertEquals(6, result.get(0).changeset());
   }
 
   @Test
@@ -183,38 +182,38 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(6, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE, ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(3).activities.get()
+        result.get(3).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(4).activities.get()
+        result.get(4).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE),
-        result.get(5).activities.get()
+        result.get(5).activities().get()
     );
-    assertEquals(11, result.get(0).changeset);
-    assertNotEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertNotEquals(result.get(3).osmEntity.getTags(), result.get(1).osmEntity.getTags());
-    assertEquals(result.get(4).osmEntity.getTags(), result.get(3).osmEntity.getTags());
-    assertNotEquals(result.get(5).osmEntity.getTags(), result.get(4).osmEntity.getTags());
+    assertEquals(11, result.get(0).changeset());
+    assertNotEquals(result.get(1).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertNotEquals(result.get(3).osmEntity().getTags(), result.get(1).osmEntity().getTags());
+    assertEquals(result.get(4).osmEntity().getTags(), result.get(3).osmEntity().getTags());
+    assertNotEquals(result.get(5).osmEntity().getTags(), result.get(4).osmEntity().getTags());
   }
 
   @Test
@@ -233,7 +232,7 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -253,7 +252,7 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -273,7 +272,7 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -293,7 +292,7 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(3, result.size());
   }
 
@@ -313,24 +312,24 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(4, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(3).activities.get()
+        result.get(3).activities().get()
     );
   }
 
@@ -349,20 +348,20 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
   }
 
@@ -381,27 +380,27 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(4, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
   }
 
   @Test
   void testTagChangeTagFilterWithoutSuccess() {
     // check if results are correct if we filter for a special tag
-    // tag not in data
+    // case: tag not in data
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
             "2000-01-01T00:00:00Z",
@@ -410,11 +409,12 @@ class IterateByContributionNodesTest {
         OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
-        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),
+        osmEntity -> osmEntity.getTags().hasTagKey(
+            osmXmlTestData.keys().getOrDefault("amenity", -1)),
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -442,7 +442,7 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(2, result.size());
   }
 
@@ -472,7 +472,7 @@ class IterateByContributionNodesTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     // result size =2 because if tag filtered for disappears it's a deletion
     assertEquals(2, result.size()); // one version with tag shop
   }
@@ -499,10 +499,10 @@ class IterateByContributionNodesTest {
         osmEntity -> true,
         false
     )).iterateByContribution(GridOSHFactory.getGridOSHNodes(osmXmlTestData, 6, (new XYGrid(6))
-            .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)).collect(Collectors.toList());
+            .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)).toList();
 
     assertEquals(2, result.size());
-    assertEquals(13, result.get(0).osmEntity.getId());
-    assertEquals(14, result.get(1).osmEntity.getId());
+    assertEquals(13, result.get(0).osmEntity().getId());
+    assertEquals(14, result.get(1).osmEntity().getId());
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHRelations;
 import org.heigit.ohsome.oshdb.osh.OSHRelation;
@@ -69,7 +68,7 @@ class IterateByContributionNotOsmTypeSpecificTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(resultPoly.isEmpty());
   }
 
@@ -99,7 +98,7 @@ class IterateByContributionNotOsmTypeSpecificTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(resultPoly.isEmpty());
   }
 
@@ -130,7 +129,7 @@ class IterateByContributionNotOsmTypeSpecificTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertFalse(resultPoly.isEmpty());
   }
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Lists;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHRelations;
 import org.heigit.ohsome.oshdb.osh.OSHRelation;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateAllEntry;
@@ -22,7 +21,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on special situations
+ * Tests the {@link CellIterator#iterateByContribution(OSHEntitySource)} method on special situations
  * which are related to OSHDB grid cells.
  */
 class IterateByContributionNotOsmTypeSpecificTest {
@@ -67,7 +66,7 @@ class IterateByContributionNotOsmTypeSpecificTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(resultPoly.isEmpty());
   }
@@ -97,7 +96,7 @@ class IterateByContributionNotOsmTypeSpecificTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(resultPoly.isEmpty());
   }
@@ -128,7 +127,7 @@ class IterateByContributionNotOsmTypeSpecificTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertFalse(resultPoly.isEmpty());
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionNotOsmTypeSpecificTest.java
@@ -21,8 +21,8 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByContribution(OSHEntitySource)} method on special situations
- * which are related to OSHDB grid cells.
+ * Tests the {@link CellIterator#iterateByContribution(OSHEntitySource)} method on special
+ * situations which are related to OSHDB grid cells.
  */
 class IterateByContributionNotOsmTypeSpecificTest {
 

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -11,7 +11,6 @@ import java.util.EnumSet;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHRelations;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateAllEntry;
 import org.heigit.ohsome.oshdb.util.celliterator.helpers.GridOSHFactory;
@@ -28,7 +27,7 @@ import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on relations.
+ * Tests the {@link CellIterator#iterateByContribution(OSHEntitySource)} method on relations.
  */
 class IterateByContributionRelationsTest {
   private GridOSHRelations oshdbDataGridCell;
@@ -69,7 +68,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true, // osmEntityFilter: true -> get all
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     // one creation and two geometry changes should give a result with 3 elements
     assertEquals(3, result.size());
@@ -112,7 +111,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -146,7 +145,7 @@ class IterateByContributionRelationsTest {
             osmEntity -> true,
             false
         )).iterateByContribution(
-            oshdbDataGridCell
+            OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
         ).collect(Collectors.toList());
     });
   }
@@ -165,7 +164,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -199,7 +198,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(8, result.size());
@@ -239,7 +238,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -278,7 +277,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -317,7 +316,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -352,7 +351,7 @@ class IterateByContributionRelationsTest {
           osmEntity -> true,
           false
       )).iterateByContribution(
-          oshdbDataGridCell
+          OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
       ).toList();
     });
   }
@@ -371,7 +370,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(5, result.size());
@@ -428,7 +427,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(4, result.size());
@@ -455,7 +454,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -492,7 +491,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(2, result.size());
@@ -526,7 +525,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -556,7 +555,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(2, result.size());
@@ -591,7 +590,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.size());
     assertEquals(
@@ -641,7 +640,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.size());
   }
@@ -669,7 +668,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -697,7 +696,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.size());
   }
@@ -725,7 +724,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -746,7 +745,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
@@ -783,7 +782,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -802,7 +801,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -823,7 +822,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
 
@@ -846,7 +845,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     // full geom of same timestamp with unclippedPreviousGeometry and unclippedGeometry
@@ -888,7 +887,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -908,7 +907,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(4, result.size());
@@ -933,7 +932,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(1, result.size());
     assertEquals(
@@ -957,7 +956,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(1, result.size());
     assertEquals(
@@ -981,7 +980,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> !(osmEntity.getVersion() == 2),
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(1, result.size());
@@ -1016,7 +1015,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(4, result.size());
@@ -1054,7 +1053,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(1, result.size());
@@ -1088,7 +1087,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(1, result.size());
@@ -1121,7 +1120,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> !(osmEntity.getVersion() == 2),
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(1, result.size());
@@ -1155,7 +1154,7 @@ class IterateByContributionRelationsTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionRelationsTest.java
@@ -3,6 +3,7 @@ package org.heigit.ohsome.oshdb.util.celliterator;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -69,30 +70,30 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     // one creation and two geometry changes should give a result with 3 elements
     assertEquals(3, result.size());
     // check if the contribution types are correct
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
     // check if changeset number si correct
-    assertEquals(300, result.get(0).changeset);
+    assertEquals(300, result.get(0).changeset());
     // check if geometry types of in every contribution are correct
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof MultiPolygon);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof MultiPolygon);
-    Geometry geom4 = result.get(2).geometry.get();
+    Geometry geom4 = result.get(2).geometry().get();
     assertTrue(geom4 instanceof MultiPolygon);
   }
 
@@ -112,22 +113,22 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(303, result.get(0).changeset);
+    assertEquals(303, result.get(0).changeset());
   }
 
   @Test
@@ -165,22 +166,22 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(307, result.get(0).changeset);
+    assertEquals(307, result.get(0).changeset());
   }
 
   @Test
@@ -199,28 +200,28 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(8, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
 
-    assertEquals(310, result.get(0).changeset);
+    assertEquals(310, result.get(0).changeset());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof Polygon);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -239,27 +240,27 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
-    assertEquals(312, result.get(0).changeset);
+    assertEquals(312, result.get(0).changeset());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof Polygon);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -278,28 +279,28 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
 
-    assertEquals(313, result.get(0).changeset);
+    assertEquals(313, result.get(0).changeset());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof Polygon);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -317,24 +318,25 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
-    assertEquals(314, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertEquals(314, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom1 = result.get(1).geometry.get();
+    Geometry geom1 = result.get(1).geometry().get();
     assertTrue(geom1 instanceof GeometryCollection);
-    Geometry geom2 = result.get(2).geometry.get();
+    Geometry geom2 = result.get(2).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
@@ -351,7 +353,7 @@ class IterateByContributionRelationsTest {
           false
       )).iterateByContribution(
           oshdbDataGridCell
-      ).collect(Collectors.toList());
+      ).toList();
     });
   }
 
@@ -370,46 +372,46 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(5, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(3).activities.get()
+        result.get(3).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(4).activities.get()
+        result.get(4).activities().get()
     );
 
-    assertEquals(316, result.get(0).changeset);
+    assertEquals(316, result.get(0).changeset());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof Polygon);
-    Geometry geom3 = result.get(2).geometry.get();
+    Geometry geom3 = result.get(2).geometry().get();
     assertTrue(geom3 instanceof Polygon);
-    Geometry geom4 = result.get(3).geometry.get();
+    Geometry geom4 = result.get(3).geometry().get();
     assertTrue(geom4 instanceof Polygon);
-    Geometry geom5 = result.get(4).geometry.get();
+    Geometry geom5 = result.get(4).geometry().get();
     assertTrue(geom5 instanceof Polygon);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -427,16 +429,16 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(4, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
-    assertEquals(317, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
+    assertEquals(317, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
   }
 
   @Test
@@ -454,25 +456,25 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
 
-    assertEquals(318, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
-    assertTrue(result.get(1).geometry.get().isEmpty());
+    assertEquals(318, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
+    assertTrue(result.get(1).geometry().get().isEmpty());
   }
 
   @Test
@@ -491,23 +493,23 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(2, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
-    assertEquals(319, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
+    assertEquals(319, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
   }
 
   @Test
@@ -525,19 +527,19 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(2).geometry.get();
+    Geometry geom2 = result.get(2).geometry().get();
     assertTrue(geom2 instanceof Polygon);
-    assertEquals(320, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
+    assertEquals(320, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
   }
 
   @Test
@@ -555,24 +557,24 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(2, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof MultiPolygon);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof Polygon);
-    assertEquals(321, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
+    assertEquals(321, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
   }
 
   @Test
@@ -590,29 +592,29 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom1 = result.get(1).geometry.get();
+    Geometry geom1 = result.get(1).geometry().get();
     assertTrue(geom1 instanceof GeometryCollection);
-    Geometry geom2 = result.get(2).geometry.get();
+    Geometry geom2 = result.get(2).geometry().get();
     assertTrue(geom2 instanceof Polygon);
-    assertEquals(323, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
+    assertEquals(323, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
   }
 
 
@@ -640,7 +642,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(3, result.size());
   }
 
@@ -668,7 +670,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -696,7 +698,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(3, result.size());
   }
 
@@ -724,7 +726,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -745,17 +747,17 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
-    assertTrue(result.get(1).activities.get().isEmpty());
+    assertTrue(result.get(1).activities().get().isEmpty());
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(7, result.get(1).geometry.get().getNumPoints());
+    assertEquals(7, result.get(1).geometry().get().getNumPoints());
   }
 
   @Test
@@ -782,7 +784,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -801,7 +803,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -822,7 +824,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
 
   }
@@ -845,19 +847,19 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     // full geom of same timestamp with unclippedPreviousGeometry and unclippedGeometry
-    assertEquals(result.get(1).unclippedPreviousGeometry.get().getArea(),
-        result.get(0).unclippedGeometry.get().getArea(), DELTA);
+    assertEquals(result.get(1).unclippedPreviousGeometry().get().getArea(),
+        result.get(0).unclippedGeometry().get().getArea(), DELTA);
     // geom of requested area vs full geom after modification
-    assertNotEquals(result.get(0).geometry.get().getArea(),
-        result.get(0).unclippedGeometry.get().getArea());
+    assertNotEquals(result.get(0).geometry().get().getArea(),
+        result.get(0).unclippedGeometry().get().getArea());
     // full geom changed
-    assertNotEquals(result.get(1).unclippedGeometry.get().getArea(),
-        result.get(0).unclippedGeometry.get().getArea());
-    assertNotEquals(result.get(1).unclippedGeometry.get().getArea(),
-        result.get(2).unclippedGeometry.get().getArea());
+    assertNotEquals(result.get(1).unclippedGeometry().get().getArea(),
+        result.get(0).unclippedGeometry().get().getArea());
+    assertNotEquals(result.get(1).unclippedGeometry().get().getArea(),
+        result.get(2).unclippedGeometry().get().getArea());
 
   }
 
@@ -887,7 +889,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -907,14 +909,14 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(4, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
-    assertTrue(result.get(3).geometry.get().isEmpty());
+    assertTrue(result.get(3).geometry().get().isEmpty());
   }
 
   @Test
@@ -932,11 +934,11 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(1, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
   }
@@ -956,11 +958,11 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(1, result.size());
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
   }
@@ -980,12 +982,12 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(1, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
   }
@@ -1015,16 +1017,16 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(4, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(3).activities.get()
+        result.get(3).activities().get()
     );
 
   }
@@ -1053,12 +1055,12 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(1, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
   }
@@ -1087,12 +1089,12 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(1, result.size());
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
   }
 
@@ -1120,12 +1122,12 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(1, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
   }
@@ -1154,7 +1156,7 @@ class IterateByContributionRelationsTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.io.ObjectInputStream;
 import java.util.List;
 import java.util.TreeSet;
-import java.util.stream.Collectors;
 import org.h2.jdbcx.JdbcConnectionPool;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
@@ -74,10 +73,10 @@ class IterateByContributionTest {
             false
         )).iterateByContribution(
             oshCellRawData
-        ).collect(Collectors.toList());
+        ).toList();
         countTotal += result.size();
         for (IterateAllEntry entry : result) {
-          if (entry.activities.contains(ContributionType.CREATION)) {
+          if (entry.activities().contains(ContributionType.CREATION)) {
             countCreated++;
           } else {
             countOther++;

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /**
- * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method.
+ * Tests the {@link CellIterator#iterateByContribution(OSHEntitySource)} method.
  */
 class IterateByContributionTest {
   private static JdbcConnectionPool source;
@@ -72,7 +72,7 @@ class IterateByContributionTest {
             osmEntity -> true,
             false
         )).iterateByContribution(
-            oshCellRawData
+            OSHEntitySource.fromGridOSHEntity(oshCellRawData)
         ).toList();
         countTotal += result.size();
         for (IterateAllEntry entry : result) {

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHRelations;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateAllEntry;
 import org.heigit.ohsome.oshdb.util.celliterator.helpers.GridOSHFactory;
@@ -26,7 +25,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on relations except
+ * Tests the {@link CellIterator#iterateByContribution(OSHEntitySource)} method on relations except
  * multipolygon relations.
  */
 class IterateByContributionTypeNotMultipolygonTest {
@@ -59,7 +58,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -99,7 +98,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -134,7 +133,7 @@ class IterateByContributionTypeNotMultipolygonTest {
           osmEntity -> true,
           false
       )).iterateByContribution(
-          oshdbDataGridCell
+          OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
       ).toList();
     });
   }
@@ -153,7 +152,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -187,7 +186,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(8, result.size());
@@ -227,7 +226,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -267,7 +266,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -306,7 +305,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -341,7 +340,7 @@ class IterateByContributionTypeNotMultipolygonTest {
           osmEntity -> true,
           false
       )).iterateByContribution(
-          oshdbDataGridCell
+          OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
       ).toList();
     });
   }
@@ -360,7 +359,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(5, result.size());
@@ -417,7 +416,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(4, result.size());
@@ -444,7 +443,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -472,7 +471,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(2, result.size());
@@ -506,7 +505,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -536,7 +535,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(2, result.size());
@@ -571,7 +570,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.size());
     assertEquals(
@@ -621,7 +620,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.size());
   }
@@ -649,7 +648,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.size());
   }
@@ -677,7 +676,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -698,7 +697,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(
@@ -736,7 +735,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -755,7 +754,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -776,7 +775,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -804,7 +803,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     Geometry geom1 = result.get(0).geometry().get();
     assertTrue(geom1 instanceof GeometryCollection);
@@ -826,7 +825,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(4, result.size());
@@ -851,7 +850,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -879,7 +878,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(1, result.size());
     assertEquals(

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionTypeNotMultipolygonTest.java
@@ -3,12 +3,12 @@ package org.heigit.ohsome.oshdb.util.celliterator;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHRelations;
@@ -60,27 +60,27 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(300, result.get(0).changeset);
-    Geometry geom = result.get(0).geometry.get();
+    assertEquals(300, result.get(0).changeset());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof GeometryCollection);
-    Geometry geom4 = result.get(2).geometry.get();
+    Geometry geom4 = result.get(2).geometry().get();
     assertTrue(geom4 instanceof GeometryCollection);
   }
 
@@ -100,24 +100,25 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(303, result.get(0).changeset);
+    assertEquals(303, result.get(0).changeset());
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void testWaysNotExistent() {
     // relation with two ways, both missing
@@ -134,7 +135,7 @@ class IterateByContributionTypeNotMultipolygonTest {
           false
       )).iterateByContribution(
           oshdbDataGridCell
-      ).collect(Collectors.toList());
+      ).toList();
     });
   }
 
@@ -153,22 +154,22 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(307, result.get(0).changeset);
+    assertEquals(307, result.get(0).changeset());
   }
 
   @Test
@@ -187,28 +188,28 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(8, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
 
-    assertEquals(310, result.get(0).changeset);
+    assertEquals(310, result.get(0).changeset());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof GeometryCollection);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -227,28 +228,28 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
 
-    assertEquals(312, result.get(0).changeset);
+    assertEquals(312, result.get(0).changeset());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof GeometryCollection);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -267,28 +268,28 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
 
-    assertEquals(313, result.get(0).changeset);
+    assertEquals(313, result.get(0).changeset());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof GeometryCollection);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -306,24 +307,25 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
-    assertEquals(314, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertEquals(314, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom1 = result.get(1).geometry.get();
+    Geometry geom1 = result.get(1).geometry().get();
     assertTrue(geom1 instanceof GeometryCollection);
-    Geometry geom2 = result.get(2).geometry.get();
+    Geometry geom2 = result.get(2).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
   }
 
+  @SuppressWarnings("ResultOfMethodCallIgnored")
   @Test
   void testNodesOfWaysNotExistent() {
     // relation 2 way members nodes do not exist
@@ -340,7 +342,7 @@ class IterateByContributionTypeNotMultipolygonTest {
           false
       )).iterateByContribution(
           oshdbDataGridCell
-      ).collect(Collectors.toList());
+      ).toList();
     });
   }
 
@@ -359,46 +361,46 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(5, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(3).activities.get()
+        result.get(3).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(4).activities.get()
+        result.get(4).activities().get()
     );
 
-    assertEquals(316, result.get(0).changeset);
+    assertEquals(316, result.get(0).changeset());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
-    Geometry geom3 = result.get(2).geometry.get();
+    Geometry geom3 = result.get(2).geometry().get();
     assertTrue(geom3 instanceof GeometryCollection);
-    Geometry geom4 = result.get(3).geometry.get();
+    Geometry geom4 = result.get(3).geometry().get();
     assertTrue(geom4 instanceof GeometryCollection);
-    Geometry geom5 = result.get(4).geometry.get();
+    Geometry geom5 = result.get(4).geometry().get();
     assertTrue(geom5 instanceof GeometryCollection);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -416,16 +418,16 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(4, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
-    assertEquals(317, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
+    assertEquals(317, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
   }
 
   @Test
@@ -443,16 +445,16 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
 
-    assertEquals(318, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
+    assertEquals(318, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
   }
 
   @Test
@@ -471,23 +473,23 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(2, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
-    assertEquals(319, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
+    assertEquals(319, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
   }
 
   @Test
@@ -505,19 +507,19 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom2 = result.get(2).geometry.get();
+    Geometry geom2 = result.get(2).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
-    assertEquals(320, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
+    assertEquals(320, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
   }
 
   @Test
@@ -535,24 +537,24 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(2, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
-    assertEquals(321, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
+    assertEquals(321, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
   }
 
   @Test
@@ -570,29 +572,29 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom1 = result.get(1).geometry.get();
+    Geometry geom1 = result.get(1).geometry().get();
     assertTrue(geom1 instanceof GeometryCollection);
-    Geometry geom2 = result.get(2).geometry.get();
+    Geometry geom2 = result.get(2).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
-    assertEquals(323, result.get(0).changeset);
-    assertEquals(null, result.get(0).previousGeometry.get());
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
+    assertEquals(323, result.get(0).changeset());
+    assertNull(result.get(0).previousGeometry().get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
   }
 
 
@@ -620,7 +622,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(3, result.size());
   }
 
@@ -648,7 +650,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(3, result.size());
   }
 
@@ -676,7 +678,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -697,18 +699,18 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
-    assertTrue(result.get(1).activities.get().isEmpty());
+    assertTrue(result.get(1).activities().get().isEmpty());
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(7, result.get(1).geometry.get().getNumPoints());
+    assertEquals(7, result.get(1).geometry().get().getNumPoints());
   }
 
   @Test
@@ -735,7 +737,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -754,7 +756,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -775,7 +777,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -803,8 +805,8 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
-    Geometry geom1 = result.get(0).geometry.get();
+    ).toList();
+    Geometry geom1 = result.get(0).geometry().get();
     assertTrue(geom1 instanceof GeometryCollection);
     assertEquals(1, result.size());
   }
@@ -825,12 +827,12 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(4, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
   }
 
@@ -850,7 +852,7 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -878,11 +880,11 @@ class IterateByContributionTypeNotMultipolygonTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(1, result.size());
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
@@ -2,12 +2,12 @@ package org.heigit.ohsome.oshdb.util.celliterator;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHWays;
@@ -56,37 +56,37 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(31, result.get(0).changeset);
+    assertEquals(31, result.get(0).changeset());
 
-    assertEquals(4, result.get(0).geometry.get().getNumPoints());
-    assertEquals(8, result.get(1).geometry.get().getNumPoints());
-    assertEquals(9, result.get(2).geometry.get().getNumPoints());
+    assertEquals(4, result.get(0).geometry().get().getNumPoints());
+    assertEquals(8, result.get(1).geometry().get().getNumPoints());
+    assertEquals(9, result.get(2).geometry().get().getNumPoints());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof LineString);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof LineString);
-    Geometry geom3 = result.get(2).geometry.get();
+    Geometry geom3 = result.get(2).geometry().get();
     assertTrue(geom3 instanceof LineString);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -105,39 +105,39 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(4, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
 
-    assertEquals(34, result.get(0).changeset);
+    assertEquals(34, result.get(0).changeset());
 
-    assertEquals(2, result.get(0).geometry.get().getNumPoints());
-    assertEquals(2, result.get(1).geometry.get().getNumPoints());
-    assertEquals(3, result.get(3).geometry.get().getNumPoints());
+    assertEquals(2, result.get(0).geometry().get().getNumPoints());
+    assertEquals(2, result.get(1).geometry().get().getNumPoints());
+    assertEquals(3, result.get(3).geometry().get().getNumPoints());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof LineString);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof LineString);
-    Geometry geom4 = result.get(3).geometry.get();
+    Geometry geom4 = result.get(3).geometry().get();
     assertTrue(geom4 instanceof LineString);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
-    assertNotEquals(result.get(3).geometry.get(), result.get(3).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
+    assertNotEquals(result.get(3).geometry().get(), result.get(3).previousGeometry().get());
   }
 
   @Test
@@ -156,22 +156,22 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(36, result.get(0).changeset);
+    assertEquals(36, result.get(0).changeset());
   }
 
   @Test
@@ -189,37 +189,37 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE, ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(39, result.get(0).changeset);
+    assertEquals(39, result.get(0).changeset());
 
-    assertEquals(3, result.get(0).geometry.get().getNumPoints());
-    assertEquals(5, result.get(1).geometry.get().getNumPoints());
-    assertEquals(5, result.get(2).geometry.get().getNumPoints());
+    assertEquals(3, result.get(0).geometry().get().getNumPoints());
+    assertEquals(5, result.get(1).geometry().get().getNumPoints());
+    assertEquals(5, result.get(2).geometry().get().getNumPoints());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof LineString);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof LineString);
-    Geometry geom3 = result.get(2).geometry.get();
+    Geometry geom3 = result.get(2).geometry().get();
     assertTrue(geom3 instanceof LineString);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
-    assertEquals(result.get(2).geometry.get(), result.get(2).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
+    assertEquals(result.get(2).geometry().get(), result.get(2).previousGeometry().get());
   }
 
   @Test
@@ -240,32 +240,32 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(6, result.size());
-    assertEquals(2, result.get(0).geometry.get().getNumPoints());
-    assertEquals(3, result.get(1).geometry.get().getNumPoints());
-    assertEquals(2, result.get(2).geometry.get().getNumPoints());
-    assertEquals(3, result.get(3).geometry.get().getNumPoints());
-    assertEquals(3, result.get(4).geometry.get().getNumPoints());
+    assertEquals(2, result.get(0).geometry().get().getNumPoints());
+    assertEquals(3, result.get(1).geometry().get().getNumPoints());
+    assertEquals(2, result.get(2).geometry().get().getNumPoints());
+    assertEquals(3, result.get(3).geometry().get().getNumPoints());
+    assertEquals(3, result.get(4).geometry().get().getNumPoints());
 
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(3).activities.get()
+        result.get(3).activities().get()
     );
-    assertEquals(42, result.get(0).changeset);
+    assertEquals(42, result.get(0).changeset());
   }
 
 
@@ -284,36 +284,36 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(6, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE, ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(3).activities.get()
+        result.get(3).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.DELETION),
-        result.get(4).activities.get()
+        result.get(4).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(5).activities.get()
+        result.get(5).activities().get()
     );
 
-    assertEquals(44, result.get(0).changeset);
-    assertNotEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertEquals(result.get(5).osmEntity.getTags(), result.get(3).osmEntity.getTags());
+    assertEquals(44, result.get(0).changeset());
+    assertNotEquals(result.get(1).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertEquals(result.get(5).osmEntity().getTags(), result.get(3).osmEntity().getTags());
   }
 
   @Test
@@ -331,29 +331,29 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(2, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.TAG_CHANGE, ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
 
-    assertEquals(48, result.get(0).changeset);
+    assertEquals(48, result.get(0).changeset());
 
-    assertEquals(5, result.get(0).geometry.get().getNumPoints());
-    assertEquals(5, result.get(1).geometry.get().getNumPoints());
+    assertEquals(5, result.get(0).geometry().get().getNumPoints());
+    assertEquals(5, result.get(1).geometry().get().getNumPoints());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof LineString);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
   }
 
   @Test
@@ -371,29 +371,29 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(2, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
 
-    assertEquals(50, result.get(0).changeset);
+    assertEquals(50, result.get(0).changeset());
 
-    assertEquals(5, result.get(0).geometry.get().getNumPoints());
-    assertEquals(4, result.get(1).geometry.get().getNumPoints());
+    assertEquals(5, result.get(0).geometry().get().getNumPoints());
+    assertEquals(4, result.get(1).geometry().get().getNumPoints());
 
-    assertEquals(null, result.get(0).previousGeometry.get());
-    Geometry geom = result.get(0).geometry.get();
+    assertNull(result.get(0).previousGeometry().get());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof LineString);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(1).previousGeometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(1).previousGeometry().get());
   }
 
   @Test
@@ -412,16 +412,16 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     // should be 2: entity has created at start time, modified in between and at end time (excluded)
     assertEquals(2, result.size());
-    assertEquals(61, result.get(0).changeset);
+    assertEquals(61, result.get(0).changeset());
   }
 
   @Test
   void testTwoNodesChangedAtSameTimeDifferentChangesets() {
     // way with two nodes, nodes changed lat lon, both at same time, different changesets
-    // which changeset is shown in result.get(1).changeset? -> from node 20, not 21
+    // which changeset is shown in result.get(1).changeset()? -> from node 20, not 21
     List<IterateAllEntry> result = (new CellIterator(
         new OSHDBTimestamps(
             "2000-01-01T00:00:00Z",
@@ -434,19 +434,19 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(2, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     // randomly 332 or 334
-    //assertEquals(332, result.get(1).changeset);
+    //assertEquals(332, result.get(1).changeset());
   }
 
   @Test
@@ -465,15 +465,15 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(2, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
-    assertTrue(result.get(1).activities.get().isEmpty());
-    assertEquals(3, result.get(1).geometry.get().getNumPoints());
+    assertTrue(result.get(1).activities().get().isEmpty());
+    assertEquals(3, result.get(1).geometry().get().getNumPoints());
   }
 
   @Test
@@ -493,19 +493,19 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
-    assertTrue(result.get(1).activities.get().isEmpty());
+    assertTrue(result.get(1).activities().get().isEmpty());
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
-    assertEquals(3, result.get(1).geometry.get().getNumPoints());
+    assertEquals(3, result.get(1).geometry().get().getNumPoints());
   }
 
   @Test
@@ -524,15 +524,15 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
-    assertTrue(result.get(1).activities.get().isEmpty());
-    assertTrue(result.get(2).activities.get().isEmpty());
+    assertTrue(result.get(1).activities().get().isEmpty());
+    assertTrue(result.get(2).activities().get().isEmpty());
   }
 
   @Test
@@ -550,20 +550,20 @@ class IterateByContributionWaysTest {
         false
     )).iterateByContribution(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
     assertEquals(
         EnumSet.of(ContributionType.CREATION),
-        result.get(0).activities.get()
+        result.get(0).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(1).activities.get()
+        result.get(1).activities().get()
     );
     assertEquals(
         EnumSet.of(ContributionType.GEOMETRY_CHANGE),
-        result.get(2).activities.get()
+        result.get(2).activities().get()
     );
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByContributionWaysTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.EnumSet;
 import java.util.List;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHWays;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateAllEntry;
 import org.heigit.ohsome.oshdb.util.celliterator.helpers.GridOSHFactory;
@@ -23,7 +22,7 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByContribution(GridOSHEntity)} method on ways.
+ * Tests the {@link CellIterator#iterateByContribution(OSHEntitySource)} method on ways.
  */
 class IterateByContributionWaysTest {
   private GridOSHWays oshdbDataGridCell;
@@ -55,7 +54,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -104,7 +103,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(4, result.size());
@@ -155,7 +154,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -188,7 +187,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -239,7 +238,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(6, result.size());
@@ -283,7 +282,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(6, result.size());
     assertEquals(
@@ -330,7 +329,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(2, result.size());
     assertEquals(
@@ -370,7 +369,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(2, result.size());
     assertEquals(
@@ -411,7 +410,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     // should be 2: entity has created at start time, modified in between and at end time (excluded)
     assertEquals(2, result.size());
@@ -433,7 +432,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(2, result.size());
@@ -464,7 +463,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(2, result.size());
@@ -492,7 +491,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -523,7 +522,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -549,7 +548,7 @@ class IterateByContributionWaysTest {
         osmEntity -> true,
         false
     )).iterateByContribution(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
@@ -1,5 +1,6 @@
 package org.heigit.ohsome.oshdb.util.celliterator;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -108,7 +109,7 @@ class IterateByTimestampNotOsmTypeSpecificTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -138,7 +139,7 @@ class IterateByTimestampNotOsmTypeSpecificTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -169,7 +170,7 @@ class IterateByTimestampNotOsmTypeSpecificTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
-    assertTrue(!result.isEmpty());
+    ).toList();
+    assertFalse(result.isEmpty());
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampNotOsmTypeSpecificTest.java
@@ -12,7 +12,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHRelations;
 import org.heigit.ohsome.oshdb.impl.osh.OSHNodeImpl;
 import org.heigit.ohsome.oshdb.impl.osh.OSHRelationImpl;
@@ -35,7 +34,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByTimestamps(GridOSHEntity)} method on special situations
+ * Tests the {@link CellIterator#iterateByTimestamps(OSHEntitySource)} method on special situations
  * which are related to OSHDB grid cells.
  */
 class IterateByTimestampNotOsmTypeSpecificTest {
@@ -108,7 +107,7 @@ class IterateByTimestampNotOsmTypeSpecificTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -138,7 +137,7 @@ class IterateByTimestampNotOsmTypeSpecificTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -169,7 +168,7 @@ class IterateByTimestampNotOsmTypeSpecificTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertFalse(result.isEmpty());
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -271,4 +271,35 @@ class IterateByTimestampsNodesTest {
     assertEquals(13, result.get(1).osmEntity().getId());
     assertEquals(14, result.get(2).osmEntity().getId());
   }
+
+  @Test
+  void testLastContributionTimestamp() {
+    // node 3: creation and 4 visible changes, but no geometry and no tag changes
+
+    List<IterateByTimestampEntry> result = (new CellIterator(
+        new OSHDBTimestamps(
+            "2000-06-01T00:00:00Z",
+            "2018-06-01T00:00:00Z",
+            "P1Y"
+        ).get(),
+        OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
+        areaDecider,
+        oshEntity -> oshEntity.getId() == 3,
+        osmEntity -> true,
+        false
+    )).iterateByTimestamps(
+        oshdbDataGridCell
+    ).toList();
+    assertEquals(5, result.size());
+    assertEquals("2007-06-01T00:00:00", result.get(0).timestamp().toString());
+    assertEquals("2007-01-01T00:00:00", result.get(0).lastModificationTimestamp().toString());
+    assertEquals("2014-06-01T00:00:00", result.get(1).timestamp().toString());
+    assertEquals("2014-01-01T00:00:00", result.get(1).lastModificationTimestamp().toString());
+    assertEquals("2016-06-01T00:00:00", result.get(2).timestamp().toString());
+    assertEquals("2016-01-01T00:00:00", result.get(2).lastModificationTimestamp().toString());
+    assertEquals("2017-06-01T00:00:00", result.get(3).timestamp().toString());
+    assertEquals("2016-01-01T00:00:00", result.get(3).lastModificationTimestamp().toString());
+    assertEquals("2018-06-01T00:00:00", result.get(4).timestamp().toString());
+    assertEquals("2016-01-01T00:00:00", result.get(4).lastModificationTimestamp().toString());
+  }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHNodes;
@@ -59,13 +58,13 @@ class IterateByTimestampsNodesTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(11, result.size());
-    assertNotEquals(result.get(1).geometry.get().getCoordinates(),
-        result.get(0).geometry.get().getCoordinates());
-    assertNotEquals(result.get(2).geometry.get().getCoordinates(),
-        result.get(1).geometry.get().getCoordinates());
+    assertNotEquals(result.get(1).geometry().get().getCoordinates(),
+        result.get(0).geometry().get().getCoordinates());
+    assertNotEquals(result.get(2).geometry().get().getCoordinates(),
+        result.get(1).geometry().get().getCoordinates());
   }
 
   @Test
@@ -85,19 +84,19 @@ class IterateByTimestampsNodesTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(12, result.size());
-    assertNotEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertEquals(result.get(2).osmEntity.getTags(), result.get(1).osmEntity.getTags());
-    assertEquals(result.get(3).osmEntity.getTags(), result.get(2).osmEntity.getTags());
-    assertEquals(result.get(4).osmEntity.getTags(), result.get(3).osmEntity.getTags());
-    assertEquals(result.get(5).osmEntity.getTags(), result.get(4).osmEntity.getTags());
-    assertEquals(result.get(6).osmEntity.getTags(), result.get(5).osmEntity.getTags());
-    assertNotEquals(result.get(7).osmEntity.getTags(), result.get(6).osmEntity.getTags());
-    assertEquals(result.get(8).osmEntity.getTags(), result.get(7).osmEntity.getTags());
-    assertEquals(result.get(9).osmEntity.getTags(), result.get(8).osmEntity.getTags());
-    assertEquals(result.get(10).osmEntity.getTags(), result.get(9).osmEntity.getTags());
-    assertEquals(result.get(11).osmEntity.getTags(), result.get(10).osmEntity.getTags());
+    assertNotEquals(result.get(1).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertEquals(result.get(2).osmEntity().getTags(), result.get(1).osmEntity().getTags());
+    assertEquals(result.get(3).osmEntity().getTags(), result.get(2).osmEntity().getTags());
+    assertEquals(result.get(4).osmEntity().getTags(), result.get(3).osmEntity().getTags());
+    assertEquals(result.get(5).osmEntity().getTags(), result.get(4).osmEntity().getTags());
+    assertEquals(result.get(6).osmEntity().getTags(), result.get(5).osmEntity().getTags());
+    assertNotEquals(result.get(7).osmEntity().getTags(), result.get(6).osmEntity().getTags());
+    assertEquals(result.get(8).osmEntity().getTags(), result.get(7).osmEntity().getTags());
+    assertEquals(result.get(9).osmEntity().getTags(), result.get(8).osmEntity().getTags());
+    assertEquals(result.get(10).osmEntity().getTags(), result.get(9).osmEntity().getTags());
+    assertEquals(result.get(11).osmEntity().getTags(), result.get(10).osmEntity().getTags());
   }
 
   @Test
@@ -117,7 +116,7 @@ class IterateByTimestampsNodesTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(5, result.size());
   }
 
@@ -143,31 +142,31 @@ class IterateByTimestampsNodesTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(11, result.size());
-    assertNotEquals(result.get(1).geometry.get().getCoordinates(),
-        result.get(0).geometry.get().getCoordinates());
-    assertArrayEquals(result.get(2).geometry.get().getCoordinates(),
-        result.get(1).geometry.get().getCoordinates());
-    assertNotEquals(result.get(3).geometry.get().getCoordinates(),
-        result.get(2).geometry.get().getCoordinates());
-    assertArrayEquals(result.get(5).geometry.get().getCoordinates(),
-        result.get(3).geometry.get().getCoordinates());
-    assertNotEquals(result.get(6).geometry.get().getCoordinates(),
-        result.get(3).geometry.get().getCoordinates());
-    assertArrayEquals(result.get(9).geometry.get().getCoordinates(),
-        result.get(6).geometry.get().getCoordinates());
-    assertNotEquals(result.get(1).osmEntity.getTags(),
-        result.get(0).osmEntity.getTags());
-    assertEquals(result.get(2).osmEntity.getTags(),
-        result.get(1).osmEntity.getTags());
-    assertNotEquals(result.get(3).osmEntity.getTags(),
-        result.get(2).osmEntity.getTags());
-    assertEquals(result.get(5).osmEntity.getTags(),
-        result.get(4).osmEntity.getTags());
-    assertNotEquals(result.get(9).osmEntity.getTags(),
-        result.get(6).osmEntity.getTags());
+    assertNotEquals(result.get(1).geometry().get().getCoordinates(),
+        result.get(0).geometry().get().getCoordinates());
+    assertArrayEquals(result.get(2).geometry().get().getCoordinates(),
+        result.get(1).geometry().get().getCoordinates());
+    assertNotEquals(result.get(3).geometry().get().getCoordinates(),
+        result.get(2).geometry().get().getCoordinates());
+    assertArrayEquals(result.get(5).geometry().get().getCoordinates(),
+        result.get(3).geometry().get().getCoordinates());
+    assertNotEquals(result.get(6).geometry().get().getCoordinates(),
+        result.get(3).geometry().get().getCoordinates());
+    assertArrayEquals(result.get(9).geometry().get().getCoordinates(),
+        result.get(6).geometry().get().getCoordinates());
+    assertNotEquals(result.get(1).osmEntity().getTags(),
+        result.get(0).osmEntity().getTags());
+    assertEquals(result.get(2).osmEntity().getTags(),
+        result.get(1).osmEntity().getTags());
+    assertNotEquals(result.get(3).osmEntity().getTags(),
+        result.get(2).osmEntity().getTags());
+    assertEquals(result.get(5).osmEntity().getTags(),
+        result.get(4).osmEntity().getTags());
+    assertNotEquals(result.get(9).osmEntity().getTags(),
+        result.get(6).osmEntity().getTags());
   }
 
   @Test
@@ -186,7 +185,7 @@ class IterateByTimestampsNodesTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(7, result.size());
   }
 
@@ -202,11 +201,12 @@ class IterateByTimestampsNodesTest {
         OSHDBBoundingBox.bboxWgs84Coordinates(-180.0, -90.0, 180.0, 90.0),
         areaDecider,
         oshEntity -> oshEntity.getId() == 5,
-        osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().getOrDefault("amenity", -1)),
+        osmEntity -> osmEntity.getTags().hasTagKey(
+            osmXmlTestData.keys().getOrDefault("amenity", -1)),
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -235,7 +235,7 @@ class IterateByTimestampsNodesTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(1, result.size());
   }
 
@@ -264,11 +264,11 @@ class IterateByTimestampsNodesTest {
     )).iterateByTimestamps(
         GridOSHFactory.getGridOSHNodes(osmXmlTestData, 6, (new XYGrid(6))
             .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
-    assertEquals(13, result.get(0).osmEntity.getId());
-    assertEquals(13, result.get(1).osmEntity.getId());
-    assertEquals(14, result.get(2).osmEntity.getId());
+    assertEquals(13, result.get(0).osmEntity().getId());
+    assertEquals(13, result.get(1).osmEntity().getId());
+    assertEquals(14, result.get(2).osmEntity().getId());
   }
 }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsNodesTest.java
@@ -8,7 +8,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.List;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHNodes;
 import org.heigit.ohsome.oshdb.index.XYGrid;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateByTimestampEntry;
@@ -23,7 +22,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByTimestamps(GridOSHEntity)} method on OSM nodes.
+ * Tests the {@link CellIterator#iterateByTimestamps(OSHEntitySource)} method on OSM nodes.
  */
 class IterateByTimestampsNodesTest {
   private final GridOSHNodes oshdbDataGridCell;
@@ -57,7 +56,7 @@ class IterateByTimestampsNodesTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(11, result.size());
@@ -83,7 +82,7 @@ class IterateByTimestampsNodesTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(12, result.size());
     assertNotEquals(result.get(1).osmEntity().getTags(), result.get(0).osmEntity().getTags());
@@ -115,7 +114,7 @@ class IterateByTimestampsNodesTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(5, result.size());
   }
@@ -141,7 +140,7 @@ class IterateByTimestampsNodesTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(11, result.size());
@@ -184,7 +183,7 @@ class IterateByTimestampsNodesTest {
         osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(7, result.size());
   }
@@ -205,7 +204,7 @@ class IterateByTimestampsNodesTest {
             osmXmlTestData.keys().getOrDefault("amenity", -1)),
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -234,7 +233,7 @@ class IterateByTimestampsNodesTest {
         osmEntity -> osmEntity.getTags().hasTagKey(osmXmlTestData.keys().get("shop")),
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(1, result.size());
   }
@@ -261,10 +260,10 @@ class IterateByTimestampsNodesTest {
         oshEntity -> oshEntity.getId() >= 10 && oshEntity.getId() < 20,
         osmEntity -> true,
         false
-    )).iterateByTimestamps(
+    )).iterateByTimestamps(OSHEntitySource.fromGridOSHEntity(
         GridOSHFactory.getGridOSHNodes(osmXmlTestData, 6, (new XYGrid(6))
             .getId(1.0, 1.0)/* approx. 0, 0, 5.6, 5.6*/)
-    ).toList();
+    )).toList();
 
     assertEquals(3, result.size());
     assertEquals(13, result.get(0).osmEntity().getId());
@@ -288,7 +287,7 @@ class IterateByTimestampsNodesTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(5, result.size());
     assertEquals("2007-06-01T00:00:00", result.get(0).timestamp().toString());

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHRelations;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateByTimestampEntry;
 import org.heigit.ohsome.oshdb.util.celliterator.helpers.GridOSHFactory;
@@ -26,7 +25,7 @@ import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByTimestamps(GridOSHEntity)} method on OSM relations.
+ * Tests the {@link CellIterator#iterateByTimestamps(OSHEntitySource)} method on OSM relations.
  */
 class IterateByTimestampsRelationsTest {
   private final GridOSHRelations oshdbDataGridCell;
@@ -59,7 +58,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(12, result.size());
@@ -89,7 +88,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(9, result.size());
@@ -113,7 +112,7 @@ class IterateByTimestampsRelationsTest {
           osmEntity -> true,
           false
       )).iterateByTimestamps(
-          oshdbDataGridCell
+          OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
       ).collect(Collectors.toList());
     });
   }
@@ -133,7 +132,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(14, result.size());
@@ -156,7 +155,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(10, result.size());
@@ -188,7 +187,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(10, result.size());
@@ -219,7 +218,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(10, result.size());
@@ -244,7 +243,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(10, result.size());
@@ -273,7 +272,7 @@ class IterateByTimestampsRelationsTest {
           osmEntity -> true,
           false
       )).iterateByTimestamps(
-          oshdbDataGridCell
+          OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
       ).collect(Collectors.toList());
     });
   }
@@ -293,7 +292,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(10, result.size());
@@ -329,7 +328,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(13, result.size());
@@ -351,7 +350,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(10, result.size());
@@ -376,7 +375,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(10, result.size());
@@ -402,7 +401,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(12, result.size());
@@ -428,7 +427,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(12, result.size());
@@ -455,7 +454,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(12, result.size());
 
@@ -494,7 +493,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(10, result.size());
   }
@@ -523,7 +522,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(0, result.size());
   }
@@ -553,7 +552,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(10, result.size());
   }
@@ -583,7 +582,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(resultPoly.isEmpty());
   }
@@ -605,7 +604,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertNotEquals(result.get(3).geometry().get(), result.get(0).geometry().get());
@@ -635,7 +634,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -656,7 +655,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.size());
   }
@@ -676,7 +675,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(resultPoly.isEmpty());
   }
@@ -699,7 +698,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     // geom of requested area vs full geom after modification
@@ -738,7 +737,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertTrue(result.isEmpty());
   }
@@ -759,7 +758,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -780,7 +779,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(5, result.size());
@@ -801,7 +800,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(0, result.size());
   }
@@ -831,7 +830,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -861,7 +860,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(5, result.size());
@@ -891,7 +890,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(0, result.size());
@@ -921,7 +920,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> !(osmEntity.getVersion() == 2),
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(3, result.size());
@@ -951,7 +950,7 @@ class IterateByTimestampsRelationsTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(12, result.size());

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsRelationsTest.java
@@ -60,16 +60,16 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(12, result.size());
 
-    assertEquals(300, result.get(0).osmEntity.getChangesetId());
-    Geometry geom = result.get(0).geometry.get();
+    assertEquals(300, result.get(0).osmEntity().getChangesetId());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof MultiPolygon);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof MultiPolygon);
-    Geometry geom4 = result.get(2).geometry.get();
+    Geometry geom4 = result.get(2).geometry().get();
     assertTrue(geom4 instanceof MultiPolygon);
   }
 
@@ -90,10 +90,10 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(9, result.size());
-    assertEquals(303, result.get(0).osmEntity.getChangesetId());
+    assertEquals(303, result.get(0).osmEntity().getChangesetId());
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -134,10 +134,10 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(14, result.size());
-    assertEquals(307, result.get(0).osmEntity.getChangesetId());
+    assertEquals(307, result.get(0).osmEntity().getChangesetId());
   }
 
   @Test
@@ -157,19 +157,19 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(10, result.size());
-    assertEquals(310, result.get(0).osmEntity.getChangesetId());
+    assertEquals(310, result.get(0).osmEntity().getChangesetId());
 
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof Polygon);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(1).geometry.get());
-    assertEquals(result.get(3).geometry.get(), result.get(2).geometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(0).geometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(1).geometry().get());
+    assertEquals(result.get(3).geometry().get(), result.get(2).geometry().get());
   }
 
   @Test
@@ -189,18 +189,18 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(10, result.size());
-    assertEquals(312, result.get(0).osmEntity.getChangesetId());
+    assertEquals(312, result.get(0).osmEntity().getChangesetId());
 
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom3 = result.get(1).geometry.get();
+    Geometry geom3 = result.get(1).geometry().get();
     assertTrue(geom3 instanceof Polygon);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
-    assertNotEquals(result.get(6).geometry.get(), result.get(1).geometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(0).geometry().get());
+    assertNotEquals(result.get(6).geometry().get(), result.get(1).geometry().get());
   }
 
   @Test
@@ -220,13 +220,13 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(10, result.size());
-    assertEquals(313, result.get(0).osmEntity.getChangesetId());
+    assertEquals(313, result.get(0).osmEntity().getChangesetId());
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
-    assertEquals(result.get(6).geometry.get(), result.get(5).geometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(0).geometry().get());
+    assertEquals(result.get(6).geometry().get(), result.get(5).geometry().get());
   }
 
   @Test
@@ -245,14 +245,14 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(10, result.size());
 
-    assertEquals(314, result.get(0).osmEntity.getChangesetId());
-    Geometry geom = result.get(0).geometry.get();
+    assertEquals(314, result.get(0).osmEntity().getChangesetId());
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof GeometryCollection);
-    Geometry geom2 = result.get(9).geometry.get();
+    Geometry geom2 = result.get(9).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
   }
 
@@ -294,24 +294,24 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(10, result.size());
-    assertEquals(316, result.get(0).osmEntity.getChangesetId());
+    assertEquals(316, result.get(0).osmEntity().getChangesetId());
 
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof Polygon);
-    Geometry geom3 = result.get(2).geometry.get();
+    Geometry geom3 = result.get(2).geometry().get();
     assertTrue(geom3 instanceof Polygon);
-    Geometry geom4 = result.get(3).geometry.get();
+    Geometry geom4 = result.get(3).geometry().get();
     assertTrue(geom4 instanceof Polygon);
-    Geometry geom5 = result.get(9).geometry.get();
+    Geometry geom5 = result.get(9).geometry().get();
     assertTrue(geom5 instanceof Polygon);
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
-    assertEquals(result.get(2).geometry.get(), result.get(1).geometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(0).geometry().get());
+    assertEquals(result.get(2).geometry().get(), result.get(1).geometry().get());
   }
 
   @Test
@@ -330,10 +330,10 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(13, result.size());
-    assertEquals(317, result.get(0).osmEntity.getChangesetId());
+    assertEquals(317, result.get(0).osmEntity().getChangesetId());
   }
 
   @Test
@@ -352,12 +352,12 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(10, result.size());
-    assertEquals(318, result.get(0).osmEntity.getChangesetId());
+    assertEquals(318, result.get(0).osmEntity().getChangesetId());
 
-    assertTrue(result.get(6).geometry.get().isEmpty());
+    assertTrue(result.get(6).geometry().get().isEmpty());
   }
 
   @Test
@@ -377,14 +377,14 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(10, result.size());
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(7).geometry.get();
+    Geometry geom2 = result.get(7).geometry().get();
     assertTrue(geom2 instanceof GeometryCollection);
-    assertEquals(319, result.get(0).osmEntity.getChangesetId());
+    assertEquals(319, result.get(0).osmEntity().getChangesetId());
   }
 
   @Test
@@ -403,14 +403,14 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(12, result.size());
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(2).geometry.get();
+    Geometry geom2 = result.get(2).geometry().get();
     assertTrue(geom2 instanceof Polygon);
-    assertEquals(320, result.get(0).osmEntity.getChangesetId());
+    assertEquals(320, result.get(0).osmEntity().getChangesetId());
   }
 
   @Test
@@ -429,15 +429,15 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(12, result.size());
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof MultiPolygon);
-    Geometry geom2 = result.get(9).geometry.get();
+    Geometry geom2 = result.get(9).geometry().get();
     assertTrue(geom2 instanceof Polygon);
-    assertEquals(321, result.get(0).osmEntity.getChangesetId());
-    assertNotEquals(result.get(9).geometry.get(), result.get(0).geometry.get());
+    assertEquals(321, result.get(0).osmEntity().getChangesetId());
+    assertNotEquals(result.get(9).geometry().get(), result.get(0).geometry().get());
   }
 
   @Test
@@ -456,17 +456,17 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(12, result.size());
 
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom1 = result.get(1).geometry.get();
+    Geometry geom1 = result.get(1).geometry().get();
     assertTrue(geom1 instanceof GeometryCollection);
-    Geometry geom2 = result.get(9).geometry.get();
+    Geometry geom2 = result.get(9).geometry().get();
     assertTrue(geom2 instanceof Polygon);
-    assertEquals(323, result.get(0).osmEntity.getChangesetId());
-    assertNotEquals(result.get(9).geometry.get(), result.get(0).geometry.get());
+    assertEquals(323, result.get(0).osmEntity().getChangesetId());
+    assertNotEquals(result.get(9).geometry().get(), result.get(0).geometry().get());
   }
 
   @Test
@@ -495,7 +495,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(10, result.size());
   }
 
@@ -524,7 +524,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(0, result.size());
   }
 
@@ -554,7 +554,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(10, result.size());
   }
 
@@ -584,7 +584,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(resultPoly.isEmpty());
   }
 
@@ -606,9 +606,9 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
-    assertNotEquals(result.get(3).geometry.get(), result.get(0).geometry.get());
+    assertNotEquals(result.get(3).geometry().get(), result.get(0).geometry().get());
   }
 
   @Test
@@ -636,7 +636,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
   }
@@ -657,7 +657,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(3, result.size());
   }
 
@@ -677,7 +677,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(resultPoly.isEmpty());
   }
 
@@ -700,16 +700,16 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     // geom of requested area vs full geom after modification
-    assertNotEquals(result.get(0).geometry.get().getArea(),
-        result.get(0).unclippedGeometry.get().getArea());
+    assertNotEquals(result.get(0).geometry().get().getArea(),
+        result.get(0).unclippedGeometry().get().getArea());
     // full geom changed
-    assertNotEquals(result.get(2).unclippedGeometry.get().getArea(),
-        result.get(0).unclippedGeometry.get().getArea());
-    assertNotEquals(result.get(2).unclippedGeometry.get().getArea(),
-        result.get(4).unclippedGeometry.get().getArea());
+    assertNotEquals(result.get(2).unclippedGeometry().get().getArea(),
+        result.get(0).unclippedGeometry().get().getArea());
+    assertNotEquals(result.get(2).unclippedGeometry().get().getArea(),
+        result.get(4).unclippedGeometry().get().getArea());
   }
 
   @Test
@@ -739,7 +739,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertTrue(result.isEmpty());
   }
 
@@ -760,7 +760,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
   }
@@ -781,7 +781,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(5, result.size());
   }
@@ -802,7 +802,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(0, result.size());
   }
 
@@ -832,7 +832,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
   }
@@ -862,7 +862,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(5, result.size());
   }
@@ -892,7 +892,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(0, result.size());
   }
@@ -922,7 +922,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(3, result.size());
   }
@@ -952,7 +952,7 @@ class IterateByTimestampsRelationsTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(12, result.size());
   }

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.util.List;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
-import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHWays;
 import org.heigit.ohsome.oshdb.util.celliterator.CellIterator.IterateByTimestampEntry;
 import org.heigit.ohsome.oshdb.util.celliterator.helpers.GridOSHFactory;
@@ -21,7 +20,7 @@ import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Polygon;
 
 /**
- * Tests the {@link CellIterator#iterateByTimestamps(GridOSHEntity)} method on OSM ways.
+ * Tests the {@link CellIterator#iterateByTimestamps(OSHEntitySource)} method on OSM ways.
  */
 class IterateByTimestampsWaysTest {
 
@@ -56,7 +55,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(10, result.size());
     assertEquals(result.get(1).osmEntity().getTags(), result.get(0).osmEntity().getTags());
@@ -91,7 +90,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(10, result.size());
@@ -122,7 +121,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(10, result.size());
 
@@ -146,7 +145,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(11, result.size());
 
@@ -184,7 +183,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(8, result.size());
     assertEquals(2, result.get(0).geometry().get().getNumPoints());
@@ -212,7 +211,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(7, result.size());
 
@@ -238,7 +237,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(11, result.size());
 
@@ -268,7 +267,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(11, result.size());
     assertEquals(5, result.get(0).geometry().get().getNumPoints());
@@ -298,7 +297,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(9, result.size());
   }
@@ -319,7 +318,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertEquals(2, result.size());
@@ -344,7 +343,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
 
     assertNotEquals(result.get(0).geometry().get(), result.get(3).geometry().get());
@@ -368,7 +367,7 @@ class IterateByTimestampsWaysTest {
         osmEntity -> true,
         false
     )).iterateByTimestamps(
-        oshdbDataGridCell
+        OSHEntitySource.fromGridOSHEntity(oshdbDataGridCell)
     ).toList();
     assertEquals(3, result.get(0).geometry().get().getNumPoints());
     // only 4 timestamps in result, because after 03/2012 no more node refs

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/celliterator/IterateByTimestampsWaysTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.heigit.ohsome.oshdb.OSHDBBoundingBox;
 import org.heigit.ohsome.oshdb.grid.GridOSHEntity;
 import org.heigit.ohsome.oshdb.grid.GridOSHWays;
@@ -58,22 +57,22 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(10, result.size());
-    assertEquals(result.get(1).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertEquals(4, result.get(0).geometry.get().getNumPoints());
-    assertEquals(8, result.get(1).geometry.get().getNumPoints());
-    assertEquals(9, result.get(2).geometry.get().getNumPoints());
+    assertEquals(result.get(1).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertEquals(4, result.get(0).geometry().get().getNumPoints());
+    assertEquals(8, result.get(1).geometry().get().getNumPoints());
+    assertEquals(9, result.get(2).geometry().get().getNumPoints());
 
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof LineString);
-    Geometry geom2 = result.get(1).geometry.get();
+    Geometry geom2 = result.get(1).geometry().get();
     assertTrue(geom2 instanceof LineString);
-    Geometry geom3 = result.get(2).geometry.get();
+    Geometry geom3 = result.get(2).geometry().get();
     assertTrue(geom3 instanceof LineString);
-    assertEquals(31, result.get(0).osmEntity.getChangesetId());
-    assertNotEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(1).geometry.get());
+    assertEquals(31, result.get(0).osmEntity().getChangesetId());
+    assertNotEquals(result.get(1).geometry().get(), result.get(0).geometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(1).geometry().get());
   }
 
   @Test
@@ -93,17 +92,17 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(10, result.size());
 
-    assertEquals(34, result.get(0).osmEntity.getChangesetId());
-    assertEquals(35, result.get(8).osmEntity.getChangesetId());
+    assertEquals(34, result.get(0).osmEntity().getChangesetId());
+    assertEquals(35, result.get(8).osmEntity().getChangesetId());
 
-    assertNotEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
-    assertNotEquals(result.get(2).geometry.get(), result.get(1).geometry.get());
-    assertEquals(result.get(5).geometry.get(), result.get(4).geometry.get());
-    assertNotEquals(result.get(9).geometry.get(), result.get(1).geometry.get());
+    assertNotEquals(result.get(1).geometry().get(), result.get(0).geometry().get());
+    assertNotEquals(result.get(2).geometry().get(), result.get(1).geometry().get());
+    assertEquals(result.get(5).geometry().get(), result.get(4).geometry().get());
+    assertNotEquals(result.get(9).geometry().get(), result.get(1).geometry().get());
   }
 
   @Test
@@ -124,11 +123,11 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(10, result.size());
 
-    assertEquals(36, result.get(0).osmEntity.getChangesetId());
-    assertEquals(38, result.get(9).osmEntity.getChangesetId());
+    assertEquals(36, result.get(0).osmEntity().getChangesetId());
+    assertEquals(38, result.get(9).osmEntity().getChangesetId());
   }
 
   @Test
@@ -148,23 +147,23 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(11, result.size());
 
-    assertEquals(3, result.get(0).geometry.get().getNumPoints());
-    assertEquals(5, result.get(2).geometry.get().getNumPoints());
-    assertEquals(5, result.get(10).geometry.get().getNumPoints());
+    assertEquals(3, result.get(0).geometry().get().getNumPoints());
+    assertEquals(5, result.get(2).geometry().get().getNumPoints());
+    assertEquals(5, result.get(10).geometry().get().getNumPoints());
 
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof LineString);
-    Geometry geom2 = result.get(2).geometry.get();
+    Geometry geom2 = result.get(2).geometry().get();
     assertTrue(geom2 instanceof LineString);
-    Geometry geom3 = result.get(10).geometry.get();
+    Geometry geom3 = result.get(10).geometry().get();
     assertTrue(geom3 instanceof LineString);
-    assertNotEquals(result.get(2).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertNotEquals(result.get(10).osmEntity.getTags(), result.get(2).osmEntity.getTags());
-    assertNotEquals(result.get(2).geometry.get(), result.get(0).geometry.get());
-    assertEquals(result.get(10).geometry.get(), result.get(2).geometry.get());
+    assertNotEquals(result.get(2).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertNotEquals(result.get(10).osmEntity().getTags(), result.get(2).osmEntity().getTags());
+    assertNotEquals(result.get(2).geometry().get(), result.get(0).geometry().get());
+    assertEquals(result.get(10).geometry().get(), result.get(2).geometry().get());
   }
 
   @Test
@@ -186,16 +185,16 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(8, result.size());
-    assertEquals(2, result.get(0).geometry.get().getNumPoints());
-    assertEquals(3, result.get(3).geometry.get().getNumPoints());
-    assertEquals(2, result.get(4).geometry.get().getNumPoints());
+    assertEquals(2, result.get(0).geometry().get().getNumPoints());
+    assertEquals(3, result.get(3).geometry().get().getNumPoints());
+    assertEquals(2, result.get(4).geometry().get().getNumPoints());
 
-    assertEquals(42, result.get(0).osmEntity.getChangesetId());
-    assertEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
-    assertNotEquals(result.get(3).geometry.get(), result.get(1).geometry.get());
-    assertNotEquals(result.get(4).geometry.get(), result.get(3).geometry.get());
+    assertEquals(42, result.get(0).osmEntity().getChangesetId());
+    assertEquals(result.get(1).geometry().get(), result.get(0).geometry().get());
+    assertNotEquals(result.get(3).geometry().get(), result.get(1).geometry().get());
+    assertNotEquals(result.get(4).geometry().get(), result.get(3).geometry().get());
   }
 
   @Test
@@ -214,14 +213,14 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(7, result.size());
 
-    assertNotEquals(result.get(2).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertEquals(result.get(6).osmEntity.getTags(), result.get(2).osmEntity.getTags());
-    assertEquals(result.get(1).geometry.get(), result.get(0).geometry.get());
-    assertNotEquals(result.get(3).geometry.get(), result.get(1).geometry.get());
-    assertNotEquals(result.get(6).geometry.get(), result.get(3).geometry.get());
+    assertNotEquals(result.get(2).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertEquals(result.get(6).osmEntity().getTags(), result.get(2).osmEntity().getTags());
+    assertEquals(result.get(1).geometry().get(), result.get(0).geometry().get());
+    assertNotEquals(result.get(3).geometry().get(), result.get(1).geometry().get());
+    assertNotEquals(result.get(6).geometry().get(), result.get(3).geometry().get());
   }
 
   @Test
@@ -240,18 +239,18 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(11, result.size());
 
-    assertEquals(5, result.get(0).geometry.get().getNumPoints());
-    assertEquals(5, result.get(1).geometry.get().getNumPoints());
+    assertEquals(5, result.get(0).geometry().get().getNumPoints());
+    assertEquals(5, result.get(1).geometry().get().getNumPoints());
 
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(8).geometry.get();
+    Geometry geom2 = result.get(8).geometry().get();
     assertTrue(geom2 instanceof LineString);
-    assertNotEquals(result.get(8).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertNotEquals(result.get(8).geometry.get(), result.get(0).geometry.get());
+    assertNotEquals(result.get(8).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertNotEquals(result.get(8).geometry().get(), result.get(0).geometry().get());
   }
 
   @Test
@@ -270,17 +269,17 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(11, result.size());
-    assertEquals(5, result.get(0).geometry.get().getNumPoints());
-    assertEquals(4, result.get(8).geometry.get().getNumPoints());
+    assertEquals(5, result.get(0).geometry().get().getNumPoints());
+    assertEquals(4, result.get(8).geometry().get().getNumPoints());
 
-    Geometry geom = result.get(0).geometry.get();
+    Geometry geom = result.get(0).geometry().get();
     assertTrue(geom instanceof Polygon);
-    Geometry geom2 = result.get(8).geometry.get();
+    Geometry geom2 = result.get(8).geometry().get();
     assertTrue(geom2 instanceof LineString);
-    assertEquals(result.get(8).osmEntity.getTags(), result.get(0).osmEntity.getTags());
-    assertNotEquals(result.get(8).geometry.get(), result.get(0).geometry.get());
+    assertEquals(result.get(8).osmEntity().getTags(), result.get(0).osmEntity().getTags());
+    assertNotEquals(result.get(8).geometry().get(), result.get(0).geometry().get());
   }
 
   @Test
@@ -300,7 +299,7 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
     assertEquals(9, result.size());
   }
 
@@ -321,10 +320,10 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
     assertEquals(2, result.size());
-    assertEquals(result.get(0).geometry.get(), result.get(1).geometry.get());
+    assertEquals(result.get(0).geometry().get(), result.get(1).geometry().get());
   }
 
   @Test
@@ -346,12 +345,12 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
+    ).toList();
 
-    assertNotEquals(result.get(0).geometry.get(), result.get(3).geometry.get());
+    assertNotEquals(result.get(0).geometry().get(), result.get(3).geometry().get());
     assertEquals(4, result.size());
-    assertEquals(3, result.get(1).geometry.get().getNumPoints());
-    assertEquals(4, result.get(0).unclippedGeometry.get().getNumPoints());
+    assertEquals(3, result.get(1).geometry().get().getNumPoints());
+    assertEquals(4, result.get(0).unclippedGeometry().get().getNumPoints());
   }
 
   @Test
@@ -370,8 +369,8 @@ class IterateByTimestampsWaysTest {
         false
     )).iterateByTimestamps(
         oshdbDataGridCell
-    ).collect(Collectors.toList());
-    assertEquals(3, result.get(0).geometry.get().getNumPoints());
+    ).toList();
+    assertEquals(3, result.get(0).geometry().get().getNumPoints());
     // only 4 timestamps in result, because after 03/2012 no more node refs
     assertEquals(4, result.size());
   }


### PR DESCRIPTION
### Description
Includes the following aspects of the `CellIterator` class:
* return the `lastContributionTimestamp` for each entity snapshot (i.e. the timestamp when the OSM entity was last touched before the snapshot timestamp)
* decouple `CellIterator` from grid implementation: It now accepts an `OSHEntitySource` (i.e. a stream of `OSHEntity` object plus the corresponding bounding box) instead of a raw grid cell object. This makes it easier to swap this out in the future with alternative backends that don't rely on this exact implementation of the grid
* refactor internal "data holding" classes to records

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~

