### PR TITLE
don't return degenerate geometries in fast intersects operation

### DIFF
--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -34,6 +34,8 @@ public class FastPolygonOperations implements Serializable {
   private final double envWidth;
   private final double envHeight;
 
+  private final GeometryFactory gf = new GeometryFactory();
+
   /**
    * Constructor using a given geometry {@code geom} and geometry type {@code P}.
    *
@@ -49,8 +51,6 @@ public class FastPolygonOperations implements Serializable {
     env = geom.getEnvelopeInternal();
     envWidth = env.getMaxX() - env.getMinX();
     envHeight = env.getMaxY() - env.getMinY();
-
-    GeometryFactory gf = new GeometryFactory();
 
     Geometry[] result = new Geometry[numBands * numBands];
     traverseQuads(bandIterations, 0, 0, env, geom, gf, result);
@@ -184,7 +184,6 @@ public class FastPolygonOperations implements Serializable {
     }
 
     assert intersector != null;
-    
     Geometry result;
     if (other instanceof GeometryCollection) {
       result = other.intersection(intersector);

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -193,5 +193,6 @@ public class FastPolygonOperations implements Serializable {
     if (result.getDimension() != other.getDimension()) {
       return gf.createEmpty(other.getDimension());
     }
+    return result;
   }
 }

--- a/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperations.java
+++ b/oshdb-util/src/main/java/org/heigit/ohsome/oshdb/util/geometry/fip/FastPolygonOperations.java
@@ -184,10 +184,15 @@ public class FastPolygonOperations implements Serializable {
     }
 
     assert intersector != null;
+    
+    Geometry result;
     if (other instanceof GeometryCollection) {
-      return other.intersection(intersector);
+      result = other.intersection(intersector);
     } else {
-      return intersector.intersection(other);
+      result = intersector.intersection(other);
+    }
+    if (result.getDimension() != other.getDimension()) {
+      return gf.createEmpty(other.getDimension());
     }
   }
 }


### PR DESCRIPTION
when a geometry only touches the clipping polygon (and has no points inside the poly), `intersector.intersection()` will produce a "degenerate" version of the original geometry: a (multi)linestring when the geometry was a polygon, or a (multi)point when the geometry was a linestring.
This can lead to inconsistencies when a geometry-type filter is used (e.g. `geometry: polygon`), as the output will then potentially also contain geometries that don't match the filter.

### Corresponding issue
Fixes https://github.com/GIScience/ohsome-api/issues/339

### Checklist
- [ ] My code follows the [code-style](https://github.com/GIScience/oshdb/blob/main/CONTRIBUTING.md) rules, and I have checked on the [static analyses](https://jenkins.ohsome.org/job/oshdb/view/change-requests/) and [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) (if applicable) results
- [x] I have commented my code
- ~~I have written javadoc (required for public classes and methods)~~
- [ ] I have added sufficient unit tests
- [ ] I have made corresponding changes to the [documentation](https://github.com/GIScience/oshdb/tree/main/documentation)
- [ ] I have updated the [CHANGELOG.md](https://github.com/GIScience/oshdb/blob/main/CHANGELOG.md)
- ~~I have adjusted the [examples](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-examples/-/issues/new) in the corresponding repository~~
- ~~I have adjusted the [benchmark](https://reports.ohsome.org/oshdb-benchmarks/) or [created an issue](https://gitlab.gistools.geog.uni-heidelberg.de/giscience/big-data/ohsome/oshdb-benchmarks/-/issues/new) in the corresponding repository~~
