### PR TITLE
upgrade postgres to v42.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ Changelog
 
 ## 1.3.0-SNAPSHOT (current main)
 
+### other changes
+
+* upgrade dependencies: ignite to v2.16, guava to v33, caffeine to v3.1.8 ([#521]), postgresql to v42.6 ([#523])
+* rename development branch to `main` ([#522])
+
+[#521]: https://github.com/GIScience/oshdb/pull/521
+[#522]: https://github.com/GIScience/oshdb/pull/522
+[#523]: https://github.com/GIScience/oshdb/pull/523
+
 
 ## 1.2.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <jts.version>1.19.0</jts.version>
     <!-- h2.version has to be in sync with ignite.version -->
     <h2.version>1.4.197</h2.version>
-    <postgresql.version>42.5.4</postgresql.version>
+    <postgresql.version>42.6.0</postgresql.version>
     <slf4j.version>1.7.36</slf4j.version>
     <junit.version>5.9.2</junit.version>
     <jetbrainsannotations.version>24.0.1</jetbrainsannotations.version>


### PR DESCRIPTION
to match the version included via [ignite v2.16](https://ignite.apache.org/releases/2.16.0/release_notes.html) (#521)

### New or changed dependencies
- upgrade postgresql from v42.6.0 (from v42.5.4)
