### PR TITLE
allow queries with filters to use fast-lane reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Changelog
 
 * `OSMEntitySnapshot` now also returns the `lastContributionTimestamp` for each snapshot ([#495])
 
+### performance improvements
+
+* Significantly improve performance of queries which use filters and don't use `flatMap` ([#511])
+
 ### other changes
 
 * `CellIterator` is now decoupled from implementation of the "Grid" ([#495])
@@ -14,6 +18,7 @@ Changelog
 
 [#495]: https://github.com/GIScience/oshdb/pull/495
 [#501]: https://github.com/GIScience/oshdb/pull/501
+[#511]: https://github.com/GIScience/oshdb/pull/511
 
 
 ## 1.1.2

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteAffinityCall.java
@@ -292,7 +292,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
 
   @Override
   protected <R, S> S mapReduceCellsOSMContribution(
-      SerializableFunction<OSMContribution, R> mapper,
+      SerializableFunction<OSMContribution, Optional<R>> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
       SerializableBinaryOperator<S> combiner
@@ -331,7 +331,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
 
   @Override
   protected <R, S> S mapReduceCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, R> mapper,
+      SerializableFunction<OSMEntitySnapshot, Optional<R>> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
       SerializableBinaryOperator<S> combiner
@@ -371,7 +371,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
 
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
-      SerializableFunction<OSMContribution, X> mapper) throws Exception {
+      SerializableFunction<OSMContribution, Optional<X>> mapper) throws Exception {
     return stream(Kernels.getOSMContributionCellStreamer(mapper, this));
   }
 
@@ -383,7 +383,7 @@ public class MapReducerIgniteAffinityCall<X> extends MapReducer<X>
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
+      SerializableFunction<OSMEntitySnapshot, Optional<X>> mapper) throws Exception {
     return stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper, this));
   }
 

--- a/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
+++ b/oshdb-api-ignite/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerIgniteScanQuery.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.SortedSet;
 import java.util.TreeMap;
 import java.util.UUID;
@@ -110,7 +111,8 @@ public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
   // === map-reduce operations ===
 
   @Override
-  protected <R, S> S mapReduceCellsOSMContribution(SerializableFunction<OSMContribution, R> mapper,
+  protected <R, S> S mapReduceCellsOSMContribution(
+      SerializableFunction<OSMContribution, Optional<R>> mapper,
       SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
       SerializableBinaryOperator<S> combiner) throws Exception {
     // load tag interpreter helper which is later used for geometry building
@@ -147,7 +149,8 @@ public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
 
   @Override
   protected <R, S> S mapReduceCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, R> mapper, SerializableSupplier<S> identitySupplier,
+      SerializableFunction<OSMEntitySnapshot, Optional<R>> mapper,
+      SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator, SerializableBinaryOperator<S> combiner)
       throws Exception {
     // load tag interpreter helper which is later used for geometry building
@@ -185,7 +188,7 @@ public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
 
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
-      SerializableFunction<OSMContribution, X> mapper) throws Exception {
+      SerializableFunction<OSMContribution, Optional<X>> mapper) throws Exception {
     // load tag interpreter helper which is later used for geometry building
     TagInterpreter tagInterpreter = this.getTagInterpreter();
 
@@ -219,7 +222,7 @@ public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
+      SerializableFunction<OSMEntitySnapshot, Optional<X>> mapper) throws Exception {
     // load tag interpreter helper which is later used for geometry building
     TagInterpreter tagInterpreter = this.getTagInterpreter();
 
@@ -367,12 +370,12 @@ public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
 
   private static class MapReduceCellsOSMContributionOnIgniteCacheComputeJob
       <R, S, P extends Geometry & Polygonal>
-      extends MapReduceCellsOnIgniteCacheComputeJob<OSMContribution, R, R, S, P> {
+      extends MapReduceCellsOnIgniteCacheComputeJob<OSMContribution, R, Optional<R>, S, P> {
     MapReduceCellsOSMContributionOnIgniteCacheComputeJob(TagInterpreter tagInterpreter,
         String cacheName, Map<Integer, TreeMap<Long, CellIdRange>> cellIdRangesByLevel,
         SortedSet<OSHDBTimestamp> tstamps, OSHDBBoundingBox bbox, P poly,
         OSHEntityFilter preFilter, OSMEntityFilter filter,
-        SerializableFunction<OSMContribution, R> mapper,
+        SerializableFunction<OSMContribution, Optional<R>> mapper,
         SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
         SerializableBinaryOperator<S> combiner) {
       super(tagInterpreter, cacheName, cellIdRangesByLevel, tstamps, bbox, poly, preFilter, filter,
@@ -417,12 +420,12 @@ public class MapReducerIgniteScanQuery<X> extends MapReducer<X> {
 
   private static class MapReduceCellsOSMEntitySnapshotOnIgniteCacheComputeJob
       <R, S, P extends Geometry & Polygonal>
-      extends MapReduceCellsOnIgniteCacheComputeJob<OSMEntitySnapshot, R, R, S, P> {
+      extends MapReduceCellsOnIgniteCacheComputeJob<OSMEntitySnapshot, R, Optional<R>, S, P> {
     MapReduceCellsOSMEntitySnapshotOnIgniteCacheComputeJob(TagInterpreter tagInterpreter,
         String cacheName, Map<Integer, TreeMap<Long, CellIdRange>> cellIdRangesByLevel,
         SortedSet<OSHDBTimestamp> tstamps, OSHDBBoundingBox bbox, P poly,
         OSHEntityFilter preFilter, OSMEntityFilter filter,
-        SerializableFunction<OSMEntitySnapshot, R> mapper,
+        SerializableFunction<OSMEntitySnapshot, Optional<R>> mapper,
         SerializableSupplier<S> identitySupplier, SerializableBiFunction<S, R, S> accumulator,
         SerializableBinaryOperator<S> combiner) {
       super(tagInterpreter, cacheName, cellIdRangesByLevel, tstamps, bbox, poly, preFilter, filter,

--- a/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/MapReduceOSHDBIgniteAffinityCallTest.java
+++ b/oshdb-api-ignite/src/test/java/org/heigit/ohsome/oshdb/api/tests/MapReduceOSHDBIgniteAffinityCallTest.java
@@ -22,19 +22,4 @@ class MapReduceOSHDBIgniteAffinityCallTest extends MapReduceOSHDBIgniteTest {
   MapReduceOSHDBIgniteAffinityCallTest() throws Exception {
     super(oshdb -> oshdb.computeMode(AFFINITY_CALL));
   }
-
-  @Test
-  void testOSMEntitySnapshotViewStreamNullValues() throws Exception {
-    // simple stream query
-    Set<Integer> result = createMapReducerOSMEntitySnapshot()
-        .timestamps(
-            new OSHDBTimestamps("2010-01-01", "2015-01-01", OSHDBTimestamps.Interval.YEARLY))
-        .filter("id:617308093")
-        .map(snapshot -> snapshot.getEntity().getUserId())
-        .map(x -> (Integer) null)
-        .stream()
-        .collect(Collectors.toSet());
-
-    assertEquals(1, result.size());
-  }
 }

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/FilterFunction.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/FilterFunction.java
@@ -1,0 +1,28 @@
+package org.heigit.ohsome.oshdb.api.mapreducer;
+
+import java.util.Collections;
+import org.heigit.ohsome.oshdb.util.function.SerializablePredicate;
+
+/**
+ * A special map function that represents a filter.
+ *
+ * <p>Note that this class is using raw types on purpose because MapReducer's "map functions"
+ * are designed to input and output arbitrary data types. The necessary type checks are performed
+ * at at runtime in the respective setters.</p>
+ */
+@SuppressWarnings({"rawtypes", "unchecked"}) // see javadoc above
+class FilterFunction extends MapFunction {
+  private final SerializablePredicate filter;
+
+  FilterFunction(SerializablePredicate filter) {
+    super((x, ignored) -> filter.test(x)
+        ? Collections.singletonList(x)
+        : Collections.emptyList(),
+        true);
+    this.filter = filter;
+  }
+
+  public boolean test(Object root) {
+    return this.filter.test(root);
+  }
+}

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerJdbc.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerJdbc.java
@@ -99,7 +99,11 @@ abstract class MapReducerJdbc<X> extends MapReducer<X> implements CancelableProc
     private final Connection conn;
     GridOSHEntity next;
 
-    public GridOSHEntityIterator(ResultSet oshCellsRawData, PreparedStatement pstmt, Connection conn) {
+    public GridOSHEntityIterator(
+        ResultSet oshCellsRawData,
+        PreparedStatement pstmt,
+        Connection conn
+    ) {
       this.oshCellsRawData = oshCellsRawData;
       this.preparedStatement = pstmt;
       this.conn = conn;

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerJdbcMultithread.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.heigit.ohsome.oshdb.api.db.OSHDBDatabase;
 import org.heigit.ohsome.oshdb.api.mapreducer.MapReducer;
@@ -99,7 +100,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
 
   @Override
   protected <R, S> S mapReduceCellsOSMContribution(
-      SerializableFunction<OSMContribution, R> mapper,
+      SerializableFunction<OSMContribution, Optional<R>> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
       SerializableBinaryOperator<S> combiner
@@ -137,7 +138,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
 
   @Override
   protected <R, S> S mapReduceCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, R> mapper,
+      SerializableFunction<OSMEntitySnapshot, Optional<R>> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
       SerializableBinaryOperator<S> combiner
@@ -177,7 +178,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
 
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
-      SerializableFunction<OSMContribution, X> mapper) throws Exception {
+      SerializableFunction<OSMContribution, Optional<X>> mapper) throws Exception {
     return this.stream(Kernels.getOSMContributionCellStreamer(mapper, this));
   }
 
@@ -189,7 +190,7 @@ public class MapReducerJdbcMultithread<X> extends MapReducerJdbc<X> {
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
+      SerializableFunction<OSMEntitySnapshot, Optional<X>> mapper) throws Exception {
     return this.stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper, this));
   }
 

--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/backend/MapReducerJdbcSinglethread.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Streams;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 import org.heigit.ohsome.oshdb.api.db.OSHDBDatabase;
 import org.heigit.ohsome.oshdb.api.db.OSHDBJdbc;
@@ -105,7 +106,7 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
 
   @Override
   protected <R, S> S mapReduceCellsOSMContribution(
-      SerializableFunction<OSMContribution, R> mapper,
+      SerializableFunction<OSMContribution, Optional<R>> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
       SerializableBinaryOperator<S> combiner
@@ -143,7 +144,7 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
 
   @Override
   protected <R, S> S mapReduceCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, R> mapper,
+      SerializableFunction<OSMEntitySnapshot, Optional<R>> mapper,
       SerializableSupplier<S> identitySupplier,
       SerializableBiFunction<S, R, S> accumulator,
       SerializableBinaryOperator<S> combiner
@@ -183,7 +184,7 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
 
   @Override
   protected Stream<X> mapStreamCellsOSMContribution(
-      SerializableFunction<OSMContribution, X> mapper) throws Exception {
+      SerializableFunction<OSMContribution, Optional<X>> mapper) throws Exception {
     return this.stream(Kernels.getOSMContributionCellStreamer(mapper, this));
   }
 
@@ -196,7 +197,7 @@ public class MapReducerJdbcSinglethread<X> extends MapReducerJdbc<X> {
 
   @Override
   protected Stream<X> mapStreamCellsOSMEntitySnapshot(
-      SerializableFunction<OSMEntitySnapshot, X> mapper) throws Exception {
+      SerializableFunction<OSMEntitySnapshot, Optional<X>> mapper) throws Exception {
     return this.stream(Kernels.getOSMEntitySnapshotCellStreamer(mapper, this));
   }
 

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/HelpersOSMContributionViewTest.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/HelpersOSMContributionViewTest.java
@@ -247,13 +247,6 @@ class HelpersOSMContributionViewTest {
 
     assertEquals(21, result4.get(true).size());
     assertEquals(21, result4.get(false).size());
-
-    // doesn't crash with null pointers
-    Set<Object> result5 = this.createMapReducer()
-        .timestamps(timestamps2)
-        .map(x -> null)
-        .uniq();
-    assertEquals(1, result5.size() );
   }
 
 }

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/TestAutoAggregation.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Streams;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.SortedMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -135,7 +136,7 @@ class TestAutoAggregation {
 
     @Override
     protected Stream<X> mapStreamCellsOSMContribution(
-        SerializableFunction<OSMContribution, X> mapper)  {
+        SerializableFunction<OSMContribution, Optional<X>> mapper)  {
       throw new UnsupportedOperationException();
     }
 
@@ -147,7 +148,7 @@ class TestAutoAggregation {
 
     @Override
     protected Stream<X> mapStreamCellsOSMEntitySnapshot(
-        SerializableFunction<OSMEntitySnapshot, X> mapper) {
+        SerializableFunction<OSMEntitySnapshot, Optional<X>> mapper) {
       throw new UnsupportedOperationException();
     }
 
@@ -159,7 +160,8 @@ class TestAutoAggregation {
 
     @Override
     protected <R, S> S mapReduceCellsOSMContribution(
-        SerializableFunction<OSMContribution, R> mapper, SerializableSupplier<S> identitySupplier,
+        SerializableFunction<OSMContribution, Optional<R>> mapper,
+        SerializableSupplier<S> identitySupplier,
         SerializableBiFunction<S, R, S> accumulator, SerializableBinaryOperator<S> combiner) {
       throw new UnsupportedOperationException();
     }
@@ -174,10 +176,15 @@ class TestAutoAggregation {
 
     @Override
     protected <R, S> S mapReduceCellsOSMEntitySnapshot(
-        SerializableFunction<OSMEntitySnapshot, R> mapper, SerializableSupplier<S> identitySupplier,
+        SerializableFunction<OSMEntitySnapshot, Optional<R>> mapper,
+        SerializableSupplier<S> identitySupplier,
         SerializableBiFunction<S, R, S> accumulator, SerializableBinaryOperator<S> combiner) {
-      return nodes.stream().map(TestAutoAggregation::snapshot).map(mapper).reduce(identitySupplier.get(),
-          accumulator, combiner);
+      return nodes.stream()
+          .map(TestAutoAggregation::snapshot)
+          .map(mapper)
+          .filter(Optional::isPresent)
+          .map(Optional::get)
+          .reduce(identitySupplier.get(), accumulator, combiner);
     }
 
     @Override

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/mappable/OSMContribution.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/mappable/OSMContribution.java
@@ -91,7 +91,8 @@ public interface OSMContribution extends OSHDBMapReducible, Comparable<OSMContri
    * {@link #getContributionTypes() getContributionTypes}. This method is
    * preferred to {@code getContributionTypes().contains(ContributionType)}
    * because the class uses lazy evaluation and the computation of a
-   * {@link ContributionType.GEOMETRY_CHANGE} can be computation intensive.
+   * {@link ContributionType#GEOMETRY_CHANGE} can be computation intensive.
+   * </p>
    *
    * @param contributionType the ContributionType to check
    * @return true if this contribution does the respective change, false otherwise


### PR DESCRIPTION
Currently, every query which is using a filter (either via an _ohsome_ filter or a custom filter predicate) is using the slower backend routines, because the actual filtering is [implemented using `flatMap`](https://github.com/GIScience/oshdb/blob/1.1.2/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java#L468-L480) which has a larger overhead than the more streamlined routines which know that no `flatMap` operations have to be performed.

This has the small side-effect that the `NullPointerException` from #159 is back (yet, in a [different place](https://github.com/GIScience/oshdb/pull/511/files#diff-95104b8cca94370e78170795154170a2a716d328d8c7cc484f51e19ff11e9010R1747)). But I'd say this is acceptable, as using `null` values for actual `map` results should be avoided anyway.

### Todo
- [x] compare performance (should be most notable on a query which affects many entities, e.g. `type:way and building=*` in a country-sized bbox like Germany)
- [x] revert benchmarking-only code (7418f6d0b9669586b8c23adafd27843c80235e89)

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/master/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- [x] I have written javadoc (required for public classes and methods)
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/master/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/master/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~
