### PR TITLE
fix: Bug OSHRelation Encoding

### DIFF
--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHRelationImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHRelationImpl.java
@@ -265,8 +265,8 @@ public class OSHRelationImpl extends OSHEntityImpl
       var members = relation.getMembers();
       if (version.isVisible() && !Arrays.equals(members, lastMembers)) {
         changed |= CHANGED_MEMBERS;
-        lastMembers = members;
       }
+      lastMembers = members;
 
       builder.build(version, changed);
 

--- a/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHRelationImpl.java
+++ b/oshdb/src/main/java/org/heigit/ohsome/oshdb/impl/osh/OSHRelationImpl.java
@@ -265,6 +265,7 @@ public class OSHRelationImpl extends OSHEntityImpl
       var members = relation.getMembers();
       if (version.isVisible() && !Arrays.equals(members, lastMembers)) {
         changed |= CHANGED_MEMBERS;
+        lastMembers = members;
       }
 
       builder.build(version, changed);


### PR DESCRIPTION
Bug Fix for OSHRelation Encoding.

### Description
Due to a missing assigment, OSHRelations don't compact the members as well and even introduce a bug when there is a versions with non members, the previous version members where taken!

This is a non breaking bug-fix


### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- ~I have commented my code~
- ~I have written javadoc (required for public classes and methods)~
-  ~I have added sufficient unit tests~
- ~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~
- ~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~

Please check all finished tasks. If some tasks do not apply to your PR, please cross their text out (by using `~...~`) and remove their checkboxes.
