### PR TITLE
bugfix: areaOfInterest should not override previously set bbox

### DIFF
--- a/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
+++ b/oshdb-api/src/main/java/org/heigit/ohsome/oshdb/api/mapreducer/MapReducer.java
@@ -228,7 +228,7 @@ public abstract class MapReducer<X> implements
   public MapReducer<X> areaOfInterest(@NotNull OSHDBBoundingBox bboxFilter) {
     MapReducer<X> ret = this.copy();
     if (this.polyFilter == null) {
-      ret.bboxFilter = bboxFilter.intersection(bboxFilter);
+      ret.bboxFilter = ret.bboxFilter.intersection(bboxFilter);
     } else {
       ret.polyFilter = Geo.clip(ret.polyFilter, bboxFilter);
       ret.bboxFilter = OSHDBGeometryBuilder.boundingBoxOf(ret.polyFilter.getEnvelopeInternal());

--- a/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/OSMDataFiltersTest.java
+++ b/oshdb-api/src/test/java/org/heigit/ohsome/oshdb/api/tests/OSMDataFiltersTest.java
@@ -46,6 +46,28 @@ class OSMDataFiltersTest {
   }
 
   @Test
+  void bboxesNotIntersecting() throws Exception {
+    Integer result = createMapReducerOSMEntitySnapshot()
+        .filter("type:node")
+        .areaOfInterest(OSHDBBoundingBox.bboxWgs84Coordinates(0, 0, 1, 1))
+        .areaOfInterest(bbox)
+        .timestamps(timestamps1)
+        .count();
+    assertEquals(0, result.intValue());
+  }
+
+  @Test
+  void bboxesIntersecting() throws Exception {
+    Integer result = createMapReducerOSMEntitySnapshot()
+        .filter("type:node")
+        .areaOfInterest(OSHDBBoundingBox.bboxWgs84Coordinates(-180, -90, 180, 90))
+        .areaOfInterest(bbox)
+        .timestamps(timestamps1)
+        .count();
+    assertEquals(2, result.intValue());
+  }
+
+  @Test
   void polygon() throws Exception {
     Integer result = createMapReducerOSMEntitySnapshot()
         .filter("type:node")


### PR DESCRIPTION
instead, it should use the intersection of the previously set bbox and the "incoming" one, to be consistent with all "filters" work on a mapreducer.