### PR TITLE
fix crash while building geometry of multipolygon with zero-node way members

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ Changelog
 
 ## 1.3.0-SNAPSHOT (current main)
 
+### bugfixes
+
+* Fix crash while building geometry of multipolygon with zero-node way members under certain circumstances
+
 
 ## 1.2.2
 

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderInternal.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/OSHDBGeometryBuilderInternal.java
@@ -876,6 +876,9 @@ public class OSHDBGeometryBuilderInternal {
         joinable = false;
         for (var waysIterator = ways.iterator(); waysIterator.hasNext();) {
           LinkedList<OSMNode> what = waysIterator.next();
+          if (what.isEmpty()) {
+            continue;
+          }
           if (lastId == what.getFirst().getId()) {
             // end of partial ring matches to start of current line
             what.removeFirst();

--- a/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
+++ b/oshdb-util/src/test/java/org/heigit/ohsome/oshdb/util/geometry/incomplete/OSHDBGeometryBuilderTestPolygonIncompleteDataTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.heigit.ohsome.oshdb.OSHDBTimestamp;
+import org.heigit.ohsome.oshdb.osm.OSMRelation;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryBuilder;
 import org.heigit.ohsome.oshdb.util.geometry.OSHDBGeometryTest;
 import org.heigit.ohsome.oshdb.util.geometry.helpers.TimestampParser;
@@ -68,5 +69,15 @@ class OSHDBGeometryBuilderTestPolygonIncompleteDataTest extends OSHDBGeometryTes
     // relation with one way with two nodes, both missing
     Geometry result = buildGeometry(relations(502L, 0), timestamp);
     assertNotNull(result);
+  }
+
+  @Test
+  void testRelationMemberWayWithoutNodes() {
+    // ways without nodes references (=invalid OSM data) can occur in old OSM data
+    // example: https://www.openstreetmap.org/api/0.6/way/25714579/6
+    OSMRelation rel = relations(503L, 0);
+    Geometry result = buildGeometry(rel);
+    // no exception should have been thrown at this point
+    assertTrue(result.isValid());
   }
 }

--- a/oshdb-util/src/test/resources/incomplete-osm/polygon.osm
+++ b/oshdb-util/src/test/resources/incomplete-osm/polygon.osm
@@ -9,19 +9,15 @@
     <node id="21" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.34" lat="1.05"/>
     <node id="22" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.32" lat="1.05"/>
     <node id="23" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.32" lat="1.04"/>
-
     <node id="24" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.31" lat="1.04"/>
     <node id="25" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.33" lat="1.05"/>
     <node id="26" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.33" lat="1.04"/>
 	  <node id="27" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.32" lat="1.04"/>
-
     <node id="28" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1" lon="7.31" lat="1.01"/>
 	  <way id="102" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <nd ref="11"/>
         <nd ref="12"/>
         <nd ref="13"/>
-        <tag k="test:section" v="mp-geom"/>
-        <tag k="test:id" v="703"/>
     </way>
     <way id="103" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <nd ref="13"/>
@@ -31,8 +27,6 @@
         <nd ref="17"/>
         <nd ref="18"/>
         <nd ref="11"/>
-        <tag k="test:section" v="mp-geom"/>
-        <tag k="test:id" v="703"/>
     </way>
     <way id="105" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <nd ref="24"/>
@@ -41,36 +35,35 @@
         <nd ref="27"/>
         <nd ref="28"/>
         <nd ref="24"/>
-        <tag k="test:section" v="mp-geom"/>
-        <tag k="test:id" v="703"/>
     </way>
 	  <way id="106" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <nd ref="1"/>
         <nd ref="2"/>
-        <tag k="test:section" v="mp-geom"/>
-        <tag k="test:id" v="731"/>
+    </way>
+	  <way id="107" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
     </way>
     <relation id="500" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <member type="way" ref="102" role="outer"/>
         <member type="way" ref="103" role="outer"/>
         <tag k="type" v="multipolygon"/>
-        <tag k="test:section" v="mp-geom"/>
-        <tag k="test:id" v="703"/>
         <tag k="landuse" v="forest"/>
     </relation>
 	  <relation id="501" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <member type="way" ref="104" role="outer"/>
         <member type="way" ref="105" role="outer"/>
         <tag k="type" v="multipolygon"/>
-        <tag k="test:section" v="mp-geom"/>
-        <tag k="test:id" v="703"/>
         <tag k="landuse" v="forest"/>
     </relation>
 	  <relation id="502" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
         <member type="way" ref="106" role="outer"/>
         <tag k="type" v="multipolygon"/>
-        <tag k="test:section" v="mp-geom"/>
-        <tag k="test:id" v="703"/>
+        <tag k="landuse" v="forest"/>
+    </relation>
+	  <relation id="503" version="1" timestamp="2014-01-01T00:00:00Z" uid="1" user="test" changeset="1">
+        <member type="way" ref="102" role="outer"/>
+        <member type="way" ref="107" role="outer"/>
+        <member type="way" ref="103" role="outer"/>
+        <tag k="type" v="multipolygon"/>
         <tag k="landuse" v="forest"/>
     </relation>
 </osm>


### PR DESCRIPTION
this bug occurs when the following two conditions are met:

* a multipolygon refers to a member which at the given timestamp has zero nodes
  - example: https://www.openstreetmap.org/api/0.6/relation/22050/history at `2008-09-30T10:00:52Z` contains https://www.openstreetmap.org/api/0.6/way/25714579/6 which has zero nodes
  - AFAIK only old versions of the OSM API allowed such "invalid" ways to exists. Now there is a [check](https://github.com/openstreetmap/openstreetmap-website/blob/349200f/app/models/way.rb#L167) in [place](https://github.com/openstreetmap/cgimap/blob/8bfb626/include/cgimap/api06/changeset_upload/way.hpp#L56) which prevents these corner cases
* the order of the relation members is such that the 0-node member's previous members do not form a closed loop

### Checklist
- [x] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/main/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- ~~I have written javadoc (required for public classes and methods)~~
- [x] I have added sufficient unit tests
- ~~I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/main/documentation)~~
- [x] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/main/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~
